### PR TITLE
feat: add Other Sessions panel

### DIFF
--- a/.agent/plan.json
+++ b/.agent/plan.json
@@ -1,0 +1,16 @@
+{
+  "goal": "other-sessions panel",
+  "updatedAt": "2026-01-13",
+  "steps": [
+    { "step": "Create issue", "status": "in-progress" },
+    { "step": "Create branch", "status": "pending" },
+    { "step": "Write data layer tests", "status": "pending" },
+    { "step": "Implement data layer", "status": "pending" },
+    { "step": "Write UI tests", "status": "pending" },
+    { "step": "Implement UI component", "status": "pending" },
+    { "step": "Add config schema", "status": "pending" },
+    { "step": "Integration test", "status": "pending" },
+    { "step": "Update documentation", "status": "pending" },
+    { "step": "Create PR", "status": "pending" }
+  ]
+}

--- a/src/data/otherSessions.ts
+++ b/src/data/otherSessions.ts
@@ -1,0 +1,299 @@
+import {
+  existsSync as nodeExistsSync,
+  readFileSync as nodeReadFileSync,
+  readdirSync as nodeReaddirSync,
+  statSync as nodeStatSync,
+} from "fs";
+import { homedir } from "os";
+import { join, basename } from "path";
+
+export interface FsMock {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string) => string;
+  readdirSync: (path: string) => string[];
+  statSync: (path: string) => { mtimeMs?: number; isDirectory?: () => boolean };
+}
+
+let fs: FsMock = {
+  existsSync: nodeExistsSync,
+  readFileSync: (path: string) => nodeReadFileSync(path, "utf-8"),
+  readdirSync: (path: string) => nodeReaddirSync(path) as string[],
+  statSync: nodeStatSync,
+};
+
+export function setFsMock(mock: FsMock): void {
+  fs = mock;
+}
+
+export function resetFsMock(): void {
+  fs = {
+    existsSync: nodeExistsSync,
+    readFileSync: (path: string) => nodeReadFileSync(path, "utf-8"),
+    readdirSync: (path: string) => nodeReaddirSync(path) as string[],
+    statSync: nodeStatSync,
+  };
+}
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const MAX_LINES_TO_SCAN = 100;
+
+export interface ProjectInfo {
+  encodedPath: string;
+  decodedPath: string;
+}
+
+export interface SessionInfo {
+  projectPath: string;
+  projectName: string;
+  lastModified: Date;
+  lastMessage: string | null;
+  isActive: boolean;
+  relativeTime: string;
+}
+
+export interface OtherSessionsData {
+  totalProjects: number;
+  activeCount: number;
+  recentSession: SessionInfo | null;
+  timestamp: string;
+}
+
+export interface OtherSessionsOptions {
+  activeThresholdMs?: number;
+}
+
+function getProjectsDir(): string {
+  return join(homedir(), ".claude", "projects");
+}
+
+function decodeProjectPath(encoded: string): string {
+  // Convert "-Users-test-project" back to "/Users/test/project"
+  return encoded.replace(/-/g, "/");
+}
+
+export function getAllProjects(): ProjectInfo[] {
+  const projectsDir = getProjectsDir();
+
+  if (!fs.existsSync(projectsDir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(projectsDir);
+  const projects: ProjectInfo[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(projectsDir, entry);
+    try {
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory?.()) {
+        projects.push({
+          encodedPath: entry,
+          decodedPath: decodeProjectPath(entry),
+        });
+      }
+    } catch {
+      // Skip entries we can't stat
+    }
+  }
+
+  return projects;
+}
+
+interface JsonlAssistantEntry {
+  type: "assistant";
+  message: {
+    content: Array<{
+      type: string;
+      text?: string;
+    }>;
+  };
+}
+
+export function parseLastAssistantMessage(sessionFile: string): string | null {
+  if (!fs.existsSync(sessionFile)) {
+    return null;
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(sessionFile);
+  } catch {
+    return null;
+  }
+
+  const lines = content.trim().split("\n").filter(Boolean);
+  if (lines.length === 0) {
+    return null;
+  }
+
+  // Scan from the end to find last assistant message with text
+  const recentLines = lines.slice(-MAX_LINES_TO_SCAN).reverse();
+
+  for (const line of recentLines) {
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === "assistant") {
+        const assistantEntry = entry as JsonlAssistantEntry;
+        const content = assistantEntry.message?.content;
+        if (Array.isArray(content)) {
+          const textBlock = content.find((c) => c.type === "text" && c.text);
+          if (textBlock?.text) {
+            return textBlock.text.replace(/\n/g, " ");
+          }
+        }
+      }
+    } catch {
+      // Skip invalid JSON
+    }
+  }
+
+  return null;
+}
+
+export function formatRelativeTime(date: Date): string {
+  const elapsed = Date.now() - date.getTime();
+  const seconds = Math.floor(elapsed / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (seconds < 1) {
+    return "just now";
+  }
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+  return `${days}d ago`;
+}
+
+function findMostRecentSession(projectDir: string): { file: string; mtimeMs: number } | null {
+  if (!fs.existsSync(projectDir)) {
+    return null;
+  }
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(projectDir);
+  } catch {
+    return null;
+  }
+
+  const jsonlFiles = files.filter((f) => f.endsWith(".jsonl"));
+  if (jsonlFiles.length === 0) {
+    return null;
+  }
+
+  let latestFile: string | null = null;
+  let latestMtime = 0;
+
+  for (const file of jsonlFiles) {
+    const filePath = join(projectDir, file);
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.mtimeMs && stat.mtimeMs > latestMtime) {
+        latestMtime = stat.mtimeMs;
+        latestFile = filePath;
+      }
+    } catch {
+      // Skip files we can't stat
+    }
+  }
+
+  if (!latestFile) {
+    return null;
+  }
+
+  return { file: latestFile, mtimeMs: latestMtime };
+}
+
+export function getOtherSessionsData(
+  currentProjectPath: string,
+  options: OtherSessionsOptions = {}
+): OtherSessionsData {
+  const activeThresholdMs = options.activeThresholdMs ?? FIVE_MINUTES_MS;
+  const projectsDir = getProjectsDir();
+
+  const defaultResult: OtherSessionsData = {
+    totalProjects: 0,
+    activeCount: 0,
+    recentSession: null,
+    timestamp: new Date().toISOString(),
+  };
+
+  if (!fs.existsSync(projectsDir)) {
+    return defaultResult;
+  }
+
+  const allProjects = getAllProjects();
+  defaultResult.totalProjects = allProjects.length;
+
+  // Normalize current project path for comparison
+  const normalizedCurrentPath = currentProjectPath.replace(/\/$/, "");
+
+  // Collect session info for all OTHER projects
+  const otherSessions: Array<{
+    projectPath: string;
+    projectName: string;
+    lastModified: Date;
+    mtimeMs: number;
+    sessionFile: string;
+  }> = [];
+
+  for (const project of allProjects) {
+    // Skip current project
+    if (project.decodedPath === normalizedCurrentPath) {
+      continue;
+    }
+
+    const projectDir = join(projectsDir, project.encodedPath);
+    const sessionInfo = findMostRecentSession(projectDir);
+
+    if (sessionInfo) {
+      otherSessions.push({
+        projectPath: project.decodedPath,
+        projectName: basename(project.decodedPath),
+        lastModified: new Date(sessionInfo.mtimeMs),
+        mtimeMs: sessionInfo.mtimeMs,
+        sessionFile: sessionInfo.file,
+      });
+    }
+  }
+
+  // Count active sessions
+  const now = Date.now();
+  let activeCount = 0;
+  for (const session of otherSessions) {
+    if (now - session.mtimeMs < activeThresholdMs) {
+      activeCount++;
+    }
+  }
+  defaultResult.activeCount = activeCount;
+
+  // Find most recent session
+  if (otherSessions.length === 0) {
+    return defaultResult;
+  }
+
+  otherSessions.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  const mostRecent = otherSessions[0];
+
+  const lastMessage = parseLastAssistantMessage(mostRecent.sessionFile);
+  const isActive = now - mostRecent.mtimeMs < activeThresholdMs;
+
+  defaultResult.recentSession = {
+    projectPath: mostRecent.projectPath,
+    projectName: mostRecent.projectName,
+    lastModified: mostRecent.lastModified,
+    lastMessage,
+    isActive,
+    relativeTime: formatRelativeTime(mostRecent.lastModified),
+  };
+
+  return defaultResult;
+}

