### PR TITLE
feat: Responsive width with max limit

### DIFF
--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -1,6 +1,36 @@
 // Default panel width (can be overridden via config)
 export const DEFAULT_PANEL_WIDTH = 70;
 
+// Terminal width limits
+export const MIN_TERMINAL_WIDTH = 50;
+export const MAX_TERMINAL_WIDTH = 120;
+export const DEFAULT_FALLBACK_WIDTH = 80;
+
+// For testing - allows mocking process.stdout.columns
+let stdoutColumnsFn: () => number | undefined = () => process.stdout.columns;
+
+export function setStdoutColumnsFn(fn: () => number | undefined): void {
+  stdoutColumnsFn = fn;
+}
+
+export function resetStdoutColumnsFn(): void {
+  stdoutColumnsFn = () => process.stdout.columns;
+}
+
+/**
+ * Get terminal width with min/max limits.
+ * Returns the terminal width capped at MAX_TERMINAL_WIDTH (120),
+ * with a minimum of MIN_TERMINAL_WIDTH (50).
+ * Falls back to DEFAULT_FALLBACK_WIDTH (80) if detection fails.
+ */
+export function getTerminalWidth(): number {
+  const columns = stdoutColumnsFn();
+  if (!columns || columns <= 0) {
+    return DEFAULT_FALLBACK_WIDTH;
+  }
+  return Math.min(Math.max(columns, MIN_TERMINAL_WIDTH), MAX_TERMINAL_WIDTH);
+}
+
 // Legacy exports for backward compatibility (use functions with width param for new code)
 export const PANEL_WIDTH = DEFAULT_PANEL_WIDTH;
 export const CONTENT_WIDTH = DEFAULT_PANEL_WIDTH - 4;

--- a/tests/terminal-width.test.ts
+++ b/tests/terminal-width.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getTerminalWidth,
+  setStdoutColumnsFn,
+  resetStdoutColumnsFn,
+  MIN_TERMINAL_WIDTH,
+  MAX_TERMINAL_WIDTH,
+  DEFAULT_FALLBACK_WIDTH,
+} from "../src/ui/constants.js";
+
+describe("getTerminalWidth", () => {
+  afterEach(() => {
+    resetStdoutColumnsFn();
+  });
+
+  describe("normal terminal sizes", () => {
+    it("returns terminal width for normal size (100 columns)", () => {
+      setStdoutColumnsFn(() => 100);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(100);
+    });
+
+    it("returns terminal width for small terminal (60 columns)", () => {
+      setStdoutColumnsFn(() => 60);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(60);
+    });
+  });
+
+  describe("max width cap", () => {
+    it("caps width at MAX_TERMINAL_WIDTH (120) for wide terminals", () => {
+      setStdoutColumnsFn(() => 200);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(MAX_TERMINAL_WIDTH);
+      expect(width).toBe(120);
+    });
+
+    it("caps width at 120 for ultrawide terminals (300 columns)", () => {
+      setStdoutColumnsFn(() => 300);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(120);
+    });
+
+    it("returns exactly 120 when terminal is 120 columns", () => {
+      setStdoutColumnsFn(() => 120);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(120);
+    });
+  });
+
+  describe("min width enforcement", () => {
+    it("enforces minimum width for very small terminals", () => {
+      setStdoutColumnsFn(() => 30);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(MIN_TERMINAL_WIDTH);
+      expect(width).toBe(50);
+    });
+
+    it("returns exactly 50 when terminal is 50 columns", () => {
+      setStdoutColumnsFn(() => 50);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(50);
+    });
+  });
+
+  describe("fallback behavior", () => {
+    it("returns fallback width when columns is undefined", () => {
+      setStdoutColumnsFn(() => undefined);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(DEFAULT_FALLBACK_WIDTH);
+      expect(width).toBe(80);
+    });
+
+    it("returns fallback width when columns is 0", () => {
+      setStdoutColumnsFn(() => 0);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(80);
+    });
+
+    it("returns fallback width when columns is negative", () => {
+      setStdoutColumnsFn(() => -1);
+
+      const width = getTerminalWidth();
+
+      expect(width).toBe(80);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Width follows terminal size, capped at 120 chars
- Falls back to 80 when detection fails  
- Minimum width enforced at 50 chars
- Real-time resize handling via `process.stdout` resize event

## Benefits
- Normal monitors: uses full width
- Ultrawide: doesn't stretch awkwardly, stays readable
- Longer Bash commands and file paths won't get truncated as much

## Test plan
- [x] Tests for `getTerminalWidth()` function (10 tests)
- [x] Tests for ClaudePanel responsive width (2 tests)
- [x] All existing tests pass (298 total)
- [x] Build succeeds

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)