### PR TITLE
feat: sort project list by most recent modification time

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -89,17 +89,19 @@ export function runInit(cwd: string = process.cwd()): InitResult {
     result.skipped.push(".agenthud/config.yaml");
   }
 
-  // Handle .gitignore
-  if (!existsSync(".gitignore")) {
-    writeFileSync(".gitignore", ".agenthud/\n");
-    result.created.push(".gitignore");
-  } else {
-    const content = readFileSync(".gitignore", "utf-8");
-    if (!content.includes(".agenthud/")) {
-      appendFileSync(".gitignore", "\n.agenthud/\n");
+  // Handle .gitignore (only if this is a git repository)
+  if (existsSync(".git")) {
+    if (!existsSync(".gitignore")) {
+      writeFileSync(".gitignore", ".agenthud/\n");
       result.created.push(".gitignore");
     } else {
-      result.skipped.push(".gitignore");
+      const content = readFileSync(".gitignore", "utf-8");
+      if (!content.includes(".agenthud/")) {
+        appendFileSync(".gitignore", "\n.agenthud/\n");
+        result.created.push(".gitignore");
+      } else {
+        result.skipped.push(".gitignore");
+      }
     }
   }
 

--- a/src/data/sessionAvailability.ts
+++ b/src/data/sessionAvailability.ts
@@ -87,14 +87,17 @@ export function hasCurrentProjectSession(cwd: string): boolean {
 /**
  * Get list of projects that have Claude sessions, excluding current project
  * Sorted by most recent modification time (newest first)
+ * Excludes projects whose decoded path doesn't exist on filesystem
  */
 export function getProjectsWithSessions(currentPath: string): ProjectInfo[] {
   const allProjects = getAllProjects();
   const currentEncoded = currentPath.replace(/[/\\]/g, "-");
 
   // Get projects with their modification times
+  // Filter out: current project, and projects whose decoded path doesn't exist
   const projectsWithMtime = allProjects
     .filter((p) => p.encodedPath !== currentEncoded)
+    .filter((p) => existsSync(p.decodedPath)) // Only include projects that exist
     .map((p) => ({
       name: basename(p.decodedPath),
       path: p.decodedPath,

--- a/tests/data/sessionAvailability.test.ts
+++ b/tests/data/sessionAvailability.test.ts
@@ -7,6 +7,8 @@ vi.mock("node:fs", async (importOriginal) => {
   return {
     ...actual,
     existsSync: vi.fn(),
+    readdirSync: vi.fn(),
+    statSync: vi.fn(),
   };
 });
 
@@ -20,7 +22,7 @@ vi.mock("../../src/data/otherSessions.js", () => ({
   getAllProjects: vi.fn(),
 }));
 
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { getAllProjects } from "../../src/data/otherSessions.js";
 import {
   checkSessionAvailability,
@@ -30,6 +32,8 @@ import {
 } from "../../src/data/sessionAvailability.js";
 
 const mockExistsSync = vi.mocked(existsSync);
+const mockReaddirSync = vi.mocked(readdirSync);
+const mockStatSync = vi.mocked(statSync);
 const mockGetAllProjects = vi.mocked(getAllProjects);
 
 describe("sessionAvailability", () => {
@@ -64,19 +68,40 @@ describe("sessionAvailability", () => {
   });
 
   describe("getProjectsWithSessions", () => {
-    it("returns list of projects with name and path", () => {
+    it("returns list of projects sorted by most recent modification time", () => {
       mockGetAllProjects.mockReturnValue([
         { encodedPath: "-Users-test-project-a", decodedPath: "/Users/test/project-a" },
         { encodedPath: "-Users-test-project-b", decodedPath: "/Users/test/project-b" },
         { encodedPath: "-Users-test-project-c", decodedPath: "/Users/test/project-c" },
       ]);
 
+      // Mock session directories exist
+      mockExistsSync.mockReturnValue(true);
+
+      // Mock session files for each project
+      mockReaddirSync.mockImplementation((dir) => {
+        if (String(dir).includes("-Users-test-project-a")) return ["session1.jsonl"];
+        if (String(dir).includes("-Users-test-project-b")) return ["session1.jsonl"];
+        if (String(dir).includes("-Users-test-project-c")) return ["session1.jsonl"];
+        return [];
+      });
+
+      // Mock modification times: project-c is newest, project-a is oldest
+      mockStatSync.mockImplementation((path) => {
+        const pathStr = String(path);
+        if (pathStr.includes("-Users-test-project-a")) return { mtimeMs: 1000, isDirectory: () => true } as any;
+        if (pathStr.includes("-Users-test-project-b")) return { mtimeMs: 2000, isDirectory: () => true } as any;
+        if (pathStr.includes("-Users-test-project-c")) return { mtimeMs: 3000, isDirectory: () => true } as any;
+        return { mtimeMs: 0, isDirectory: () => true } as any;
+      });
+
       const result = getProjectsWithSessions("/Users/test/current");
 
+      // Should be sorted by most recent first
       expect(result).toEqual([
-        { name: "project-a", path: "/Users/test/project-a" },
-        { name: "project-b", path: "/Users/test/project-b" },
         { name: "project-c", path: "/Users/test/project-c" },
+        { name: "project-b", path: "/Users/test/project-b" },
+        { name: "project-a", path: "/Users/test/project-a" },
       ]);
     });
 
@@ -87,13 +112,14 @@ describe("sessionAvailability", () => {
         { encodedPath: "-Users-test-project-b", decodedPath: "/Users/test/project-b" },
       ]);
 
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue(["session1.jsonl"] as any);
+      mockStatSync.mockReturnValue({ mtimeMs: 1000, isDirectory: () => true } as any);
+
       const result = getProjectsWithSessions("/Users/test/current");
 
-      expect(result).toEqual([
-        { name: "project-a", path: "/Users/test/project-a" },
-        { name: "project-b", path: "/Users/test/project-b" },
-      ]);
       expect(result.map((p) => p.name)).not.toContain("current");
+      expect(result.length).toBe(2);
     });
 
     it("returns empty array when no projects exist", () => {
@@ -102,6 +128,28 @@ describe("sessionAvailability", () => {
       const result = getProjectsWithSessions("/Users/test/current");
 
       expect(result).toEqual([]);
+    });
+
+    it("puts projects without sessions at the end", () => {
+      mockGetAllProjects.mockReturnValue([
+        { encodedPath: "-Users-test-project-a", decodedPath: "/Users/test/project-a" },
+        { encodedPath: "-Users-test-project-b", decodedPath: "/Users/test/project-b" },
+      ]);
+
+      mockExistsSync.mockImplementation((path) => {
+        // project-a has no session directory
+        if (String(path).includes("-Users-test-project-a")) return false;
+        return true;
+      });
+
+      mockReaddirSync.mockReturnValue(["session1.jsonl"] as any);
+      mockStatSync.mockReturnValue({ mtimeMs: 1000, isDirectory: () => true } as any);
+
+      const result = getProjectsWithSessions("/Users/test/current");
+
+      // project-b should come first (has session), project-a last (no session)
+      expect(result[0].name).toBe("project-b");
+      expect(result[1].name).toBe("project-a");
     });
   });
 
@@ -127,19 +175,37 @@ describe("sessionAvailability", () => {
       expect(result.otherProjects).toEqual([]);
     });
 
-    it("returns otherProjects list when current project has no session but others do", () => {
-      mockExistsSync.mockReturnValue(false);
+    it("returns otherProjects list sorted by most recent when current has no session", () => {
+      // First call to existsSync checks current project session (returns false)
+      // Subsequent calls check other project directories
+      mockExistsSync.mockImplementation((path) => {
+        const pathStr = String(path);
+        if (pathStr.includes("-Users-test-current")) return false;
+        return true;
+      });
+
       mockGetAllProjects.mockReturnValue([
         { encodedPath: "-Users-test-project-a", decodedPath: "/Users/test/project-a" },
         { encodedPath: "-Users-test-project-b", decodedPath: "/Users/test/project-b" },
       ]);
 
+      mockReaddirSync.mockReturnValue(["session1.jsonl"] as any);
+
+      // project-b is more recent than project-a
+      mockStatSync.mockImplementation((path) => {
+        const pathStr = String(path);
+        if (pathStr.includes("-Users-test-project-a")) return { mtimeMs: 1000, isDirectory: () => true } as any;
+        if (pathStr.includes("-Users-test-project-b")) return { mtimeMs: 2000, isDirectory: () => true } as any;
+        return { mtimeMs: 0, isDirectory: () => true } as any;
+      });
+
       const result = checkSessionAvailability("/Users/test/current");
 
       expect(result.hasCurrentSession).toBe(false);
+      // Should be sorted by most recent first
       expect(result.otherProjects).toEqual([
-        { name: "project-a", path: "/Users/test/project-a" },
         { name: "project-b", path: "/Users/test/project-b" },
+        { name: "project-a", path: "/Users/test/project-a" },
       ]);
     });
 

--- a/tests/data/sessionAvailability.test.ts
+++ b/tests/data/sessionAvailability.test.ts
@@ -179,18 +179,22 @@ describe("sessionAvailability", () => {
     });
 
     it("excludes directories that are not development projects", () => {
+      const projectPath = join("/Users", "test", "project");
+      const homePath = join("/Users", "test");
+      const projectGitPath = join(projectPath, ".git");
+
       mockGetAllProjects.mockReturnValue([
-        { encodedPath: "-Users-test-project", decodedPath: "/Users/test/project" },
-        { encodedPath: "-Users-test-home", decodedPath: "/Users/test" }, // home dir, not a project
+        { encodedPath: "-Users-test-project", decodedPath: projectPath },
+        { encodedPath: "-Users-test-home", decodedPath: homePath }, // home dir, not a project
       ]);
 
       // Mock: project has .git, home dir doesn't have any project indicators
       mockExistsSync.mockImplementation((path) => {
         const pathStr = String(path);
         // Both paths exist
-        if (pathStr === "/Users/test/project" || pathStr === "/Users/test") return true;
+        if (pathStr === projectPath || pathStr === homePath) return true;
         // project has .git
-        if (pathStr === "/Users/test/project/.git") return true;
+        if (pathStr === projectGitPath) return true;
         // home dir has no project indicators
         return false;
       });
@@ -198,7 +202,7 @@ describe("sessionAvailability", () => {
       mockReaddirSync.mockReturnValue(["session1.jsonl"] as any);
       mockStatSync.mockReturnValue({ mtimeMs: 1000, isDirectory: () => true } as any);
 
-      const result = getProjectsWithSessions("/Users/other/current");
+      const result = getProjectsWithSessions(join("/Users", "other", "current"));
 
       // Should only include project, not home dir
       expect(result.length).toBe(1);
@@ -219,49 +223,59 @@ describe("sessionAvailability", () => {
 
   describe("isDevProject", () => {
     it("returns true if .git directory exists", () => {
+      const projectPath = join("/Users", "test", "project");
+      const gitPath = join(projectPath, ".git");
       mockExistsSync.mockImplementation((path) => {
-        return String(path) === "/Users/test/project/.git";
+        return String(path) === gitPath;
       });
 
-      expect(isDevProject("/Users/test/project")).toBe(true);
+      expect(isDevProject(projectPath)).toBe(true);
     });
 
     it("returns true if package.json exists", () => {
+      const projectPath = join("/Users", "test", "project");
+      const pkgPath = join(projectPath, "package.json");
       mockExistsSync.mockImplementation((path) => {
-        return String(path) === "/Users/test/project/package.json";
+        return String(path) === pkgPath;
       });
 
-      expect(isDevProject("/Users/test/project")).toBe(true);
+      expect(isDevProject(projectPath)).toBe(true);
     });
 
     it("returns true if Cargo.toml exists", () => {
+      const projectPath = join("/Users", "test", "project");
+      const cargoPath = join(projectPath, "Cargo.toml");
       mockExistsSync.mockImplementation((path) => {
-        return String(path) === "/Users/test/project/Cargo.toml";
+        return String(path) === cargoPath;
       });
 
-      expect(isDevProject("/Users/test/project")).toBe(true);
+      expect(isDevProject(projectPath)).toBe(true);
     });
 
     it("returns true if pyproject.toml exists", () => {
+      const projectPath = join("/Users", "test", "project");
+      const pyPath = join(projectPath, "pyproject.toml");
       mockExistsSync.mockImplementation((path) => {
-        return String(path) === "/Users/test/project/pyproject.toml";
+        return String(path) === pyPath;
       });
 
-      expect(isDevProject("/Users/test/project")).toBe(true);
+      expect(isDevProject(projectPath)).toBe(true);
     });
 
     it("returns true if go.mod exists", () => {
+      const projectPath = join("/Users", "test", "project");
+      const goPath = join(projectPath, "go.mod");
       mockExistsSync.mockImplementation((path) => {
-        return String(path) === "/Users/test/project/go.mod";
+        return String(path) === goPath;
       });
 
-      expect(isDevProject("/Users/test/project")).toBe(true);
+      expect(isDevProject(projectPath)).toBe(true);
     });
 
     it("returns false if no project indicators exist", () => {
       mockExistsSync.mockReturnValue(false);
 
-      expect(isDevProject("/Users/test/random-folder")).toBe(false);
+      expect(isDevProject(join("/Users", "test", "random-folder"))).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
Sort the project list by most recent session modification time, so actively used projects appear at the top and old/accidental sessions (like home directory) sink to the bottom.

**Before:**
```
Projects with Claude Code sessions:
  1. neochoon (~)
  2. claude (~/claude)
  3. dotfiles (~/claude/projects/Users/neochoon/dotfiles)
  4. Relay (~/WestbrookAI/Relay)
  ...
```

**After:**
```
Projects with Claude Code sessions:
  1. agenthud (~/WestbrookAI/agenthud)
  2. pain-radar (~/WestbrookAI/pain-radar)
  3. dotfiles (~/dotfiles)
  4. neochoon (~)
  ...
```

## Changes
- Add `getProjectMostRecentMtime()` function to get the modification time of a project's most recent session file
- Update `getProjectsWithSessions()` to sort by modification time (newest first)
- Projects without sessions are placed at the end

## Test plan
- [x] Unit tests for sorting behavior
- [x] Unit tests for projects without sessions going to end
- [x] All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Detects and filters to development-style projects when listing sessions.
  * Projects with sessions are sorted by most-recent activity; those without sessions appear last.
  * The current project is excluded from the returned list.

* **Chores**
  * Init command now only creates or appends .gitignore entries when inside a Git repository; skipped otherwise.

* **Tests**
  * Added tests for recency sorting, exclusion of current project, handling of missing session dirs, dev-project detection, and .gitignore behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->