### PR TITLE
feat: add init command for onboarding

### DIFF
--- a/.agent/plan.json
+++ b/.agent/plan.json
@@ -1,16 +1,14 @@
 {
-  "goal": "Build agenthud CLI tool",
-  "updatedAt": "2026-01-09T16:30:00Z",
+  "goal": "Add init command for onboarding",
+  "updatedAt": "2026-01-10T18:25:00Z",
   "steps": [
-    { "step": "Set up project (npm, TypeScript, Vitest)", "status": "done" },
-    { "step": "Implement git data collection module", "status": "done" },
-    { "step": "Create GitPanel UI component", "status": "done" },
-    { "step": "Add CLI entry point with watch mode", "status": "done" },
-    { "step": "Fix getTodayStats bug", "status": "done" },
-    { "step": "Add --dir flag for project directory", "status": "pending" },
-    { "step": "Add --json flag for JSON output", "status": "pending" },
-    { "step": "Add PlanPanel component", "status": "done" },
-    { "step": "Add TestPanel component", "status": "done" },
-    { "step": "Publish to npm", "status": "pending" }
+    { "step": "Create issue and branch", "status": "done" },
+    { "step": "Write tests for init command", "status": "done" },
+    { "step": "Write tests for WelcomePanel", "status": "done" },
+    { "step": "Implement init command", "status": "done" },
+    { "step": "Implement WelcomePanel", "status": "done" },
+    { "step": "Update App.tsx to show welcome", "status": "done" },
+    { "step": "Update documentation", "status": "done" },
+    { "step": "Commit and create PR", "status": "in-progress" }
   ]
 }

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -214,3 +214,57 @@ Creates `.agent/test-results.json`:
 | `isOutdated` | `boolean` | Hash differs from HEAD |
 | `commitsBehind` | `number` | Commits since test run |
 | `error` | `string?` | Error message |
