### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.2] - 2025-01-15
+
 ### Internal
 - **Auto Deploy** - npm publish and GitHub Release on tag push (`v*`)
 
@@ -66,7 +68,8 @@
 - **Test Panel** - Test results at a glance
 - Watch mode for live updates
 
-[Unreleased]: https://github.com/neochoon/agenthud/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/neochoon/agenthud/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/neochoon/agenthud/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/neochoon/agenthud/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/neochoon/agenthud/compare/v0.5.17...v0.6.0
 [0.5.17]: https://github.com/neochoon/agenthud/compare/v0.5.0...v0.5.17

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenthud",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenthud",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "ink": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenthud",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "CLI tool to monitor agent status in real-time. Works with Claude Code, multi-agent workflows, and any AI agent system.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.6.2

### Internal
- **Auto Deploy** - npm publish and GitHub Release on tag push (`v*`)

## Checklist
- [x] CHANGELOG.md updated
- [x] Version bumped in package.json
- [ ] CI passes

After merge:
```bash
git checkout main && git pull
git tag v0.6.2
git push origin v0.6.2
```