### PR TITLE
feat: Wire up config to all panels

### DIFF
--- a/.agenthud/plan.json
+++ b/.agenthud/plan.json
@@ -1,16 +1,14 @@
 {
-  "goal": "Add config system with per-panel refresh",
-  "updatedAt": "2026-01-10T21:30:00Z",
+  "goal": "Wire up config to panels",
+  "updatedAt": "2026-01-10T22:30:00Z",
   "steps": [
     { "step": "Create issue and branch", "status": "done" },
-    { "step": "Add yaml dependency", "status": "done" },
-    { "step": "Write config parser tests", "status": "done" },
-    { "step": "Implement config parser", "status": "done" },
-    { "step": "Write per-panel refresh tests", "status": "done" },
-    { "step": "Implement per-panel refresh", "status": "done" },
-    { "step": "Write command runner tests", "status": "done" },
-    { "step": "Implement command runner", "status": "done" },
-    { "step": "Update init command", "status": "done" },
+    { "step": "Write tests for config-driven git", "status": "done" },
+    { "step": "Implement config-driven git", "status": "done" },
+    { "step": "Write tests for config-driven plan", "status": "done" },
+    { "step": "Implement config-driven plan", "status": "done" },
+    { "step": "Wire up tests panel with command runner", "status": "done" },
+    { "step": "Update App.tsx", "status": "done" },
     { "step": "Update documentation", "status": "done" }
   ]
 }

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -276,10 +276,10 @@ Maintain `.agenthud/` directory:
 ## Config System
 
 - **Added**: 2026-01-10
-- **Issue**: #17
+- **Issue**: #17, #19
 - **Status**: Complete
 - **Tests**: `tests/config.test.ts`, `tests/config-integration.test.tsx`, `tests/runner.test.ts`
-- **Source**: `src/config/parser.ts`, `src/runner/command.ts`
+- **Source**: `src/config/parser.ts`, `src/runner/command.ts`, `src/data/git.ts`, `src/data/plan.ts`
 
 ### Configuration File
 
@@ -291,15 +291,20 @@ panels:
   git:
     enabled: true
     interval: 30s
+    command:
+      branch: git branch --show-current
+      commits: git log --since=midnight --pretty=format:"%h|%aI|%s"
+      stats: git log --since=midnight --numstat --pretty=format:""
 
   plan:
     enabled: true
     interval: 10s
+    source: .agenthud/plan.json
 
   tests:
     enabled: true
     interval: manual
-    # command: npm test -- --reporter=json
+    command: npm test -- --reporter=json
 ```
 
 ### Panel Options
@@ -308,8 +313,16 @@ panels:
 |--------|------|-------------|
 | `enabled` | `boolean` | Show/hide panel |
 | `interval` | `string` | Refresh interval (`30s`, `5m`, `manual`) |
+| `command` | `string/object` | Shell command(s) to run |
 | `source` | `string` | (plan only) Path to plan.json |
-| `command` | `string` | (tests only) Command to run |
+
+### Config-Driven Data
+
+| Panel | Data Source | Config Field |
+|-------|-------------|--------------|
+| Git | Shell commands | `git.command.{branch,commits,stats}` |
+| Plan | File read | `plan.source` |
+| Tests | Shell command | `tests.command` |
 
 ### Interval Values
 

--- a/src/data/plan.ts
+++ b/src/data/plan.ts
@@ -1,6 +1,7 @@
 import { readFileSync as nodeReadFileSync } from "fs";
-import { join } from "path";
+import { join, dirname } from "path";
 import type { Plan, Decision, PlanData } from "../types/index.js";
+import type { PlanPanelConfig } from "../config/parser.js";
 
 type ReadFileFn = (path: string) => string;
 
@@ -41,6 +42,40 @@ export function getPlanData(dir: string = process.cwd()): PlanData {
   }
 
   // Read decisions.json (optional - no error if missing/invalid)
+  try {
+    const content = readFileFn(decisionsPath);
+    const parsed = JSON.parse(content) as { decisions: Decision[] };
+    decisions = (parsed.decisions || []).slice(0, MAX_DECISIONS);
+  } catch {
+    decisions = [];
+  }
+
+  return { plan, decisions, error };
+}
+
+export function getPlanDataWithConfig(config: PlanPanelConfig): PlanData {
+  const planPath = config.source;
+  const planDir = dirname(planPath);
+  const decisionsPath = join(planDir, "decisions.json");
+
+  let plan: Plan | null = null;
+  let decisions: Decision[] = [];
+  let error: string | undefined;
+
+  // Read plan.json from config source
+  try {
+    const content = readFileFn(planPath);
+    plan = JSON.parse(content) as Plan;
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      error = "Invalid plan.json";
+    } else {
+      error = "No plan found";
+    }
+    plan = null;
+  }
+
+  // Read decisions.json from same directory
   try {
     const content = readFileFn(decisionsPath);
     const parsed = JSON.parse(content) as { decisions: Decision[] };


### PR DESCRIPTION
## Summary

Connect the config system to all panels so they use configured commands/sources.

### Changes

| Panel | Before | After |
|-------|--------|-------|
| Git | Hardcoded git commands | Uses `config.git.command.{branch,commits,stats}` |
| Plan | Hardcoded `.agenthud/plan.json` | Uses `config.plan.source` |
| Tests | Reads test-results.json | Runs `config.tests.command` |

### New Functions

- `getGitData(config)` - Get all git data using config commands
- `getPlanDataWithConfig(config)` - Read plan from config source

Closes #19

## Test plan

- [x] 144 tests passing
- [x] Git panel uses custom commands from config
- [x] Plan panel reads from custom source path
- [x] Tests panel runs command and parses JSON output
- [x] All panels respect refresh intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)