### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 ## [Unreleased]
 
+## [0.6.1] - 2025-01-15
+
 ### New
 - **Token Usage in Title** - See session token count (input + cache + output) in Claude panel title
 - **Subagent Tokens** - Includes token usage from subagent sessions
+- **Configurable Session Timeout** - Set `session_timeout` in config (default: 60 min)
+
+### Fixed
+- Panel countdown timers freezing at 1 second
+- Data refresh stopping after first interval
+- Wrong session selected when multiple sessions have same modification time
+- Windows path separator issue for subagent token counting
 
 ### Internal
 - **Refactored App.tsx** - Extracted reusable hooks (useCountdown, useVisualFeedback, useHotkeys, usePanelData)
@@ -54,7 +63,8 @@
 - **Test Panel** - Test results at a glance
 - Watch mode for live updates
 
-[Unreleased]: https://github.com/neochoon/agenthud/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/neochoon/agenthud/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/neochoon/agenthud/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/neochoon/agenthud/compare/v0.5.17...v0.6.0
 [0.5.17]: https://github.com/neochoon/agenthud/compare/v0.5.0...v0.5.17
 [0.5.0]: https://github.com/neochoon/agenthud/compare/v0.4.0...v0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenthud",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenthud",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "ink": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenthud",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "CLI tool to monitor agent status in real-time. Works with Claude Code, multi-agent workflows, and any AI agent system.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Release v0.6.1 with bug fixes and new features.

### New
- Token usage display in Claude panel title
- Subagent token counting
- Configurable session timeout (default: 60 min)

### Fixed
- Panel countdown timers freezing at 1 second
- Data refresh stopping after first interval
- Wrong session selected when multiple sessions have same modification time
- Windows path separator issue for subagent token counting

## Test plan
- [x] All 489 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)