### PR TITLE
feat: add Task tool description parsing in Claude Panel

### DIFF
--- a/src/data/claude.ts
+++ b/src/data/claude.ts
@@ -138,7 +138,7 @@ export function findActiveSession(sessionDir: string): string | null {
   return null;
 }
 
-function getToolDetail(toolName: string, input?: { command?: string; file_path?: string; pattern?: string; query?: string }): string {
+function getToolDetail(toolName: string, input?: { command?: string; file_path?: string; pattern?: string; query?: string; description?: string }): string {
   if (!input) return "";
 
   if (input.command) {
@@ -152,6 +152,9 @@ function getToolDetail(toolName: string, input?: { command?: string; file_path?:
   }
   if (input.query) {
     return input.query;
+  }
+  if (input.description) {
+    return input.description;
   }
   return "";
 }


### PR DESCRIPTION
## Summary
- Add `description` field support to `getToolDetail()` function
- Task tool calls now display their description in activity log
- Priority order maintained: `command` > `file_path` > `pattern` > `query` > `description`

## Before
```
[10:23:45] ? Task:
```

## After
```
[10:23:45] ? Task: Re-check PR eligibility
```

## Test plan
- [x] Test extracts description for Task tool
- [x] Test returns empty detail for Task tool without description
- [x] Test prioritizes command over description for tools with both
- [x] All 407 tests pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)