### PR TITLE
feat: hide TodoWrite and aggregate consecutive activities

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,6 +100,7 @@ export interface ActivityEntry {
   icon: string;
   label: string;
   detail: string;
+  count?: number; // For aggregating consecutive same activities
 }
 
 export interface TodoItem {

--- a/src/ui/ClaudePanel.tsx
+++ b/src/ui/ClaudePanel.tsx
@@ -105,6 +105,11 @@ function formatActivityParts(activity: ActivityEntry, maxWidth: number): Activit
   const icon = activity.icon;
   const label = activity.label;
   const detail = activity.detail;
+  const count = activity.count;
+
+  // Count suffix for aggregated activities (e.g., " (×3)")
+  const countSuffix = count && count > 1 ? ` (×${count})` : "";
+  const countSuffixWidth = countSuffix.length;
 
   // Skip label for User and Response - they're already distinguished by color
   const skipLabel = label === "User" || label === "Response";
@@ -117,7 +122,7 @@ function formatActivityParts(activity: ActivityEntry, maxWidth: number): Activit
   if (skipLabel && detail) {
     // For User/Response: just show detail without label
     const prefixWidth = timestampWidth + iconWidth + 1; // timestamp + icon + space
-    const availableWidth = maxWidth - prefixWidth;
+    const availableWidth = maxWidth - prefixWidth - countSuffixWidth;
     let truncatedDetail = detail;
     let detailDisplayWidth = getDisplayWidth(detail);
 
@@ -140,8 +145,8 @@ function formatActivityParts(activity: ActivityEntry, maxWidth: number): Activit
     return {
       timestamp,
       icon,
-      labelContent: truncatedDetail,
-      displayWidth: prefixWidth + detailDisplayWidth,
+      labelContent: truncatedDetail + countSuffix,
+      displayWidth: prefixWidth + detailDisplayWidth + countSuffixWidth,
     };
   }
 
@@ -152,7 +157,7 @@ function formatActivityParts(activity: ActivityEntry, maxWidth: number): Activit
   const totalPrefixWidth = timestampWidth + contentPrefixWidth;
 
   if (detail) {
-    const availableWidth = maxWidth - totalPrefixWidth;
+    const availableWidth = maxWidth - totalPrefixWidth - countSuffixWidth;
     let truncatedDetail = detail;
     let detailDisplayWidth = getDisplayWidth(detail);
 
@@ -173,13 +178,13 @@ function formatActivityParts(activity: ActivityEntry, maxWidth: number): Activit
       detailDisplayWidth = currentWidth;
     }
 
-    const labelContent = `${label}: ${truncatedDetail}`;
-    const displayWidth = totalPrefixWidth + detailDisplayWidth;
+    const labelContent = `${label}: ${truncatedDetail}${countSuffix}`;
+    const displayWidth = totalPrefixWidth + detailDisplayWidth + countSuffixWidth;
     return { timestamp, icon, labelContent, displayWidth };
   }
 
-  const labelContent = label;
-  const displayWidth = totalPrefixWidth;
+  const labelContent = label + countSuffix;
+  const displayWidth = totalPrefixWidth + countSuffixWidth;
   return { timestamp, icon, labelContent, displayWidth };
 }
 

--- a/tests/ClaudePanel.test.tsx
+++ b/tests/ClaudePanel.test.tsx
@@ -869,4 +869,68 @@ describe("ClaudePanel", () => {
       expect(output).toContain("Todo (2/2 done)");
     });
   });
+
+  describe("activity count display", () => {
+    it("shows count suffix for aggregated activities", () => {
+      const data = createMockData({
+        state: {
+          status: "running",
+          activities: [
+            {
+              timestamp: new Date("2025-01-12T10:30:00"),
+              type: "tool",
+              icon: ICONS.Edit,
+              label: "Edit",
+              detail: "file.ts",
+              count: 3,
+            },
+          ],
+          tokenCount: 0,
+          sessionStartTime: null,
+          todos: null,
+        },
+      });
+
+      const { lastFrame } = render(<ClaudePanel data={data} />);
+      const output = lastFrame() || "";
+
+      expect(output).toContain("Edit: file.ts (×3)");
+    });
+
+    it("does not show count suffix when count is 1 or undefined", () => {
+      const data = createMockData({
+        state: {
+          status: "running",
+          activities: [
+            {
+              timestamp: new Date("2025-01-12T10:30:00"),
+              type: "tool",
+              icon: ICONS.Edit,
+              label: "Edit",
+              detail: "file.ts",
+              count: 1,
+            },
+            {
+              timestamp: new Date("2025-01-12T10:30:05"),
+              type: "tool",
+              icon: ICONS.Bash,
+              label: "Bash",
+              detail: "npm test",
+            },
+          ],
+          tokenCount: 0,
+          sessionStartTime: null,
+          todos: null,
+        },
+      });
+
+      const { lastFrame } = render(<ClaudePanel data={data} />);
+      const output = lastFrame() || "";
+
+      expect(output).toContain("Edit: file.ts");
+      expect(output).not.toContain("(×1)");
+      expect(output).toContain("Bash: npm test");
+      expect(output).not.toMatch(/npm test.*×/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Skip TodoWrite entries from activity log (already shown in Todo section)
- Aggregate consecutive same-tool same-file operations with count
- Display count suffix like "Edit: file.ts (×3)"

Before:
```
[20:27:23] ~ Edit: ClaudePanel.test.tsx
[20:26:54] ~ Edit: ClaudePanel.test.tsx
[20:26:16] ~ Edit: ClaudePanel.test.tsx
[20:29:22] ~ TodoWrite
```

After:
```
[20:27:23] ~ Edit: ClaudePanel.test.tsx (×3)
```

## Test plan
- [ ] Run `npm test` to verify all 421 tests pass
- [ ] Verify aggregation works correctly in agenthud

🤖 Generated with [Claude Code](https://claude.com/claude-code)