+
+## Init Command
+
+- **Added**: 2026-01-10
+- **Issue**: #13
+- **Status**: Complete
+- **Tests**: `tests/init.test.ts`, `tests/WelcomePanel.test.tsx`
+- **Source**: `src/commands/init.ts`, `src/ui/WelcomePanel.tsx`
+
+### Usage
+
+```bash
+npx agenthud init
+```
+
+### Behavior
+
+1. **Welcome screen**: When running `agenthud` without `.agent/` directory:
+```
+┌─ Welcome to agenthud ────────────────────────────────────┐
+│                                                          │
+│   No .agent/ directory found.                            │
+│                                                          │
+│   Quick setup:                                           │
+│      npx agenthud init                                   │
+│                                                          │
+│   Or visit: github.com/neochoon/agenthud                 │
+│                                                          │
+│   Press q to quit                                        │
+└──────────────────────────────────────────────────────────┘
+```
+
+2. **Init command** creates:
+   - `.agent/plan.json`: `{}`
+   - `.agent/decisions.json`: `[]`
+   - `CLAUDE.md` with Agent State section (or appends if exists)
+
+### Files Created
+
+| File | Content |
+|------|---------|
+| `.agent/plan.json` | `{}` |
+| `.agent/decisions.json` | `[]` |
+| `CLAUDE.md` | Agent State section |
+
+### CLAUDE.md Section
+
+```markdown
+## Agent State
+
+Maintain `.agent/` directory:
+- Update `plan.json` when plan changes
+- Append to `decisions.json` for key decisions
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 export interface CliOptions {
   mode: "watch" | "once";
+  command?: "init";
 }
 
 // Dependency injection for testing
@@ -22,11 +23,14 @@ export function parseArgs(args: string[]): CliOptions {
   const hasOnce = args.includes("--once");
   const hasWatch = args.includes("--watch") || args.includes("-w");
 
+  // Check for init command (must be first argument)
+  const command = args[0] === "init" ? "init" : undefined;
+
   // --once takes precedence
   if (hasOnce) {
-    return { mode: "once" };
+    return { mode: "once", command };
   }
 
   // Default is watch mode
-  return { mode: "watch" };
+  return { mode: "watch", command };
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,97 @@
+import {
+  existsSync as nodeExistsSync,
+  mkdirSync as nodeMkdirSync,
+  writeFileSync as nodeWriteFileSync,
+  readFileSync as nodeReadFileSync,
+  appendFileSync as nodeAppendFileSync,
+} from "fs";
+
+export interface FsMock {
+  existsSync: (path: string) => boolean;
+  mkdirSync: (path: string, options?: { recursive?: boolean }) => void;
+  writeFileSync: (path: string, data: string) => void;
+  readFileSync: (path: string) => string;
+  appendFileSync: (path: string, data: string) => void;
+}
+
+// Default fs functions
+let fs: FsMock = {
+  existsSync: nodeExistsSync,
+  mkdirSync: nodeMkdirSync as FsMock["mkdirSync"],
+  writeFileSync: nodeWriteFileSync as FsMock["writeFileSync"],
+  readFileSync: (path: string) => nodeReadFileSync(path, "utf-8"),
+  appendFileSync: nodeAppendFileSync as FsMock["appendFileSync"],
+};
+
+export function setFsMock(mock: FsMock): void {
+  fs = mock;
+}
+
+export function resetFsMock(): void {
+  fs = {
+    existsSync: nodeExistsSync,
+    mkdirSync: nodeMkdirSync as FsMock["mkdirSync"],
+    writeFileSync: nodeWriteFileSync as FsMock["writeFileSync"],
+    readFileSync: (path: string) => nodeReadFileSync(path, "utf-8"),
+    appendFileSync: nodeAppendFileSync as FsMock["appendFileSync"],
+  };
+}
+
+const AGENT_STATE_SECTION = `## Agent State
+
+Maintain \`.agent/\` directory:
+- Update \`plan.json\` when plan changes
+- Append to \`decisions.json\` for key decisions
+`;
+
+export interface InitResult {
+  created: string[];
+  skipped: string[];
+}
+
+export function runInit(): InitResult {
+  const result: InitResult = {
+    created: [],
+    skipped: [],
+  };
+
+  // Create .agent/ directory
+  if (!fs.existsSync(".agent")) {
+    fs.mkdirSync(".agent", { recursive: true });
+    result.created.push(".agent/");
+  } else {
+    result.skipped.push(".agent/");
+  }
+
+  // Create plan.json
+  if (!fs.existsSync(".agent/plan.json")) {
+    fs.writeFileSync(".agent/plan.json", "{}\n");
+    result.created.push(".agent/plan.json");
+  } else {
+    result.skipped.push(".agent/plan.json");
+  }
+
+  // Create decisions.json
+  if (!fs.existsSync(".agent/decisions.json")) {
+    fs.writeFileSync(".agent/decisions.json", "[]\n");
+    result.created.push(".agent/decisions.json");
+  } else {
+    result.skipped.push(".agent/decisions.json");
+  }
+
+  // Handle CLAUDE.md
+  if (!fs.existsSync("CLAUDE.md")) {
+    fs.writeFileSync("CLAUDE.md", AGENT_STATE_SECTION);
+    result.created.push("CLAUDE.md");
+  } else {
+    const content = fs.readFileSync("CLAUDE.md");
+    if (!content.includes("## Agent State")) {
+      fs.appendFileSync("CLAUDE.md", "\n" + AGENT_STATE_SECTION);
+      result.created.push("CLAUDE.md");
+    } else {
+      result.skipped.push("CLAUDE.md");
+    }
+  }
+
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,47 @@
 #!/usr/bin/env node
 import React from "react";
 import { render } from "ink";
+import { existsSync } from "fs";
 import { App } from "./ui/App.js";
 import { parseArgs, clearScreen } from "./cli.js";
+import { runInit } from "./commands/init.js";
 
 const options = parseArgs(process.argv.slice(2));
+
+// Handle init command
+if (options.command === "init") {
+  const result = runInit();
+
+  console.log("\n✓ agenthud initialized\n");
+
+  if (result.created.length > 0) {
+    console.log("Created:");
+    result.created.forEach((file) => console.log(`  ${file}`));
+  }
+
+  if (result.skipped.length > 0) {
+    console.log("\nSkipped (already exists):");
+    result.skipped.forEach((file) => console.log(`  ${file}`));
+  }
+
+  console.log("\nNext steps:");
+  console.log("  1. Edit .agent/plan.json to add your project plan");
+  console.log("  2. Run: npx agenthud\n");
+
+  process.exit(0);
+}
+
+// Check if .agent/ directory exists
+const agentDirExists = existsSync(".agent");
 
 // Clear screen in watch mode for clean display
 if (options.mode === "watch") {
   clearScreen();
 }
 
-const { waitUntilExit } = render(React.createElement(App, { mode: options.mode }));
+const { waitUntilExit } = render(
+  React.createElement(App, { mode: options.mode, agentDirExists })
+);
 
 if (options.mode === "once") {
   // In once mode, exit after first render

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useApp, useInput } from "ink";
 import { GitPanel } from "./GitPanel.js";
 import { PlanPanel } from "./PlanPanel.js";
 import { TestPanel } from "./TestPanel.js";
+import { WelcomePanel } from "./WelcomePanel.js";
 import { getCurrentBranch, getTodayCommits, getTodayStats, getUncommittedCount } from "../data/git.js";
 import { getPlanData } from "../data/plan.js";
 import { getTestData } from "../data/tests.js";
@@ -11,6 +12,7 @@ import type { Commit, GitStats, PlanData, TestData } from "../types/index.js";
 
 interface AppProps {
   mode: "watch" | "once";
+  agentDirExists?: boolean;
 }
 
 interface GitData {
@@ -63,7 +65,11 @@ function useTestData(): [TestData, () => void] {
   return [data, refresh];
 }
 
-export function App({ mode }: AppProps): React.ReactElement {
+function WelcomeApp(): React.ReactElement {
+  return <WelcomePanel />;
+}
+
+function DashboardApp({ mode }: { mode: "watch" | "once" }): React.ReactElement {
   const { exit } = useApp();
   const [gitData, refreshGit] = useGitData();
   const [planData, refreshPlan] = usePlanData();
@@ -95,11 +101,9 @@ export function App({ mode }: AppProps): React.ReactElement {
     return () => clearInterval(tick);
   }, [mode]);
 
-  // Keyboard shortcuts (watch mode only)
+  // Keyboard shortcuts
   useInput(
     (input) => {
-      if (mode !== "watch") return;
-
       if (input === "q") {
         exit();
       }
@@ -144,4 +148,11 @@ export function App({ mode }: AppProps): React.ReactElement {
       )}
     </Box>
   );
+}
+
+export function App({ mode, agentDirExists = true }: AppProps): React.ReactElement {
+  if (!agentDirExists) {
+    return <WelcomeApp />;
+  }
+  return <DashboardApp mode={mode} />;
 }

--- a/src/ui/WelcomePanel.tsx
+++ b/src/ui/WelcomePanel.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { PANEL_WIDTH } from "./constants.js";
+
+export function WelcomePanel(): React.ReactElement {
+  return (
+    <Box flexDirection="column" borderStyle="single" paddingX={1} width={PANEL_WIDTH}>
+      {/* Header */}
+      <Box marginTop={-1}>
+        <Text> Welcome to agenthud </Text>
+      </Box>
+
+      <Text> </Text>
+      <Text>  No .agent/ directory found.</Text>
+      <Text> </Text>
+      <Text>  Quick setup:</Text>
+      <Text color="cyan">     npx agenthud init</Text>
+      <Text> </Text>
+      <Text dimColor>  Or visit: github.com/neochoon/agenthud</Text>
+      <Text> </Text>
+      <Text dimColor>  Press q to quit</Text>
+    </Box>
+  );
+}

--- a/tests/WelcomePanel.test.tsx
+++ b/tests/WelcomePanel.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "ink-testing-library";
+import { WelcomePanel } from "../src/ui/WelcomePanel.js";
+
+describe("WelcomePanel", () => {
+  it("shows welcome title", () => {
+    const { lastFrame } = render(<WelcomePanel />);
+
+    expect(lastFrame()).toContain("Welcome to agenthud");
+  });
+
+  it("shows no .agent/ directory message", () => {
+    const { lastFrame } = render(<WelcomePanel />);
+
+    expect(lastFrame()).toContain("No .agent/ directory found");
+  });
+
+  it("shows init command instruction", () => {
+    const { lastFrame } = render(<WelcomePanel />);
+
+    expect(lastFrame()).toContain("npx agenthud init");
+  });
+
+  it("shows github link", () => {
+    const { lastFrame } = render(<WelcomePanel />);
+
+    expect(lastFrame()).toContain("github.com/neochoon/agenthud");
+  });
+
+  it("shows quit instruction", () => {
+    const { lastFrame } = render(<WelcomePanel />);
+
+    expect(lastFrame()).toContain("Press q to quit");
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -12,6 +12,7 @@ describe("CLI argument parsing", () => {
       const result = parseArgs([]);
 
       expect(result.mode).toBe("watch");
+      expect(result.command).toBeUndefined();
     });
 
     it("returns watch mode with --watch flag", () => {
@@ -35,6 +36,19 @@ describe("CLI argument parsing", () => {
     it("once flag takes precedence over watch", () => {
       const result = parseArgs(["--watch", "--once"]);
 
+      expect(result.mode).toBe("once");
+    });
+
+    it("returns init command when first arg is 'init'", () => {
+      const result = parseArgs(["init"]);
+
+      expect(result.command).toBe("init");
+    });
+
+    it("ignores init if not first argument", () => {
+      const result = parseArgs(["--once", "init"]);
+
+      expect(result.command).toBeUndefined();
       expect(result.mode).toBe("once");
     });
   });

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { runInit, setFsMock, resetFsMock, type FsMock } from "../src/commands/init.js";
+
+describe("init command", () => {
+  let fsMock: FsMock;
+
+  beforeEach(() => {
+    fsMock = {
+      existsSync: vi.fn(),
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      readFileSync: vi.fn(),
+      appendFileSync: vi.fn(),
+    };
+    setFsMock(fsMock);
+  });
+
+  afterEach(() => {
+    resetFsMock();
+  });
+
+  describe("creates .agent/ directory", () => {
+    it("creates directory when it doesn't exist", () => {
+      fsMock.existsSync.mockReturnValue(false);
+
+      runInit();
+
+      expect(fsMock.mkdirSync).toHaveBeenCalledWith(".agent", { recursive: true });
+    });
+
+    it("skips directory creation when it exists", () => {
+      fsMock.existsSync.mockImplementation((path: string) => path === ".agent");
+
+      runInit();
+
+      expect(fsMock.mkdirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("creates plan.json", () => {
+    it("creates empty plan.json when it doesn't exist", () => {
+      fsMock.existsSync.mockReturnValue(false);
+
+      runInit();
+
+      expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+        ".agent/plan.json",
+        "{}\n"
+      );
+    });
+
+    it("skips plan.json when it exists", () => {
+      fsMock.existsSync.mockImplementation((path: string) =>
+        path === ".agent/plan.json"
+      );
+
+      runInit();
+
+      expect(fsMock.writeFileSync).not.toHaveBeenCalledWith(
+        ".agent/plan.json",
+        expect.any(String)
+      );
+    });
+  });
+
+  describe("creates decisions.json", () => {
+    it("creates empty decisions.json when it doesn't exist", () => {
+      fsMock.existsSync.mockReturnValue(false);
+
+      runInit();
+
+      expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+        ".agent/decisions.json",
+        "[]\n"
+      );
+    });
+
+    it("skips decisions.json when it exists", () => {
+      fsMock.existsSync.mockImplementation((path: string) =>
+        path === ".agent/decisions.json"
+      );
+
+      runInit();
+
+      expect(fsMock.writeFileSync).not.toHaveBeenCalledWith(
+        ".agent/decisions.json",
+        expect.any(String)
+      );
+    });
+  });
+
+  describe("updates CLAUDE.md", () => {
+    const agentStateSection = `## Agent State
+
+Maintain \`.agent/\` directory:
+- Update \`plan.json\` when plan changes
+- Append to \`decisions.json\` for key decisions
+`;
+
+    it("creates CLAUDE.md with agent state section when it doesn't exist", () => {
+      fsMock.existsSync.mockReturnValue(false);
+
+      runInit();
+
+      expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+        "CLAUDE.md",
+        agentStateSection
+      );
+    });
+
+    it("appends agent state section to existing CLAUDE.md", () => {
+      fsMock.existsSync.mockImplementation((path: string) =>
+        path === "CLAUDE.md"
+      );
+      fsMock.readFileSync.mockReturnValue("# My Project\n\nSome content.\n");
+
+      runInit();
+
+      expect(fsMock.appendFileSync).toHaveBeenCalledWith(
+        "CLAUDE.md",
+        "\n" + agentStateSection
+      );
+    });
+
+    it("skips if CLAUDE.md already contains Agent State section", () => {
+      fsMock.existsSync.mockImplementation((path: string) =>
+        path === "CLAUDE.md"
+      );
+      fsMock.readFileSync.mockReturnValue("# Project\n\n## Agent State\n\nAlready exists.\n");
+
+      runInit();
+
+      expect(fsMock.appendFileSync).not.toHaveBeenCalled();
+      expect(fsMock.writeFileSync).not.toHaveBeenCalledWith(
+        "CLAUDE.md",
+        expect.any(String)
+      );
+    });
+  });
+
+  describe("return value", () => {
+    it("returns list of created files", () => {
+      fsMock.existsSync.mockReturnValue(false);
+
+      const result = runInit();
+
+      expect(result.created).toContain(".agent/");
+      expect(result.created).toContain(".agent/plan.json");
+      expect(result.created).toContain(".agent/decisions.json");
+      expect(result.created).toContain("CLAUDE.md");
+    });
+
+    it("returns list of skipped files", () => {
+      fsMock.existsSync.mockReturnValue(true);
+      fsMock.readFileSync.mockReturnValue("## Agent State\n");
+
+      const result = runInit();
+
+      expect(result.skipped).toContain(".agent/");
+      expect(result.skipped).toContain(".agent/plan.json");
+      expect(result.skipped).toContain(".agent/decisions.json");
+      expect(result.skipped).toContain("CLAUDE.md");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `agenthud init` command to create `.agent/` directory with empty files
- Show welcome screen when `.agent/` doesn't exist
- Create/append Agent State section to CLAUDE.md

## Changes

- `src/commands/init.ts` - init command logic
- `src/ui/WelcomePanel.tsx` - welcome screen component
- `src/ui/App.tsx` - show welcome when no .agent/
- `src/cli.ts` - parse init command
- `src/index.ts` - handle init command
- `tests/init.test.ts` - 11 tests
- `tests/WelcomePanel.test.tsx` - 5 tests

## Test plan

- [ ] Run `agenthud` in directory without `.agent/` - should show welcome screen
- [ ] Run `agenthud init` - should create files and print success
- [ ] Run `agenthud init` again - should skip existing files
- [ ] Run `agenthud` after init - should show dashboard

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)