### PR TITLE
fix: use join() for cross-platform subagents path

### DIFF
--- a/src/data/claude.ts
+++ b/src/data/claude.ts
@@ -360,7 +360,7 @@ export function parseSessionState(sessionFile: string, maxActivities: number = D
 
   // Add subagent tokens if subagents folder exists
   // Subagents folder path: {session-file-without-.jsonl}/subagents/
-  const subagentsDir = sessionFile.replace(/\.jsonl$/, "") + "/subagents";
+  const subagentsDir = join(sessionFile.replace(/\.jsonl$/, ""), "subagents");
   if (fs.existsSync(subagentsDir)) {
     try {
       const subagentFiles = fs.readdirSync(subagentsDir).filter((f) => f.endsWith(".jsonl"));

--- a/tests/claude.test.ts
+++ b/tests/claude.test.ts
@@ -425,6 +425,10 @@ describe("claude data module", () => {
 
     it("includes subagent tokens when subagents folder exists", () => {
       const now = new Date();
+      const sessionFile = join("/fake", "session.jsonl");
+      const subagentsDir = join("/fake", "session", "subagents");
+      const subagentFile = join(subagentsDir, "agent-abc123.jsonl");
+
       const mainSessionLines = [
         JSON.stringify({
           type: "assistant",
@@ -448,21 +452,21 @@ describe("claude data module", () => {
       ].join("\n");
 
       mockFs.existsSync.mockImplementation((path: string) => {
-        if (path === "/fake/session.jsonl") return true;
-        if (path === "/fake/session/subagents") return true;
+        if (path === sessionFile) return true;
+        if (path === subagentsDir) return true;
         return false;
       });
       mockFs.readFileSync.mockImplementation((path: string) => {
-        if (path === "/fake/session.jsonl") return mainSessionLines;
-        if (path === "/fake/session/subagents/agent-abc123.jsonl") return subagentLines;
+        if (path === sessionFile) return mainSessionLines;
+        if (path === subagentFile) return subagentLines;
         return "";
       });
       mockFs.readdirSync.mockImplementation((path: string) => {
-        if (path === "/fake/session/subagents") return ["agent-abc123.jsonl"];
+        if (path === subagentsDir) return ["agent-abc123.jsonl"];
         return [];
       });
 
-      const result = parseSessionState("/fake/session.jsonl");
+      const result = parseSessionState(sessionFile);
 
       // Main: 100 + 1000 + 50 = 1150
       // Subagent: 50 + 500 + 25 = 575
@@ -472,6 +476,11 @@ describe("claude data module", () => {
 
     it("handles multiple subagent files", () => {
       const now = new Date();
+      const sessionFile = join("/fake", "session.jsonl");
+      const subagentsDir = join("/fake", "session", "subagents");
+      const subagent1File = join(subagentsDir, "agent-1.jsonl");
+      const subagent2File = join(subagentsDir, "agent-2.jsonl");
+
       const mainSessionLines = [
         JSON.stringify({
           type: "assistant",
@@ -506,22 +515,22 @@ describe("claude data module", () => {
       ].join("\n");
 
       mockFs.existsSync.mockImplementation((path: string) => {
-        if (path === "/fake/session.jsonl") return true;
-        if (path === "/fake/session/subagents") return true;
+        if (path === sessionFile) return true;
+        if (path === subagentsDir) return true;
         return false;
       });
       mockFs.readFileSync.mockImplementation((path: string) => {
-        if (path === "/fake/session.jsonl") return mainSessionLines;
-        if (path === "/fake/session/subagents/agent-1.jsonl") return subagent1Lines;
-        if (path === "/fake/session/subagents/agent-2.jsonl") return subagent2Lines;
+        if (path === sessionFile) return mainSessionLines;
+        if (path === subagent1File) return subagent1Lines;
+        if (path === subagent2File) return subagent2Lines;
         return "";
       });
       mockFs.readdirSync.mockImplementation((path: string) => {
-        if (path === "/fake/session/subagents") return ["agent-1.jsonl", "agent-2.jsonl"];
+        if (path === subagentsDir) return ["agent-1.jsonl", "agent-2.jsonl"];
         return [];
       });
 
-      const result = parseSessionState("/fake/session.jsonl");
+      const result = parseSessionState(sessionFile);
 
       // Main: 100, Sub1: 200, Sub2: 300 = 600
       expect(result.tokenCount).toBe(600);
@@ -529,6 +538,8 @@ describe("claude data module", () => {
 
     it("works normally when subagents folder does not exist", () => {
       const now = new Date();
+      const sessionFile = join("/fake", "session.jsonl");
+
       const mainSessionLines = [
         JSON.stringify({
           type: "assistant",
@@ -541,12 +552,12 @@ describe("claude data module", () => {
       ].join("\n");
 
       mockFs.existsSync.mockImplementation((path: string) => {
-        if (path === "/fake/session.jsonl") return true;
+        if (path === sessionFile) return true;
         return false; // subagents folder doesn't exist
       });
       mockFs.readFileSync.mockReturnValue(mainSessionLines);
 
-      const result = parseSessionState("/fake/session.jsonl");
+      const result = parseSessionState(sessionFile);
 
       expect(result.tokenCount).toBe(100);
     });


### PR DESCRIPTION
## Summary
- Use `path.join()` instead of string concatenation with `/` for building the subagents directory path
- Update tests to use `join()` for cross-platform path matching

## Problem
Windows CI tests were failing because the subagents path was built using `/` separator which doesn't match the `join()` output on Windows.

## Test plan
- [x] All 489 tests pass locally
- [ ] Windows CI tests should pass now

🤖 Generated with [Claude Code](https://claude.com/claude-code)