### PR TITLE
feat: add npm auto-deploy on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+
+      - name: Extract changelog for release
+        id: changelog
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Extract changelog section for this version
+          awk '/^## \['"$VERSION"'\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md > release_notes.md
+
+          # If empty, use default message
+          if [ ! -s release_notes.md ]; then
+            echo "Release $VERSION" > release_notes.md
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release_notes.md
+          generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Internal
+- **Auto Deploy** - npm publish and GitHub Release on tag push (`v*`)
+
 ## [0.6.1] - 2025-01-15
 
 ### New


### PR DESCRIPTION
## Summary
- Add CD workflow for automatic npm publishing on tag push
- Auto-create GitHub Release with changelog content

## Trigger
```
git tag v0.6.2 && git push origin v0.6.2
```

## Workflow
1. Checkout → Install → Build
2. `npm publish --provenance --access public` (OIDC)
3. Extract changelog → Create GitHub Release

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)