### PR TITLE
feat: show read file content in the Read detail view

### DIFF
--- a/src/data/toolDetails.ts
+++ b/src/data/toolDetails.ts
@@ -25,7 +25,7 @@ interface PatchHunk {
 export interface ToolUseResult {
   structuredPatch?: PatchHunk[];
   content?: string;
-  file?: { startLine?: number; numLines?: number };
+  file?: { startLine?: number; numLines?: number; content?: string };
   statusChange?: { from?: string; to?: string };
   updatedFields?: string[];
   taskId?: string;
@@ -138,6 +138,10 @@ export function buildToolDetailBody(
   // than an all-additions diff); the row summary still uses patch stats.
   if (name === "Write") {
     const content = result?.content ?? input?.content;
+    if (content) return { text: content, kind: "code" };
+  }
+  if (name === "Read") {
+    const content = result?.file?.content;
     if (content) return { text: content, kind: "code" };
   }
   if (name === "Edit" || name === "Write") {

--- a/tests/data/toolDetails.test.ts
+++ b/tests/data/toolDetails.test.ts
@@ -225,7 +225,17 @@ describe("buildToolDetailBody", () => {
     expect(body).toEqual({ text: "@@ -0,0 +1,2 @@\n+a\n+b", kind: "diff" });
   });
 
-  it("Read and Task tools have no body", () => {
+  it("Read: shows the read content as code", () => {
+    expect(
+      buildToolDetailBody(
+        "Read",
+        { file_path: "/x/a.ts", offset: 1, limit: 2 },
+        { file: { content: "line1\nline2", startLine: 1, numLines: 2 } },
+      ),
+    ).toEqual({ text: "line1\nline2", kind: "code" });
+  });
+
+  it("Read without file content, and Task/Bash tools, have no body", () => {
     expect(
       buildToolDetailBody(
         "Read",


### PR DESCRIPTION
## Summary

Follow-up to #84. Read rows already summarize the range (`Read App.tsx L60-189`); this makes pressing `↵` on a Read open the **content Claude actually read** (the `offset`/`limit` slice), rendered as code — the same detail-view path Write uses.

- `buildToolDetailBody("Read", …)` now returns `{ text: result.file.content, kind: "code" }` when `toolUseResult.file.content` is present; `null` otherwise (graceful for image/empty reads).
- Row summary unchanged. `ToolUseResult.file` gained an optional `content` field.

## Test Plan
- [x] `toolDetails.test.ts` — Read with `file.content` → `{ content, code }`; Read without content / Task / Bash → `null`
- [x] Full suite green (376), `tsc --noEmit` clean, Biome clean
- [x] End-to-end: parsing real sessions now yields `detailBody` on Read activities (e.g. `README.md L1-270` → 12.8KB body)
- [ ] Manual: open a Read row in the TUI and confirm the read content shows (after `npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)