--- a/src/ui/OtherSessionsPanel.tsx
+++ b/src/ui/OtherSessionsPanel.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type { OtherSessionsData } from "../data/otherSessions.js";
+import {
+  DEFAULT_PANEL_WIDTH,
+  BOX,
+  createTitleLine,
+  createBottomLine,
+  getInnerWidth,
+  getDisplayWidth,
+} from "./constants.js";
+
+interface OtherSessionsPanelProps {
+  data: OtherSessionsData;
+  countdown?: number | null;
+  width?: number;
+  isRunning?: boolean;
+  messageMaxLength?: number;
+}
+
+function formatCountdown(seconds: number | null | undefined): string {
+  if (seconds == null) return "";
+  const padded = String(seconds).padStart(2, " ");
+  return `↻ ${padded}s`;
+}
+
+function truncateMessage(message: string, maxLength: number): string {
+  if (getDisplayWidth(message) <= maxLength) {
+    return message;
+  }
+
+  let truncated = "";
+  let currentWidth = 0;
+
+  for (const char of message) {
+    const charWidth = getDisplayWidth(char);
+    if (currentWidth + charWidth > maxLength - 3) {
+      truncated += "...";
+      break;
+    }
+    truncated += char;
+    currentWidth += charWidth;
+  }
+
+  return truncated;
+}
+
+export function OtherSessionsPanel({
+  data,
+  countdown,
+  width = DEFAULT_PANEL_WIDTH,
+  isRunning = false,
+  messageMaxLength = 50,
+}: OtherSessionsPanelProps): React.ReactElement {
+  const countdownSuffix = isRunning ? "running..." : formatCountdown(countdown);
+  const innerWidth = getInnerWidth(width);
+  const contentWidth = innerWidth - 1; // Account for " " after │
+
+  const { totalProjects, activeCount, recentSession } = data;
+
+  // Build header line content
+  const projectWord = totalProjects === 1 ? "project" : "projects";
+  const headerText = `📁 ${totalProjects} ${projectWord} | ⚡ ${activeCount} active`;
+  const headerPadding = Math.max(0, contentWidth - getDisplayWidth(headerText));
+
+  // Clear to end of line to prevent ghost text
+  const clearEOL = "\x1b[K";
+
+  const lines: React.ReactElement[] = [];
+
+  // Header line with counts
+  lines.push(
+    <Text key="header">
+      {BOX.v}{" "}
+      <Text>{headerText}</Text>
+      {" ".repeat(headerPadding)}
+      {BOX.v}{clearEOL}
+    </Text>
+  );
+
+  // Empty line
+  lines.push(
+    <Text key="empty">
+      {BOX.v}{" "}
+      {" ".repeat(contentWidth)}
+      {BOX.v}{clearEOL}
+    </Text>
+  );
+
+  // Recent session or empty state
+  if (recentSession) {
+    const statusIcon = recentSession.isActive ? "🔵" : "⚪";
+    const sessionLine = `${statusIcon} ${recentSession.projectName} (${recentSession.relativeTime})`;
+    const sessionLinePadding = Math.max(0, contentWidth - getDisplayWidth(sessionLine));
+
+    lines.push(
+      <Text key="session">
+        {BOX.v}{" "}
+        <Text>{sessionLine}</Text>
+        {" ".repeat(sessionLinePadding)}
+        {BOX.v}{clearEOL}
+      </Text>
+    );
+
+    // Last message (if available)
+    if (recentSession.lastMessage) {
+      // Calculate available width for message (accounting for indent)
+      const indent = "   "; // 3 spaces for indent
+      const quotePrefix = '"';
+      const quoteSuffix = '"';
+      const availableWidth = contentWidth - indent.length - 2; // -2 for quotes
+
+      const truncatedMessage = truncateMessage(
+        recentSession.lastMessage,
+        Math.min(availableWidth, messageMaxLength)
+      );
+      const messageText = `${indent}${quotePrefix}${truncatedMessage}${quoteSuffix}`;
+      const messagePadding = Math.max(0, contentWidth - getDisplayWidth(messageText));
+
+      lines.push(
+        <Text key="message">
+          {BOX.v}{" "}
+          <Text dimColor>{messageText}</Text>
+          {" ".repeat(messagePadding)}
+          {BOX.v}{clearEOL}
+        </Text>
+      );
+    }
+  } else {
+    // No other sessions
+    const noSessionText = "No other active sessions";
+    const noSessionPadding = Math.max(0, contentWidth - noSessionText.length);
+
+    lines.push(
+      <Text key="no-session">
+        {BOX.v}{" "}
+        <Text dimColor>{noSessionText}</Text>
+        {" ".repeat(noSessionPadding)}
+        {BOX.v}{clearEOL}
+      </Text>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Text>{createTitleLine("Other Sessions", countdownSuffix, width)}</Text>
+      {lines}
+      <Text>{createBottomLine(width)}</Text>
+    </Box>
+  );
+}

--- a/tests/OtherSessionsPanel.test.tsx
+++ b/tests/OtherSessionsPanel.test.tsx
@@ -1,0 +1,231 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "ink-testing-library";
+import { OtherSessionsPanel } from "../src/ui/OtherSessionsPanel.js";
+import type { OtherSessionsData } from "../src/data/otherSessions.js";
+
+describe("OtherSessionsPanel", () => {
+  const createMockData = (overrides: Partial<OtherSessionsData> = {}): OtherSessionsData => ({
+    totalProjects: 3,
+    activeCount: 2,
+    recentSession: {
+      projectPath: "/Users/test/myproject",
+      projectName: "myproject",
+      lastModified: new Date(),
+      lastMessage: "Last assistant message here",
+      isActive: true,
+      relativeTime: "30s ago",
+    },
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  });
+
+  describe("header line", () => {
+    it("shows total projects and active count", () => {
+      const data = createMockData();
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("3 projects");
+      expect(lastFrame()).toContain("2 active");
+    });
+
+    it("shows singular 'project' when only one", () => {
+      const data = createMockData({ totalProjects: 1, activeCount: 1 });
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("1 project");
+      expect(lastFrame()).not.toContain("1 projects");
+    });
+
+    it("shows singular 'active' when only one", () => {
+      const data = createMockData({ totalProjects: 3, activeCount: 1 });
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("1 active");
+    });
+  });
+
+  describe("recent session display", () => {
+    it("shows project name and relative time", () => {
+      const data = createMockData();
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("myproject");
+      expect(lastFrame()).toContain("30s ago");
+    });
+
+    it("shows active icon for active session", () => {
+      const data = createMockData({
+        recentSession: {
+          projectPath: "/test/project",
+          projectName: "project",
+          lastModified: new Date(),
+          lastMessage: "Hello",
+          isActive: true,
+          relativeTime: "1m ago",
+        },
+      });
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("🔵");
+    });
+
+    it("shows inactive icon for inactive session", () => {
+      const data = createMockData({
+        recentSession: {
+          projectPath: "/test/project",
+          projectName: "project",
+          lastModified: new Date(),
+          lastMessage: "Hello",
+          isActive: false,
+          relativeTime: "10m ago",
+        },
+      });
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("⚪");
+    });
+
+    it("shows last assistant message", () => {
+      const data = createMockData({
+        recentSession: {
+          projectPath: "/test/project",
+          projectName: "project",
+          lastModified: new Date(),
+          lastMessage: "This is the last message from the assistant",
+          isActive: true,
+          relativeTime: "1m ago",
+        },
+      });
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("This is the last message");
+    });
+
+    it("truncates long messages", () => {
+      const longMessage =
+        "This is a very long message that should be truncated to fit within the panel width boundaries and not overflow";
+      const data = createMockData({
+        recentSession: {
+          projectPath: "/test/project",
+          projectName: "project",
+          lastModified: new Date(),
+          lastMessage: longMessage,
+          isActive: true,
+          relativeTime: "1m ago",
+        },
+      });
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} width={50} />);
+      const output = lastFrame() || "";
+
+      // Should contain truncation indicator
+      expect(output).toContain("...");
+      // Should not contain the full message
+      expect(output).not.toContain(longMessage);
+    });
+  });
+
+  describe("no sessions state", () => {
+    it("shows 'No other active sessions' when recentSession is null", () => {
+      const data = createMockData({
+        totalProjects: 1,
+        activeCount: 0,
+        recentSession: null,
+      });
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("No other active sessions");
+    });
+
+    it("shows empty state when no projects exist", () => {
+      const data = createMockData({
+        totalProjects: 0,
+        activeCount: 0,
+        recentSession: null,
+      });
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("0 projects");
+    });
+  });
+
+  describe("panel title", () => {
+    it("shows 'Other Sessions' in the title", () => {
+      const data = createMockData();
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      expect(lastFrame()).toContain("Other Sessions");
+    });
+  });
+
+  describe("visual feedback", () => {
+    it("shows countdown when provided", () => {
+      const data = createMockData();
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} countdown={10} />);
+
+      expect(lastFrame()).toContain("10s");
+    });
+
+    it("shows 'running...' when isRunning is true", () => {
+      const data = createMockData();
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} isRunning={true} />);
+
+      expect(lastFrame()).toContain("running...");
+    });
+  });
+
+  describe("responsive width", () => {
+    it("panel border width matches content line width", () => {
+      const data = createMockData();
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} width={80} />);
+      const output = lastFrame() || "";
+      const lines = output.split("\n");
+
+      // Strip ANSI codes
+      const stripAnsi = (str: string) => str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+
+      const titleLine = stripAnsi(lines[0]);
+      const bottomLine = stripAnsi(lines[lines.length - 1]);
+
+      // All lines should have the same width
+      expect(titleLine.length).toBe(80);
+      expect(bottomLine.length).toBe(80);
+    });
+  });
+
+  describe("null message handling", () => {
+    it("handles null lastMessage gracefully", () => {
+      const data = createMockData({
+        recentSession: {
+          projectPath: "/test/project",
+          projectName: "project",
+          lastModified: new Date(),
+          lastMessage: null,
+          isActive: true,
+          relativeTime: "1m ago",
+        },
+      });
+
+      const { lastFrame } = render(<OtherSessionsPanel data={data} />);
+
+      // Should render without crashing
+      expect(lastFrame()).toContain("project");
+      // Should not show message line or show placeholder
+      expect(lastFrame()).not.toContain("undefined");
+    });
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -389,8 +389,8 @@ panels:
 
       const { config } = parseConfig();
 
-      // Config order is preserved, missing built-in panels (project, claude) added at end
-      expect(config.panelOrder).toEqual(["git", "docker", "tests", "project", "claude"]);
+      // Config order is preserved, missing built-in panels (project, claude, other_sessions) added at end
+      expect(config.panelOrder).toEqual(["git", "docker", "tests", "project", "claude", "other_sessions"]);
     });
 
     it("returns default order when no config file", () => {
@@ -398,7 +398,7 @@ panels:
 
       const { config } = parseConfig();
 
-      expect(config.panelOrder).toEqual(["project", "git", "tests", "claude"]);
+      expect(config.panelOrder).toEqual(["project", "git", "tests", "claude", "other_sessions"]);
     });
 
     it("includes disabled panels in order (enabled checked at render time)", () => {
@@ -417,8 +417,8 @@ panels:
 
       // panelOrder should include all panels from config, regardless of enabled state
       // The enabled state is checked at render time
-      // Missing built-in panels (project, claude) added at end
-      expect(config.panelOrder).toEqual(["git", "docker", "tests", "project", "claude"]);
+      // Missing built-in panels (project, claude, other_sessions) added at end
+      expect(config.panelOrder).toEqual(["git", "docker", "tests", "project", "claude", "other_sessions"]);
     });
   });
 

