### PR TITLE
feat: display model name and turn duration in Claude panel

### DIFF
--- a/src/data/sessionAvailability.ts
+++ b/src/data/sessionAvailability.ts
@@ -22,8 +22,8 @@ export function shortenPath(path: string): string {
   if (path === home) {
     return "~";
   }
-  if (path.startsWith(home + "/") || path.startsWith(home + "\\")) {
-    return "~" + path.slice(home.length);
+  if (path.startsWith(`${home}/`) || path.startsWith(`${home}\\`)) {
+    return `~${path.slice(home.length)}`;
   }
   return path;
 }
@@ -32,18 +32,18 @@ export function shortenPath(path: string): string {
  * Project indicator files that suggest a directory is a development project
  */
 const PROJECT_INDICATORS = [
-  ".git",           // Git repository
-  "package.json",   // Node.js
-  "Cargo.toml",     // Rust
+  ".git", // Git repository
+  "package.json", // Node.js
+  "Cargo.toml", // Rust
   "pyproject.toml", // Python (modern)
-  "setup.py",       // Python (legacy)
-  "go.mod",         // Go
-  "Makefile",       // Make-based projects
+  "setup.py", // Python (legacy)
+  "go.mod", // Go
+  "Makefile", // Make-based projects
   "CMakeLists.txt", // CMake projects
-  "pom.xml",        // Java Maven
-  "build.gradle",   // Java Gradle
-  "Gemfile",        // Ruby
-  "composer.json",  // PHP
+  "pom.xml", // Java Maven
+  "build.gradle", // Java Gradle
+  "Gemfile", // Ruby
+  "composer.json", // PHP
 ];
 
 /**
@@ -148,7 +148,9 @@ export function getProjectsWithSessions(currentPath: string): ProjectInfo[] {
  * Check session availability for the application startup logic
  * Returns whether current project has session and list of other projects with sessions
  */
-export function checkSessionAvailability(cwd: string): SessionAvailabilityResult {
+export function checkSessionAvailability(
+  cwd: string,
+): SessionAvailabilityResult {
   const hasCurrentSession = hasCurrentProjectSession(cwd);
 
   if (hasCurrentSession) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,6 +117,8 @@ export interface ClaudeSessionState {
   tokenCount: number;
   sessionStartTime: Date | null;
   todos: TodoItem[] | null;
+  modelName: string | null;
+  lastTurnDuration: number | null; // in milliseconds
 }
 
 export interface ClaudeData {

--- a/src/ui/OtherSessionsPanel.tsx
+++ b/src/ui/OtherSessionsPanel.tsx
@@ -129,11 +129,12 @@ export function OtherSessionsPanel({
         {projectsText}
       </Text>
       <Text dimColor={!hasActive} color={hasActive ? "yellow" : undefined}>
-        {" "}| * {activeCount} active
+        {" "}
+        | * {activeCount} active
       </Text>
       {" ".repeat(headerPadding)}
       {BOX.v}
-          </Text>,
+    </Text>,
   );
 
   // Empty line
@@ -141,7 +142,7 @@ export function OtherSessionsPanel({
     <Text key="empty">
       {BOX.v} {" ".repeat(contentWidth)}
       {BOX.v}
-          </Text>,
+    </Text>,
   );
 
   // Recent session or empty state
@@ -158,7 +159,7 @@ export function OtherSessionsPanel({
         {BOX.v} <Text>{sessionLine}</Text>
         {" ".repeat(sessionLinePadding)}
         {BOX.v}
-              </Text>,
+      </Text>,
     );
 
     // Last message (if available)
@@ -184,7 +185,7 @@ export function OtherSessionsPanel({
           {BOX.v} <Text dimColor>{messageText}</Text>
           {" ".repeat(messagePadding)}
           {BOX.v}
-                  </Text>,
+        </Text>,
       );
     }
   } else {
@@ -197,7 +198,7 @@ export function OtherSessionsPanel({
         {BOX.v} <Text dimColor>{noSessionText}</Text>
         {" ".repeat(noSessionPadding)}
         {BOX.v}
-              </Text>,
+      </Text>,
     );
   }
 

--- a/tests/data/sessionAvailability.test.ts
+++ b/tests/data/sessionAvailability.test.ts
@@ -71,9 +71,18 @@ describe("sessionAvailability", () => {
   describe("getProjectsWithSessions", () => {
     it("returns list of projects sorted by most recent modification time", () => {
       mockGetAllProjects.mockReturnValue([
-        { encodedPath: "-Users-test-project-a", decodedPath: "/Users/test/project-a" },
-        { encodedPath: "-Users-test-project-b", decodedPath: "/Users/test/project-b" },
-        { encodedPath: "-Users-test-project-c", decodedPath: "/Users/test/project-c" },
+        {
+          encodedPath: "-Users-test-project-a",
+          decodedPath: "/Users/test/project-a",
+        },
+        {
+          encodedPath: "-Users-test-project-b",
+          decodedPath: "/Users/test/project-b",
+        },
+        {
+          encodedPath: "-Users-test-project-c",
+          decodedPath: "/Users/test/project-c",
+        },
       ]);
 
       // Mock session directories exist
@@ -81,18 +90,24 @@ describe("sessionAvailability", () => {
 
       // Mock session files for each project
       mockReaddirSync.mockImplementation((dir) => {
-        if (String(dir).includes("-Users-test-project-a")) return ["session1.jsonl"];
-        if (String(dir).includes("-Users-test-project-b")) return ["session1.jsonl"];
-        if (String(dir).includes("-Users-test-project-c")) return ["session1.jsonl"];
+        if (String(dir).includes("-Users-test-project-a"))
+          return ["session1.jsonl"];
+        if (String(dir).includes("-Users-test-project-b"))
+          return ["session1.jsonl"];
+        if (String(dir).includes("-Users-test-project-c"))
+          return ["session1.jsonl"];
         return [];
       });
 
       // Mock modification times: project-c is newest, project-a is oldest
       mockStatSync.mockImplementation((path) => {
         const pathStr = String(path);
-        if (pathStr.includes("-Users-test-project-a")) return { mtimeMs: 1000, isDirectory: () => true } as any;
-        if (pathStr.includes("-Users-test-project-b")) return { mtimeMs: 2000, isDirectory: () => true } as any;
-        if (pathStr.includes("-Users-test-project-c")) return { mtimeMs: 3000, isDirectory: () => true } as any;
+        if (pathStr.includes("-Users-test-project-a"))
+          return { mtimeMs: 1000, isDirectory: () => true } as any;
+        if (pathStr.includes("-Users-test-project-b"))
+          return { mtimeMs: 2000, isDirectory: () => true } as any;
+        if (pathStr.includes("-Users-test-project-c"))
+          return { mtimeMs: 3000, isDirectory: () => true } as any;
         return { mtimeMs: 0, isDirectory: () => true } as any;
       });
 
@@ -108,14 +123,26 @@ describe("sessionAvailability", () => {
 
     it("excludes current project from the list", () => {
       mockGetAllProjects.mockReturnValue([
-        { encodedPath: "-Users-test-project-a", decodedPath: "/Users/test/project-a" },
-        { encodedPath: "-Users-test-current", decodedPath: "/Users/test/current" },
-        { encodedPath: "-Users-test-project-b", decodedPath: "/Users/test/project-b" },
+        {
+          encodedPath: "-Users-test-project-a",
+          decodedPath: "/Users/test/project-a",
+        },
+        {
+          encodedPath: "-Users-test-current",
+          decodedPath: "/Users/test/current",
+        },
+        {
+          encodedPath: "-Users-test-project-b",
+          decodedPath: "/Users/test/project-b",
+        },
       ]);
 
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue(["session1.jsonl"] as any);
-      mockStatSync.mockReturnValue({ mtimeMs: 1000, isDirectory: () => true } as any);
+      mockStatSync.mockReturnValue({
+        mtimeMs: 1000,
+        isDirectory: () => true,
+      } as any);
 
       const result = getProjectsWithSessions("/Users/test/current");
 
@@ -133,8 +160,14 @@ describe("sessionAvailability", () => {
 
     it("puts projects without sessions at the end", () => {
       mockGetAllProjects.mockReturnValue([
-        { encodedPath: "-Users-test-project-a", decodedPath: "/Users/test/project-a" },
-        { encodedPath: "-Users-test-project-b", decodedPath: "/Users/test/project-b" },
+        {
+          encodedPath: "-Users-test-project-a",
+          decodedPath: "/Users/test/project-a",
+        },
+        {
+          encodedPath: "-Users-test-project-b",
+          decodedPath: "/Users/test/project-b",
+        },
       ]);
 
       mockExistsSync.mockImplementation((path) => {
@@ -144,7 +177,10 @@ describe("sessionAvailability", () => {
       });
 
       mockReaddirSync.mockReturnValue(["session1.jsonl"] as any);
-      mockStatSync.mockReturnValue({ mtimeMs: 1000, isDirectory: () => true } as any);
+      mockStatSync.mockReturnValue({
+        mtimeMs: 1000,
+        isDirectory: () => true,
+      } as any);
 
       const result = getProjectsWithSessions("/Users/test/current");
 
@@ -155,9 +191,18 @@ describe("sessionAvailability", () => {
 
     it("excludes projects whose decoded path does not exist", () => {
       mockGetAllProjects.mockReturnValue([
-        { encodedPath: "-Users-test-project-a", decodedPath: "/Users/test/project-a" },
-        { encodedPath: "-Users-test-nonexistent", decodedPath: "/Users/test/nonexistent" },
-        { encodedPath: "-Users-test-project-b", decodedPath: "/Users/test/project-b" },
+        {
+          encodedPath: "-Users-test-project-a",
+          decodedPath: "/Users/test/project-a",
+        },
+        {
+          encodedPath: "-Users-test-nonexistent",
+          decodedPath: "/Users/test/nonexistent",
+        },
+        {
+          encodedPath: "-Users-test-project-b",
+          decodedPath: "/Users/test/project-b",
+        },
       ]);
 
       // Mock: project-a and project-b exist with .git, nonexistent doesn't exist
@@ -169,7 +214,10 @@ describe("sessionAvailability", () => {
       });
 
       mockReaddirSync.mockReturnValue(["session1.jsonl"] as any);
-      mockStatSync.mockReturnValue({ mtimeMs: 1000, isDirectory: () => true } as any);
+      mockStatSync.mockReturnValue({
+        mtimeMs: 1000,
+        isDirectory: () => true,
+      } as any);
 
       const result = getProjectsWithSessions("/Users/test/current");
 
@@ -200,9 +248,14 @@ describe("sessionAvailability", () => {
       });
 
       mockReaddirSync.mockReturnValue(["session1.jsonl"] as any);
-      mockStatSync.mockReturnValue({ mtimeMs: 1000, isDirectory: () => true } as any);
+      mockStatSync.mockReturnValue({
+        mtimeMs: 1000,
+        isDirectory: () => true,
+      } as any);
 
-      const result = getProjectsWithSessions(join("/Users", "other", "current"));
+      const result = getProjectsWithSessions(
+        join("/Users", "other", "current"),
+      );
 
       // Should only include project, not home dir
       expect(result.length).toBe(1);
@@ -300,8 +353,14 @@ describe("sessionAvailability", () => {
       });
 
       mockGetAllProjects.mockReturnValue([
-        { encodedPath: "-Users-test-project-a", decodedPath: "/Users/test/project-a" },
-        { encodedPath: "-Users-test-project-b", decodedPath: "/Users/test/project-b" },
+        {
+          encodedPath: "-Users-test-project-a",
+          decodedPath: "/Users/test/project-a",
+        },
+        {
+          encodedPath: "-Users-test-project-b",
+          decodedPath: "/Users/test/project-b",
+        },
       ]);
 
       mockReaddirSync.mockReturnValue(["session1.jsonl"] as any);
@@ -309,8 +368,10 @@ describe("sessionAvailability", () => {
       // project-b is more recent than project-a
       mockStatSync.mockImplementation((path) => {
         const pathStr = String(path);
-        if (pathStr.includes("-Users-test-project-a")) return { mtimeMs: 1000, isDirectory: () => true } as any;
-        if (pathStr.includes("-Users-test-project-b")) return { mtimeMs: 2000, isDirectory: () => true } as any;
+        if (pathStr.includes("-Users-test-project-a"))
+          return { mtimeMs: 1000, isDirectory: () => true } as any;
+        if (pathStr.includes("-Users-test-project-b"))
+          return { mtimeMs: 2000, isDirectory: () => true } as any;
         return { mtimeMs: 0, isDirectory: () => true } as any;
       });
 


### PR DESCRIPTION
Closes #78

## Summary
- Display model name in Claude panel title (e.g., "Claude [opus-4.5]")
- Display last turn duration with label (e.g., "Last: 44s")

## Changes
- Extract `model` from `assistant.message.model` in JSONL
- Extract `durationMs` from `system.subtype="turn_duration"` entries
- Add `parseModelName()` function to convert model IDs to friendly names:
  - `claude-opus-4-5-20251101` → `opus-4.5`
  - `claude-sonnet-4-20250514` → `sonnet-4`
  - `claude-3-5-haiku-20241022` → `haiku-3.5`
- Add `modelName` and `lastTurnDuration` to `ClaudeSessionState` type

## UI Example
```
┌─ Claude [opus-4.5] 24.8M tokens · 13:23 (4h) · Last: 44s · ↻ 10s ─┐
│ [13:50:01] $ npm test                                              │
│ [13:50:45] < Done! All tests pass.                                 │
└────────────────────────────────────────────────────────────────────┘
```

Note: "Last: 44s" shows how long the last API response took, not a countdown.

## Test Plan
- [x] 8 new tests for model name and turn duration extraction
- [x] All 544 tests pass
- [x] Lint and build pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Panel title now displays the Claude model being used (e.g., Opus, Sonnet, Haiku).
  * Added turn duration display to show how long the last interaction took.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->