### PR TITLE
chore: release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.6.3] - 2025-01-16
+
+### New
+- **JUnit XML Support** - All test frameworks (vitest, jest, mocha, pytest) now output JUnit XML format for consistent parsing
+
+### Internal
+- Test folder structure reorganized to match `src/` layout
+- Removed test mock patterns from production code, using `vi.mock()` instead
+
 ## [0.6.2] - 2025-01-15
 
 ### Internal
@@ -68,7 +77,8 @@
 - **Test Panel** - Test results at a glance
 - Watch mode for live updates
 
-[Unreleased]: https://github.com/neochoon/agenthud/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/neochoon/agenthud/compare/v0.6.3...HEAD
+[0.6.3]: https://github.com/neochoon/agenthud/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/neochoon/agenthud/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/neochoon/agenthud/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/neochoon/agenthud/compare/v0.5.17...v0.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenthud",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenthud",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "ink": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenthud",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "CLI tool to monitor agent status in real-time. Works with Claude Code, multi-agent workflows, and any AI agent system.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.6.3

### New
- **JUnit XML Support** - All test frameworks (vitest, jest, mocha, pytest) now output JUnit XML format for consistent parsing

### Internal
- Test folder structure reorganized to match `src/` layout
- Removed test mock patterns from production code, using `vi.mock()` instead

## Checklist
- [x] CHANGELOG.md updated
- [x] Version bumped in package.json
- [ ] CI passes

After merge:
```bash
git checkout main && git pull
git tag v0.6.3
git push origin v0.6.3
```