### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-25
+
+### New
+- **Session liveness badges (`[working]` / `[waiting]`).** Recently-active session rows now show what state the session is in, not just when it was last touched. `[working]` (green) means Claude is mid-turn (a tool is running or it's about to respond); `[waiting]` (magenta) means Claude yielded the turn and the ball is in your court — including an explicit `AskUserQuestion`. Derived from the structure of the JSONL tail, so a long-running tool still reads as `[working]` even while the file is momentarily quiet. Only replaces `[hot]` (within the 30-minute window); `warm/cool/cold` stay time-based, and non-interactive sessions are unaffected.
+- **Rich tool activity details.** Tool rows now summarize what actually happened instead of just the tool name or filename: `Edit App.tsx L45-52 +3 -1` (line range + added/removed counts), `Write package.json L1-65 +65`, `Read App.tsx L60-189` (range), `TaskUpdate #1 pending→in_progress`, and `TaskCreate` shows the task subject. Pressing `↵` on an Edit opens the real unified diff with the same green/red/cyan coloring as git commits; a Write shows the written file content. Built by correlating each tool call with its result later in the session JSONL. `agenthud report` inherits the richer one-line detail for free.
+
 ## [0.9.5] - 2026-05-21
 
 ### New
@@ -365,7 +371,8 @@
 - **Test Panel** - Test results at a glance
 - Watch mode for live updates
 
-[Unreleased]: https://github.com/neochoon/agenthud/compare/v0.9.5...HEAD
+[Unreleased]: https://github.com/neochoon/agenthud/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/neochoon/agenthud/compare/v0.9.4...v0.10.0
 [0.9.5]: https://github.com/neochoon/agenthud/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/neochoon/agenthud/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/neochoon/agenthud/compare/v0.9.2...v0.9.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenthud",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenthud",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "ink": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenthud",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "CLI tool to monitor agent status in real-time. Works with Claude Code, multi-agent workflows, and any AI agent system.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.10.0

First published release since v0.9.4 — bundles the unpublished v0.9.5 batch plus two new features.

### New
- **Session liveness badges (`[working]` / `[waiting]`)** (#82) — recently-active rows show whether Claude is mid-turn (`[working]`, green) or has yielded the turn to you (`[waiting]`, magenta, incl. `AskUserQuestion`), derived from the JSONL tail. Replaces `[hot]` within the 30-minute window; non-interactive sessions unaffected.
- **Rich tool activity details** (#84) — tool rows summarize what happened (`Edit App.tsx L45-52 +3 -1`, `Read … L60-189`, `TaskUpdate #1 pending→in_progress`, `TaskCreate` subject). `↵` on an Edit shows the colored unified diff; Write shows the written content. `agenthud report` gets the richer detail too.

Also includes everything from the v0.9.5 changelog entry (live-row treatment, tracking mode `t`, spinner/flashlight perf passes), which was bumped in package.json but never tagged/published.

## Checklist
- [x] CHANGELOG.md updated ([0.10.0] section + link refs)
- [x] Version bumped in package.json (0.9.5 → 0.10.0)
- [ ] CI passes

After merge, tag on main to trigger the npm publish workflow:
```bash
git checkout main && git pull
git tag v0.10.0
git push origin v0.10.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session liveness badges to indicate session status ([working]/[waiting])
  * Enhanced activity viewer with detailed tool activity information including edit, write, read, and task summaries
  * Improved activity details behavior with Enter key integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neochoon/agenthud/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->