### PR TITLE
feat: panel-based folder structure

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -681,3 +681,80 @@ panels:
 | `countdown` | `number \| null` | Countdown seconds |
 | `width` | `number` | Panel width |
 | `justRefreshed` | `boolean` | Shows countdown in green |
+
+## Panel-Based Folder Structure
+
+- **Added**: 2026-01-11
+- **Issue**: #27
+- **Status**: Complete
+- **Tests**: `tests/init.test.ts`, `tests/plan.test.ts`, `tests/tests.test.ts`
+- **Source**: `src/commands/init.ts`, `src/data/plan.ts`, `src/data/tests.ts`, `src/config/parser.ts`
+
+### Overview
+
+The `.agenthud/` folder now uses a panel-based structure:
+
+```
+.agenthud/
+├── config.yaml
+├── plan/
+│   ├── plan.json
+│   └── decisions.json
+└── tests/
+    └── results.json
+```
+
+### Backwards Compatibility
+
+- **New projects**: Get the new folder structure on `agenthud init`
+- **Old projects**: Keep working with old locations (`.agenthud/plan.json`, `.agenthud/decisions.json`)
+- **Fallback logic**: Checks new location first, falls back to old location
+- **No migration**: No auto-migration or warnings
+
+### Init Command
+
+Creates the new structure:
+
+| Path | Content |
+|------|---------|
+| `.agenthud/` | Root directory |
+| `.agenthud/plan/` | Plan panel directory |
+| `.agenthud/tests/` | Tests panel directory |
+| `.agenthud/config.yaml` | Configuration file |
+| `.agenthud/plan/plan.json` | Plan data |
+| `.agenthud/plan/decisions.json` | Decisions list |
+
+### Config Defaults
+
+```yaml
+panels:
+  plan:
+    enabled: true
+    interval: 10s
+    source: .agenthud/plan/plan.json  # New location
+
+  tests:
+    enabled: true
+    interval: manual
+    command: npx vitest run --reporter=json
+    # source: .agenthud/tests/results.json  # Optional
+```
+
+### Tests Panel Source Option
+
+The tests panel now supports both `command` and `source` options:
+
+| Option | Priority | Behavior |
+|--------|----------|----------|
+| `command` | 1 | Run command and parse output |
+| `source` | 2 | Read from JSON file |
+
+If both are set, `command` takes priority.
+
+### Plan Fallback Logic
+
+```
+1. Check .agenthud/plan/plan.json (new location)
+2. If not found, check .agenthud/plan.json (old location)
+3. Same fallback for decisions.json
+```

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -61,7 +61,7 @@ panels:
   plan:
     enabled: true
     interval: 10s
-    source: .agenthud/plan.json
+    source: .agenthud/plan/plan.json
 
   tests:
     enabled: true
@@ -88,20 +88,36 @@ export function runInit(): InitResult {
     result.skipped.push(".agenthud/");
   }
 