--- a/tests/otherSessions.test.ts
+++ b/tests/otherSessions.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getAllProjects,
+  getOtherSessionsData,
+  parseLastAssistantMessage,
+  formatRelativeTime,
+  setFsMock,
+  resetFsMock,
+  type OtherSessionsData,
+} from "../src/data/otherSessions.js";
+
+describe("otherSessions data module", () => {
+  let mockFs: {
+    existsSync: ReturnType<typeof vi.fn>;
+    readFileSync: ReturnType<typeof vi.fn>;
+    readdirSync: ReturnType<typeof vi.fn>;
+    statSync: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockFs = {
+      existsSync: vi.fn(),
+      readFileSync: vi.fn(),
+      readdirSync: vi.fn(),
+      statSync: vi.fn(),
+    };
+    setFsMock(mockFs);
+  });
+
+  afterEach(() => {
+    resetFsMock();
+  });
+
+  describe("getAllProjects", () => {
+    it("returns empty array when projects directory does not exist", () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      const result = getAllProjects();
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns all project directories", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue([
+        "-Users-test-project1",
+        "-Users-test-project2",
+        "-Users-test-project3",
+      ]);
+      mockFs.statSync.mockReturnValue({ isDirectory: () => true });
+
+      const result = getAllProjects();
+
+      expect(result).toHaveLength(3);
+      expect(result[0].encodedPath).toBe("-Users-test-project1");
+      expect(result[0].decodedPath).toBe("/Users/test/project1");
+    });
+
+    it("filters out non-directory entries", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockReturnValue([
+        "-Users-test-project1",
+        "some-file.txt",
+      ]);
+      mockFs.statSync.mockImplementation((path: string) => ({
+        isDirectory: () => !path.includes("some-file.txt"),
+      }));
+
+      const result = getAllProjects();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].encodedPath).toBe("-Users-test-project1");
+    });
+
+    it("decodes project path correctly", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      // Note: path encoding is ambiguous for paths with hyphens
+      // "-Users-test-myproject" could be "/Users/test/myproject" or "/Users-test-myproject"
+      mockFs.readdirSync.mockReturnValue(["-Users-test-myproject"]);
+      mockFs.statSync.mockReturnValue({ isDirectory: () => true });
+
+      const result = getAllProjects();
+
+      // The decode replaces all "-" with "/", so we get segments
+      expect(result[0].decodedPath).toBe("/Users/test/myproject");
+    });
+  });
+
+  describe("parseLastAssistantMessage", () => {
+    it("returns null for empty file", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue("");
+
+      const result = parseLastAssistantMessage("/fake/session.jsonl");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when no assistant messages exist", () => {
+      const lines = [
+        JSON.stringify({ type: "user", message: { content: "Hello" } }),
+        JSON.stringify({ type: "system", subtype: "init" }),
+      ].join("\n");
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(lines);
+
+      const result = parseLastAssistantMessage("/fake/session.jsonl");
+
+      expect(result).toBeNull();
+    });
+
+    it("extracts text from last assistant message", () => {
+      const lines = [
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "First response" }] },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Last response here" }] },
+        }),
+      ].join("\n");
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(lines);
+
+      const result = parseLastAssistantMessage("/fake/session.jsonl");
+
+      expect(result).toBe("Last response here");
+    });
+
+    it("handles assistant message with tool_use only (no text)", () => {
+      const lines = [
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Earlier message" }] },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [{ type: "tool_use", name: "Bash", input: { command: "npm test" } }],
+          },
+        }),
+      ].join("\n");
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(lines);
+
+      const result = parseLastAssistantMessage("/fake/session.jsonl");
+
+      // Should return the earlier message with text, not the tool_use one
+      expect(result).toBe("Earlier message");
+    });
+
+    it("removes newlines from message", () => {
+      const lines = [
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Line one\nLine two\nLine three" }] },
+        }),
+      ].join("\n");
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(lines);
+
+      const result = parseLastAssistantMessage("/fake/session.jsonl");
+
+      expect(result).toBe("Line one Line two Line three");
+    });
+
+    it("skips invalid JSON lines", () => {
+      const lines = [
+        "invalid json",
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Valid message" }] },
+        }),
+        "{ also invalid }",
+      ].join("\n");
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(lines);
+
+      const result = parseLastAssistantMessage("/fake/session.jsonl");
+
+      expect(result).toBe("Valid message");
+    });
+  });
+
+  describe("formatRelativeTime", () => {
+    it("formats seconds ago", () => {
+      const date = new Date(Date.now() - 30 * 1000);
+      expect(formatRelativeTime(date)).toBe("30s ago");
+    });
+
+    it("formats minutes ago", () => {
+      const date = new Date(Date.now() - 5 * 60 * 1000);
+      expect(formatRelativeTime(date)).toBe("5m ago");
+    });
+
+    it("formats hours ago", () => {
+      const date = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      expect(formatRelativeTime(date)).toBe("2h ago");
+    });
+
+    it("formats days ago", () => {
+      const date = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+      expect(formatRelativeTime(date)).toBe("3d ago");
+    });
+
+    it("shows 'just now' for very recent times", () => {
+      const date = new Date(Date.now() - 500); // 0.5 seconds ago
+      expect(formatRelativeTime(date)).toBe("just now");
+    });
+  });
+
+  describe("getOtherSessionsData", () => {
+    it("returns empty data when projects directory does not exist", () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      const result = getOtherSessionsData("/current/project");
+
+      expect(result.totalProjects).toBe(0);
+      expect(result.activeCount).toBe(0);
+      expect(result.recentSession).toBeNull();
+    });
+
+    it("excludes current project from results", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockImplementation((path: string) => {
+        // Projects directory returns list of project folders
+        if (path.endsWith("projects")) {
+          return ["-Users-test-current", "-Users-test-other"];
+        }
+        // Project folders return session files
+        return ["session.jsonl"];
+      });
+      mockFs.statSync.mockImplementation((path: string) => {
+        if (path.endsWith(".jsonl")) {
+          return { mtimeMs: Date.now() - 1000, isDirectory: () => false };
+        }
+        return { isDirectory: () => true };
+      });
+      mockFs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Hello" }] },
+        })
+      );
+
+      const result = getOtherSessionsData("/Users/test/current");
+
+      // Total should include all projects (2), but active/recent should exclude current
+      expect(result.totalProjects).toBe(2);
+      // Only "other" project should be considered
+      expect(result.recentSession?.projectPath).toBe("/Users/test/other");
+    });
+
+    it("counts active sessions correctly", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockImplementation((path: string) => {
+        if (path.endsWith("projects")) {
+          return ["-Users-test-project1", "-Users-test-project2", "-Users-test-project3"];
+        }
+        return ["session.jsonl"];
+      });
+      mockFs.statSync.mockImplementation((path: string) => {
+        if (path.endsWith(".jsonl")) {
+          // project1: active (1 minute ago)
+          // project2: active (3 minutes ago)
+          // project3: inactive (10 minutes ago)
+          if (path.includes("project1")) {
+            return { mtimeMs: Date.now() - 1 * 60 * 1000, isDirectory: () => false };
+          }
+          if (path.includes("project2")) {
+            return { mtimeMs: Date.now() - 3 * 60 * 1000, isDirectory: () => false };
+          }
+          return { mtimeMs: Date.now() - 10 * 60 * 1000, isDirectory: () => false };
+        }
+        return { isDirectory: () => true };
+      });
+      mockFs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Hello" }] },
+        })
+      );
+
+      const result = getOtherSessionsData("/some/other/path");
+
+      expect(result.totalProjects).toBe(3);
+      expect(result.activeCount).toBe(2); // project1 and project2
+    });
+
+    it("returns most recent session info", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockImplementation((path: string) => {
+        if (path.endsWith("projects")) {
+          return ["-Users-test-older", "-Users-test-newer"];
+        }
+        return ["session.jsonl"];
+      });
+      mockFs.statSync.mockImplementation((path: string) => {
+        if (path.endsWith(".jsonl")) {
+          if (path.includes("newer")) {
+            return { mtimeMs: Date.now() - 30 * 1000, isDirectory: () => false }; // 30s ago
+          }
+          return { mtimeMs: Date.now() - 5 * 60 * 1000, isDirectory: () => false }; // 5m ago
+        }
+        return { isDirectory: () => true };
+      });
+      mockFs.readFileSync.mockImplementation((path: string) => {
+        if (path.includes("newer")) {
+          return JSON.stringify({
+            type: "assistant",
+            message: { content: [{ type: "text", text: "Recent message" }] },
+          });
+        }
+        return JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Old message" }] },
+        });
+      });
+
+      const result = getOtherSessionsData("/some/other/path");
+
+      expect(result.recentSession).not.toBeNull();
+      expect(result.recentSession?.projectPath).toBe("/Users/test/newer");
+      expect(result.recentSession?.projectName).toBe("newer");
+      expect(result.recentSession?.lastMessage).toBe("Recent message");
+      expect(result.recentSession?.isActive).toBe(true);
+    });
+
+    it("extracts project name from path", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockImplementation((path: string) => {
+        if (path.endsWith("projects")) {
+          return ["-Users-test-myproject"];
+        }
+        return ["session.jsonl"];
+      });
+      mockFs.statSync.mockImplementation((path: string) => {
+        if (path.endsWith(".jsonl")) {
+          return { mtimeMs: Date.now() - 1000, isDirectory: () => false };
+        }
+        return { isDirectory: () => true };
+      });
+      mockFs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Hello" }] },
+        })
+      );
+
+      const result = getOtherSessionsData("/other/path");
+
+      // Project name is the last segment of the decoded path
+      expect(result.recentSession?.projectName).toBe("myproject");
+    });
+
+    it("handles project with no session files", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockImplementation((path: string) => {
+        if (path.endsWith("projects")) {
+          return ["-Users-test-emptyproject"];
+        }
+        return []; // No session files
+      });
+      mockFs.statSync.mockReturnValue({ isDirectory: () => true });
+
+      const result = getOtherSessionsData("/other/path");
+
+      expect(result.totalProjects).toBe(1);
+      expect(result.activeCount).toBe(0);
+      expect(result.recentSession).toBeNull();
+    });
+
+    it("respects activeThreshold option", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync.mockImplementation((path: string) => {
+        if (path.endsWith("projects")) {
+          return ["-Users-test-project"];
+        }
+        return ["session.jsonl"];
+      });
+      mockFs.statSync.mockImplementation((path: string) => {
+        if (path.endsWith(".jsonl")) {
+          // 3 minutes ago - active with 5m threshold, inactive with 2m threshold
+          return { mtimeMs: Date.now() - 3 * 60 * 1000, isDirectory: () => false };
+        }
+        return { isDirectory: () => true };
+      });
+      mockFs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Hello" }] },
+        })
+      );
+
+      // With 5 minute threshold (default)
+      const result1 = getOtherSessionsData("/other/path");
+      expect(result1.activeCount).toBe(1);
+      expect(result1.recentSession?.isActive).toBe(true);
+
+      // With 2 minute threshold
+      const result2 = getOtherSessionsData("/other/path", { activeThresholdMs: 2 * 60 * 1000 });
+      expect(result2.activeCount).toBe(0);
+      expect(result2.recentSession?.isActive).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add new panel to monitor other Claude Code sessions (excluding current project)
- Display total projects, active count, and most recent session details
- Show project name, relative time, and last assistant message
- Use 🔵/⚪ icons for active/inactive status

## Features
- Scan `~/.claude/projects/` for all project sessions
- Exclude current project based on cwd
- Parse JSONL for last assistant message
- Configurable via `panels.other_sessions` in config

## Configuration
```yaml
panels:
  other_sessions:
    enabled: true
    interval: 10s
    active_threshold: 5m
    message_max_length: 50
```

## Test plan
- [x] 22 data layer tests (otherSessions.test.ts)
- [x] 15 UI tests (OtherSessionsPanel.test.tsx)
- [x] All 379 tests pass

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)