### PR TITLE
feat: CLI entry point with watch mode

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -71,3 +71,37 @@ import { GitPanel } from "./ui/GitPanel.js";
 | `branch` | `string \| null` | Current branch name |
 | `commits` | `Commit[]` | Today's commits (max 5 shown) |
 | `stats` | `GitStats` | Lines added/deleted |
+
+## CLI Entry Point
+
+- **Added**: 2026-01-09
+- **Issue**: #5
+- **Status**: Complete
+- **Tests**: `tests/cli.test.ts`, `tests/App.test.tsx`
+- **Source**: `src/cli.ts`, `src/index.ts`, `src/ui/App.tsx`
+
+### Usage
+
+```bash
+# Watch mode (default) - refreshes every 5 seconds
+agent-dashboard
+agent-dashboard --watch
+agent-dashboard -w
+
+# One-shot mode - print and exit
+agent-dashboard --once
+```
+
+### Keyboard Shortcuts (watch mode)
+
+| Key | Action |
+|-----|--------|
+| `q` | Quit |
+| `r` | Refresh immediately |
+
+### Building
+
+```bash
+npm run build
+node dist/index.js --once
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,16 @@
+export interface CliOptions {
+  mode: "watch" | "once";
+}
+
+export function parseArgs(args: string[]): CliOptions {
+  const hasOnce = args.includes("--once");
+  const hasWatch = args.includes("--watch") || args.includes("-w");
+
+  // --once takes precedence
+  if (hasOnce) {
+    return { mode: "once" };
+  }
+
+  // Default is watch mode
+  return { mode: "watch" };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import React from "react";
+import { render } from "ink";
+import { App } from "./ui/App.js";
+import { parseArgs } from "./cli.js";
+
+const options = parseArgs(process.argv.slice(2));
+
+const { waitUntilExit } = render(React.createElement(App, { mode: options.mode }));
+
+if (options.mode === "once") {
+  // In once mode, exit after first render
+  setTimeout(() => process.exit(0), 100);
+} else {
+  // In watch mode, wait until user quits
+  waitUntilExit().then(() => process.exit(0));
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,0 +1,80 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { Box, Text, useApp, useInput } from "ink";
+import { GitPanel } from "./GitPanel.js";
+import { getCurrentBranch, getTodayCommits, getTodayStats } from "../data/git.js";
+import type { Commit, GitStats } from "../types/index.js";
+
+interface AppProps {
+  mode: "watch" | "once";
+}
+
+interface GitData {
+  branch: string | null;
+  commits: Commit[];
+  stats: GitStats;
+}
+
+const REFRESH_INTERVAL = 5000; // 5 seconds
+
+function useGitData(): [GitData, () => void] {
+  const [data, setData] = useState<GitData>(() => ({
+    branch: getCurrentBranch(),
+    commits: getTodayCommits(),
+    stats: getTodayStats(),
+  }));
+
+  const refresh = useCallback(() => {
+    setData({
+      branch: getCurrentBranch(),
+      commits: getTodayCommits(),
+      stats: getTodayStats(),
+    });
+  }, []);
+
+  return [data, refresh];
+}
+
+export function App({ mode }: AppProps): React.ReactElement {
+  const { exit } = useApp();
+  const [data, refresh] = useGitData();
+
+  // Watch mode: refresh every 5 seconds
+  useEffect(() => {
+    if (mode !== "watch") return;
+
+    const interval = setInterval(refresh, REFRESH_INTERVAL);
+    return () => clearInterval(interval);
+  }, [mode, refresh]);
+
+  // Keyboard shortcuts (watch mode only)
+  useInput(
+    (input, key) => {
+      if (mode !== "watch") return;
+
+      if (input === "q") {
+        exit();
+      }
+      if (input === "r") {
+        refresh();
+      }
+    },
+    { isActive: mode === "watch" }
+  );
+
+  return (
+    <Box flexDirection="column">
+      <GitPanel
+        branch={data.branch}
+        commits={data.commits}
+        stats={data.stats}
+      />
+      {mode === "watch" && (
+        <Box marginTop={1}>
+          <Text dimColor>
+            Press <Text color="cyan">q</Text> to quit, <Text color="cyan">r</Text> to refresh
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "ink-testing-library";
+import { App } from "../src/ui/App.js";
+import { setExecFn, resetExecFn } from "../src/data/git.js";
+
+describe("App", () => {
+  let mockExec: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockExec = vi.fn();
+    setExecFn(mockExec);
+  });
+
+  afterEach(() => {
+    resetExecFn();
+  });
+
+  describe("rendering", () => {
+    it("renders GitPanel with git data", () => {
+      // Mock git commands
+      mockExec.mockImplementation((cmd: string) => {
+        if (cmd.includes("branch --show-current")) {
+          return "main\n";
+        }
+        if (cmd.includes("git log")) {
+          return "abc1234|2025-01-09T10:00:00+09:00|Add feature\n";
+        }
+        if (cmd.includes("git diff")) {
+          return " 1 file changed, 10 insertions(+), 5 deletions(-)\n";
+        }
+        return "";
+      });
+
+      const { lastFrame } = render(<App mode="once" />);
+
+      expect(lastFrame()).toContain("Git");
+      expect(lastFrame()).toContain("Branch:");
+      expect(lastFrame()).toContain("main");
+    });
+
+    it("shows 'Not a git repository' when not in git repo", () => {
+      mockExec.mockImplementation(() => {
+        throw new Error("fatal: not a git repository");
+      });
+
+      const { lastFrame } = render(<App mode="once" />);
+
+      expect(lastFrame()).toContain("Not a git repository");
+    });
+  });
+
+  describe("once mode", () => {
+    it("renders once and exits", () => {
+      mockExec.mockReturnValue("main\n");
+
+      const { lastFrame } = render(<App mode="once" />);
+
+      // Should render content
+      expect(lastFrame()).toContain("Git");
+    });
+  });
+
+  describe("keyboard shortcuts", () => {
+    it("shows help text for keyboard shortcuts in watch mode", () => {
+      mockExec.mockReturnValue("main\n");
+
+      const { lastFrame } = render(<App mode="watch" />);
+
+      expect(lastFrame()).toContain("q");
+      expect(lastFrame()).toContain("quit");
+      expect(lastFrame()).toContain("r");
+      expect(lastFrame()).toContain("refresh");
+    });
+
+    it("does not show keyboard help in once mode", () => {
+      mockExec.mockReturnValue("main\n");
+
+      const { lastFrame } = render(<App mode="once" />);
+
+      expect(lastFrame()).not.toContain("quit");
+    });
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs } from "../src/cli.js";
+
+describe("CLI argument parsing", () => {
+  describe("parseArgs", () => {
+    it("returns watch mode by default", () => {
+      const result = parseArgs([]);
+
+      expect(result.mode).toBe("watch");
+    });
+
+    it("returns watch mode with --watch flag", () => {
+      const result = parseArgs(["--watch"]);
+
+      expect(result.mode).toBe("watch");
+    });
+
+    it("returns watch mode with -w flag", () => {
+      const result = parseArgs(["-w"]);
+
+      expect(result.mode).toBe("watch");
+    });
+
+    it("returns once mode with --once flag", () => {
+      const result = parseArgs(["--once"]);
+
+      expect(result.mode).toBe("once");
+    });
+
+    it("once flag takes precedence over watch", () => {
+      const result = parseArgs(["--watch", "--once"]);
+
+      expect(result.mode).toBe("once");
+    });
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "node18",
+  clean: true,
+  shims: true,
+});


### PR DESCRIPTION
## Summary

Wire up GitPanel with real git data and add CLI entry point with watch mode.

```bash
# Watch mode (default)
agent-dashboard

# One-shot mode
agent-dashboard --once
```

## Features

- **Watch mode** (default): Refreshes every 5 seconds
- **Once mode**: Print and exit
- **Keyboard shortcuts**: `q` to quit, `r` to refresh

## Demo

```
┌─ Git ────────────────────────────────────┐
│ Branch: feat/5-cli-entry                 │
├──────────────────────────────────────────┤
│ Today: +142 -23 (3 commits)              │
│ • fef95f0 feat: add GitPanel component   │
│ • 2b30072 feat: add git data collection  │
│ • 77dbab1 chore: init project            │
└──────────────────────────────────────────┘

Press q to quit, r to refresh
```

## Dependencies

- Depends on #4 (GitPanel component)
- Depends on #2 (git data collection)

## Test plan

- [x] All 30 tests pass
- [x] Build succeeds (`npm run build`)
- [x] CLI runs correctly (`node dist/index.js --once`)

Closes #5

Generated with [Claude Code](https://claude.com/claude-code)