-  // Create plan.json
-  if (!fs.existsSync(".agenthud/plan.json")) {
-    fs.writeFileSync(".agenthud/plan.json", "{}\n");
-    result.created.push(".agenthud/plan.json");
+  // Create .agenthud/plan/ directory
+  if (!fs.existsSync(".agenthud/plan")) {
+    fs.mkdirSync(".agenthud/plan", { recursive: true });
+    result.created.push(".agenthud/plan/");
   } else {
-    result.skipped.push(".agenthud/plan.json");
+    result.skipped.push(".agenthud/plan/");
   }
 
-  // Create decisions.json
-  if (!fs.existsSync(".agenthud/decisions.json")) {
-    fs.writeFileSync(".agenthud/decisions.json", "[]\n");
-    result.created.push(".agenthud/decisions.json");
+  // Create .agenthud/tests/ directory
+  if (!fs.existsSync(".agenthud/tests")) {
+    fs.mkdirSync(".agenthud/tests", { recursive: true });
+    result.created.push(".agenthud/tests/");
   } else {
-    result.skipped.push(".agenthud/decisions.json");
+    result.skipped.push(".agenthud/tests/");
+  }
+
+  // Create plan/plan.json
+  if (!fs.existsSync(".agenthud/plan/plan.json")) {
+    fs.writeFileSync(".agenthud/plan/plan.json", "{}\n");
+    result.created.push(".agenthud/plan/plan.json");
+  } else {
+    result.skipped.push(".agenthud/plan/plan.json");
+  }
+
+  // Create plan/decisions.json
+  if (!fs.existsSync(".agenthud/plan/decisions.json")) {
+    fs.writeFileSync(".agenthud/plan/decisions.json", "[]\n");
+    result.created.push(".agenthud/plan/decisions.json");
+  } else {
+    result.skipped.push(".agenthud/plan/decisions.json");
   }
 
   // Create config.yaml

--- a/src/config/parser.ts
+++ b/src/config/parser.ts
@@ -117,7 +117,7 @@ export function getDefaultConfig(): Config {
       plan: {
         enabled: true,
         interval: 10000, // 10s
-        source: ".agenthud/plan.json",
+        source: ".agenthud/plan/plan.json",
       },
       tests: {
         enabled: true,

--- a/src/data/plan.ts
+++ b/src/data/plan.ts
@@ -1,16 +1,27 @@
-import { readFileSync as nodeReadFileSync } from "fs";
+import { readFileSync as nodeReadFileSync, existsSync as nodeExistsSync } from "fs";
 import { join, dirname } from "path";
 import type { Plan, Decision, PlanData } from "../types/index.js";
 import type { PlanPanelConfig } from "../config/parser.js";
 
 type ReadFileFn = (path: string) => string;
+type FileExistsFn = (path: string) => boolean;
 
 const AGENT_DIR = ".agenthud";
+const PLAN_DIR = "plan";
 const PLAN_FILE = "plan.json";
 const DECISIONS_FILE = "decisions.json";
 const MAX_DECISIONS = 3;
 
+// Old flat structure paths (for backwards compatibility)
+const OLD_PLAN_PATH = join(AGENT_DIR, PLAN_FILE);
+const OLD_DECISIONS_PATH = join(AGENT_DIR, DECISIONS_FILE);
+
+// New panel-based structure paths
+const NEW_PLAN_PATH = join(AGENT_DIR, PLAN_DIR, PLAN_FILE);
+const NEW_DECISIONS_PATH = join(AGENT_DIR, PLAN_DIR, DECISIONS_FILE);
+
 let readFileFn: ReadFileFn = (path) => nodeReadFileSync(path, "utf-8");
+let fileExistsFn: FileExistsFn = nodeExistsSync;
 
 export function setReadFileFn(fn: ReadFileFn): void {
   readFileFn = fn;
@@ -18,6 +29,14 @@ export function setReadFileFn(fn: ReadFileFn): void {
 
 export function resetReadFileFn(): void {
   readFileFn = (path) => nodeReadFileSync(path, "utf-8");
+}
+
+export function setFileExistsFn(fn: FileExistsFn): void {
+  fileExistsFn = fn;
+}
+
+export function resetFileExistsFn(): void {
+  fileExistsFn = nodeExistsSync;
 }
 
 export function getPlanData(dir: string = process.cwd()): PlanData {
@@ -54,15 +73,28 @@ export function getPlanData(dir: string = process.cwd()): PlanData {
 }
 
 export function getPlanDataWithConfig(config: PlanPanelConfig): PlanData {
-  const planPath = config.source;
-  const planDir = dirname(planPath);
-  const decisionsPath = join(planDir, "decisions.json");
+  const configSource = config.source;
+  const configDir = dirname(configSource);
+  const configDecisionsPath = join(configDir, "decisions.json");
+
+  // Determine actual paths with fallback support
+  // Check if new location exists, otherwise fall back to old location
+  let planPath = configSource;
+  let decisionsPath = configDecisionsPath;
+
+  // If config points to new location but it doesn't exist, try old location
+  if (configSource === NEW_PLAN_PATH && !fileExistsFn(configSource)) {
+    if (fileExistsFn(OLD_PLAN_PATH)) {
+      planPath = OLD_PLAN_PATH;
+      decisionsPath = OLD_DECISIONS_PATH;
+    }
+  }
 
   let plan: Plan | null = null;
   let decisions: Decision[] = [];
   let error: string | undefined;
 
-  // Read plan.json from config source
+  // Read plan.json from determined path
   try {
     const content = readFileFn(planPath);
     plan = JSON.parse(content) as Plan;
@@ -75,9 +107,15 @@ export function getPlanDataWithConfig(config: PlanPanelConfig): PlanData {
     plan = null;
   }
 
-  // Read decisions.json from same directory
+  // Read decisions.json from same directory as plan
+  // Also support fallback for decisions
+  let actualDecisionsPath = decisionsPath;
+  if (!fileExistsFn(decisionsPath) && fileExistsFn(OLD_DECISIONS_PATH)) {
+    actualDecisionsPath = OLD_DECISIONS_PATH;
+  }
+
   try {
-    const content = readFileFn(decisionsPath);
+    const content = readFileFn(actualDecisionsPath);
     const parsed = JSON.parse(content) as { decisions: Decision[] };
     decisions = (parsed.decisions || []).slice(0, MAX_DECISIONS);
   } catch {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -44,7 +44,7 @@ describe("getDefaultConfig", () => {
 
     expect(config.panels.plan.enabled).toBe(true);
     expect(config.panels.plan.interval).toBe(10000); // 10s
-    expect(config.panels.plan.source).toBe(".agenthud/plan.json");
+    expect(config.panels.plan.source).toBe(".agenthud/plan/plan.json");
   });
 
   it("returns default tests config", () => {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -19,8 +19,8 @@ describe("init command", () => {
     resetFsMock();
   });
 
-  describe("creates .agenthud/ directory", () => {
-    it("creates directory when it doesn't exist", () => {
+  describe("creates .agenthud/ directory structure", () => {
+    it("creates .agenthud directory when it doesn't exist", () => {
       fsMock.existsSync.mockReturnValue(false);
 
       runInit();
@@ -28,62 +28,78 @@ describe("init command", () => {
       expect(fsMock.mkdirSync).toHaveBeenCalledWith(".agenthud", { recursive: true });
     });
 
-    it("skips directory creation when it exists", () => {
+    it("creates .agenthud/plan directory", () => {
+      fsMock.existsSync.mockReturnValue(false);
+
+      runInit();
+
+      expect(fsMock.mkdirSync).toHaveBeenCalledWith(".agenthud/plan", { recursive: true });
+    });
+
+    it("creates .agenthud/tests directory", () => {
+      fsMock.existsSync.mockReturnValue(false);
+
+      runInit();
+
+      expect(fsMock.mkdirSync).toHaveBeenCalledWith(".agenthud/tests", { recursive: true });
+    });
+
+    it("skips directory creation when .agenthud exists", () => {
       fsMock.existsSync.mockImplementation((path: string) => path === ".agenthud");
 
       runInit();
 
-      expect(fsMock.mkdirSync).not.toHaveBeenCalled();
+      expect(fsMock.mkdirSync).not.toHaveBeenCalledWith(".agenthud", { recursive: true });
     });
   });
 
-  describe("creates plan.json", () => {
-    it("creates empty plan.json when it doesn't exist", () => {
+  describe("creates plan/plan.json", () => {
+    it("creates empty plan.json in plan folder when it doesn't exist", () => {
       fsMock.existsSync.mockReturnValue(false);
 
       runInit();
 
       expect(fsMock.writeFileSync).toHaveBeenCalledWith(
-        ".agenthud/plan.json",
+        ".agenthud/plan/plan.json",
         "{}\n"
       );
     });
 
     it("skips plan.json when it exists", () => {
       fsMock.existsSync.mockImplementation((path: string) =>
-        path === ".agenthud/plan.json"
+        path === ".agenthud/plan/plan.json"
       );
 
       runInit();
 
       expect(fsMock.writeFileSync).not.toHaveBeenCalledWith(
-        ".agenthud/plan.json",
+        ".agenthud/plan/plan.json",
         expect.any(String)
       );
     });
   });
 
-  describe("creates decisions.json", () => {
-    it("creates empty decisions.json when it doesn't exist", () => {
+  describe("creates plan/decisions.json", () => {
+    it("creates empty decisions.json in plan folder when it doesn't exist", () => {
       fsMock.existsSync.mockReturnValue(false);
 
       runInit();
 
       expect(fsMock.writeFileSync).toHaveBeenCalledWith(
-        ".agenthud/decisions.json",
+        ".agenthud/plan/decisions.json",
         "[]\n"
       );
     });
 
     it("skips decisions.json when it exists", () => {
       fsMock.existsSync.mockImplementation((path: string) =>
-        path === ".agenthud/decisions.json"
+        path === ".agenthud/plan/decisions.json"
       );
 
       runInit();
 
       expect(fsMock.writeFileSync).not.toHaveBeenCalledWith(
-        ".agenthud/decisions.json",
+        ".agenthud/plan/decisions.json",
         expect.any(String)
       );
     });
@@ -196,7 +212,7 @@ panels:
   plan:
     enabled: true
     interval: 10s
-    source: .agenthud/plan.json
+    source: .agenthud/plan/plan.json
 
   tests:
     enabled: true
@@ -236,8 +252,10 @@ panels:
       const result = runInit();
 
       expect(result.created).toContain(".agenthud/");
-      expect(result.created).toContain(".agenthud/plan.json");
-      expect(result.created).toContain(".agenthud/decisions.json");
+      expect(result.created).toContain(".agenthud/plan/");
+      expect(result.created).toContain(".agenthud/tests/");
+      expect(result.created).toContain(".agenthud/plan/plan.json");
+      expect(result.created).toContain(".agenthud/plan/decisions.json");
       expect(result.created).toContain(".agenthud/config.yaml");
       expect(result.created).toContain(".gitignore");
       expect(result.created).toContain("CLAUDE.md");
@@ -254,8 +272,10 @@ panels:
       const result = runInit();
 
       expect(result.skipped).toContain(".agenthud/");
-      expect(result.skipped).toContain(".agenthud/plan.json");
-      expect(result.skipped).toContain(".agenthud/decisions.json");
+      expect(result.skipped).toContain(".agenthud/plan/");
+      expect(result.skipped).toContain(".agenthud/tests/");
+      expect(result.skipped).toContain(".agenthud/plan/plan.json");
+      expect(result.skipped).toContain(".agenthud/plan/decisions.json");
       expect(result.skipped).toContain(".agenthud/config.yaml");
       expect(result.skipped).toContain(".gitignore");
       expect(result.skipped).toContain("CLAUDE.md");

--- a/tests/plan.test.ts
+++ b/tests/plan.test.ts
@@ -1,17 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { getPlanData, getPlanDataWithConfig, setReadFileFn, resetReadFileFn } from "../src/data/plan.js";
+import { getPlanData, getPlanDataWithConfig, setReadFileFn, resetReadFileFn, setFileExistsFn, resetFileExistsFn } from "../src/data/plan.js";
 import type { PlanPanelConfig } from "../src/config/parser.js";
 
 describe("plan data module", () => {
   let mockReadFile: ReturnType<typeof vi.fn>;
+  let mockFileExists: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     mockReadFile = vi.fn();
+    mockFileExists = vi.fn();
     setReadFileFn(mockReadFile);
+    setFileExistsFn(mockFileExists);
   });
 
   afterEach(() => {
     resetReadFileFn();
+    resetFileExistsFn();
   });
 
   describe("getPlanData", () => {
@@ -196,19 +200,124 @@ describe("plan data module", () => {
       const config: PlanPanelConfig = {
         enabled: true,
         interval: 10000,
-        source: ".agenthud/plan.json",
+        source: ".agenthud/plan/plan.json",
       };
 
       const planJson = JSON.stringify({ goal: "Default", steps: [] });
 
+      mockFileExists.mockReturnValue(true);
       mockReadFile.mockImplementation((path: string) => {
-        if (path === ".agenthud/plan.json") return planJson;
+        if (path === ".agenthud/plan/plan.json") return planJson;
         throw new Error("File not found");
       });
 
       const result = getPlanDataWithConfig(config);
 
       expect(result.plan?.goal).toBe("Default");
+    });
+
+    it("falls back to old location when new location does not exist", () => {
+      const config: PlanPanelConfig = {
+        enabled: true,
+        interval: 10000,
+        source: ".agenthud/plan/plan.json",
+      };
+
+      const planJson = JSON.stringify({ goal: "Old Location", steps: [] });
+      const decisionsJson = JSON.stringify({
+        decisions: [{ timestamp: "2026-01-10T10:00:00Z", decision: "Old Decision" }],
+      });
+
+      mockFileExists.mockImplementation((path: string) => {
+        // New location doesn't exist, old location does
+        if (path === ".agenthud/plan/plan.json") return false;
+        if (path === ".agenthud/plan.json") return true;
+        return false;
+      });
+
+      mockReadFile.mockImplementation((path: string) => {
+        if (path === ".agenthud/plan.json") return planJson;
+        if (path === ".agenthud/decisions.json") return decisionsJson;
+        throw new Error("File not found");
+      });
+
+      const result = getPlanDataWithConfig(config);
+
+      expect(result.plan?.goal).toBe("Old Location");
+      expect(result.decisions).toHaveLength(1);
+      expect(result.decisions[0].decision).toBe("Old Decision");
+    });
+
+    it("uses new location when both locations exist", () => {
+      const config: PlanPanelConfig = {
+        enabled: true,
+        interval: 10000,
+        source: ".agenthud/plan/plan.json",
+      };
+
+      const newPlanJson = JSON.stringify({ goal: "New Location", steps: [] });
+      const oldPlanJson = JSON.stringify({ goal: "Old Location", steps: [] });
+
+      mockFileExists.mockReturnValue(true);
+
+      mockReadFile.mockImplementation((path: string) => {
+        if (path === ".agenthud/plan/plan.json") return newPlanJson;
+        if (path === ".agenthud/plan.json") return oldPlanJson;
+        throw new Error("File not found");
+      });
+
+      const result = getPlanDataWithConfig(config);
+
+      expect(result.plan?.goal).toBe("New Location");
+    });
+
+    it("returns error when neither location exists", () => {
+      const config: PlanPanelConfig = {
+        enabled: true,
+        interval: 10000,
+        source: ".agenthud/plan/plan.json",
+      };
+
+      mockFileExists.mockReturnValue(false);
+      mockReadFile.mockImplementation(() => {
+        throw new Error("File not found");
+      });
+
+      const result = getPlanDataWithConfig(config);
+
+      expect(result.plan).toBeNull();
+      expect(result.error).toBe("No plan found");
+    });
+
+    it("falls back decisions.json to old location", () => {
+      const config: PlanPanelConfig = {
+        enabled: true,
+        interval: 10000,
+        source: ".agenthud/plan/plan.json",
+      };
+
+      const planJson = JSON.stringify({ goal: "Test", steps: [] });
+      const decisionsJson = JSON.stringify({
+        decisions: [{ timestamp: "2026-01-10T10:00:00Z", decision: "From old location" }],
+      });
+
+      mockFileExists.mockImplementation((path: string) => {
+        if (path === ".agenthud/plan/plan.json") return true;
+        if (path === ".agenthud/plan/decisions.json") return false;
+        if (path === ".agenthud/decisions.json") return true;
+        return false;
+      });
+
+      mockReadFile.mockImplementation((path: string) => {
+        if (path === ".agenthud/plan/plan.json") return planJson;
+        if (path === ".agenthud/decisions.json") return decisionsJson;
+        throw new Error("File not found");
+      });
+
+      const result = getPlanDataWithConfig(config);
+
+      expect(result.decisions).toHaveLength(1);
+      expect(result.decisions[0].decision).toBe("From old location");
     });
   });
 });

--- a/tests/tests.test.ts
+++ b/tests/tests.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   getTestData,
+  getTestDataWithConfig,
   setReadFileFn,
   resetReadFileFn,
   setGetHeadHashFn,
@@ -8,6 +9,7 @@ import {
   setGetCommitCountFn,
   resetGetCommitCountFn,
 } from "../src/data/tests.js";
+import type { TestsPanelConfig } from "../src/config/parser.js";
 
 describe("test data module", () => {
   let mockReadFile: ReturnType<typeof vi.fn>;
@@ -113,6 +115,101 @@ describe("test data module", () => {
       expect(result.results).toEqual(testResults);
       expect(result.isOutdated).toBe(false);
       expect(result.commitsBehind).toBe(0);
+    });
+  });
+
+  describe("getTestDataWithConfig", () => {
+    it("reads from source path when provided", () => {
+      const config: TestsPanelConfig = {
+        enabled: true,
+        interval: null,
+        source: ".agenthud/tests/results.json",
+      };
+
+      const testResults = {
+        hash: "abc1234",
+        timestamp: "2026-01-09T16:00:00Z",
+        passed: 15,
+        failed: 0,
+        skipped: 2,
+        failures: [],
+      };
+
+      mockReadFile.mockReturnValue(JSON.stringify(testResults));
+      mockGetHeadHash.mockReturnValue("abc1234");
+
+      const result = getTestDataWithConfig(config);
+
+      expect(result.results).toEqual(testResults);
+      expect(mockReadFile).toHaveBeenCalledWith(".agenthud/tests/results.json");
+    });
+
+    it("falls back to default path when source not provided", () => {
+      const config: TestsPanelConfig = {
+        enabled: true,
+        interval: null,
+        command: "npm test",
+      };
+
+      const testResults = {
+        hash: "def5678",
+        timestamp: "2026-01-09T17:00:00Z",
+        passed: 20,
+        failed: 1,
+        skipped: 0,
+        failures: [],
+      };
+
+      mockReadFile.mockReturnValue(JSON.stringify(testResults));
+      mockGetHeadHash.mockReturnValue("def5678");
+
+      const result = getTestDataWithConfig(config);
+
+      expect(result.results).toEqual(testResults);
+      expect(mockReadFile).toHaveBeenCalledWith(expect.stringContaining("test-results.json"));
+    });
+
+    it("returns error when source file does not exist", () => {
+      const config: TestsPanelConfig = {
+        enabled: true,
+        interval: null,
+        source: ".agenthud/tests/results.json",
+      };
+
+      mockReadFile.mockImplementation(() => {
+        throw new Error("ENOENT: no such file or directory");
+      });
+
+      const result = getTestDataWithConfig(config);
+
+      expect(result.results).toBeNull();
+      expect(result.error).toBe("No test results");
+    });
+
+    it("checks outdated status with config source", () => {
+      const config: TestsPanelConfig = {
+        enabled: true,
+        interval: null,
+        source: ".agenthud/tests/results.json",
+      };
+
+      const testResults = {
+        hash: "old1234",
+        timestamp: "2026-01-09T16:00:00Z",
+        passed: 10,
+        failed: 0,
+        skipped: 0,
+        failures: [],
+      };
+
+      mockReadFile.mockReturnValue(JSON.stringify(testResults));
+      mockGetHeadHash.mockReturnValue("new5678");
+      mockGetCommitCount.mockReturnValue(5);
+
+      const result = getTestDataWithConfig(config);
+
+      expect(result.isOutdated).toBe(true);
+      expect(result.commitsBehind).toBe(5);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Change `.agenthud/` from flat to panel-based folder structure
- Add fallback logic for backwards compatibility (old projects keep working)
- Add `source` option for tests panel (can read from file instead of command)
- Update config defaults to use new paths

Closes #27

## New Structure
```
.agenthud/
├── config.yaml
├── plan/
│   ├── plan.json
│   └── decisions.json
└── tests/
    └── results.json
```

## Test plan
- [x] Updated init.test.ts for new folder structure (18 tests)
- [x] Added plan fallback tests (5 new tests, 13 total)
- [x] Added tests panel source tests (4 new tests, 9 total)
- [x] Updated config defaults tests
- [x] All 267 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)