### PR TITLE
fix: use Node.js 24 for npm OIDC publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Use Node.js 24 (npm 11.5+) for native OIDC token exchange
- Add registry-url for npm authentication

## Changes
```yaml
- name: Use Node.js 24
  uses: actions/setup-node@v4
  with:
    node-version: 24
    registry-url: 'https://registry.npmjs.org'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)