### PR TITLE
fix: preserve whitespace/indentation in code & diff detail views

### DIFF
--- a/src/ui/DetailViewPanel.tsx
+++ b/src/ui/DetailViewPanel.tsx
@@ -45,10 +45,34 @@ export function wrapText(text: string, maxWidth: number): string[] {
  * piece. Classification happens on raw source lines (before wrapping) so
  * fence/diff heuristics see the original prefixes intact.
  */
+// Hard-wrap a line into chunks no wider than maxWidth display columns,
+// preserving every character (including leading/internal whitespace). Used for
+// code and diff bodies where indentation is meaningful.
+function hardWrapByWidth(line: string, maxWidth: number): string[] {
+  if (maxWidth <= 0) return [line];
+  const out: string[] = [];
+  let cur = "";
+  let curW = 0;
+  for (const ch of line) {
+    const w = getDisplayWidth(ch);
+    if (curW + w > maxWidth && cur !== "") {
+      out.push(cur);
+      cur = ch;
+      curW = w;
+    } else {
+      cur += ch;
+      curW += w;
+    }
+  }
+  if (cur !== "") out.push(cur);
+  return out.length > 0 ? out : [line];
+}
+
 export function wrapClassified(
   text: string,
   maxWidth: number,
   classifier: (lines: string[]) => LineCategory[],
+  preserveWhitespace = false,
 ): Array<{ text: string; category: LineCategory }> {
   if (!text) return [{ text: "(empty)", category: "prose" }];
   const sourceLines = text.split("\n");
@@ -59,6 +83,12 @@ export function wrapClassified(
     const cat = categories[i] ?? "prose";
     if (!line) {
       out.push({ text: "", category: cat });
+      continue;
+    }
+    if (preserveWhitespace) {
+      for (const chunk of hardWrapByWidth(line, maxWidth)) {
+        out.push({ text: chunk, category: cat });
+      }
       continue;
     }
     const words = line.split(" ");
@@ -104,7 +134,16 @@ export function DetailViewPanel({
         : activity.type === "commit"
           ? classifyDiffLines
           : classifyCodeFences;
-  const allLines = wrapClassified(body, contentWidth, classifier);
+  const preserveWhitespace =
+    activity.detailKind === "diff" ||
+    activity.detailKind === "code" ||
+    activity.type === "commit";
+  const allLines = wrapClassified(
+    body,
+    contentWidth,
+    classifier,
+    preserveWhitespace,
+  );
   const totalLines = allLines.length;
   const clampedOffset = Math.min(
     scrollOffset,

--- a/tests/ui/DetailViewPanel.test.tsx
+++ b/tests/ui/DetailViewPanel.test.tsx
@@ -1,7 +1,12 @@
 import { render } from "ink-testing-library";
 import { describe, expect, it } from "vitest";
 import type { ActivityEntry } from "../../src/types/index.js";
-import { DetailViewPanel, wrapText } from "../../src/ui/DetailViewPanel.js";
+import {
+  DetailViewPanel,
+  wrapClassified,
+  wrapText,
+} from "../../src/ui/DetailViewPanel.js";
+import { classifyCodeFences } from "../../src/ui/lineColoring.js";
 
 const makeActivity = (
   overrides: Partial<ActivityEntry> = {},
@@ -211,5 +216,53 @@ describe("wrapText", () => {
     const result = wrapText(text, 30);
     expect(result[0]).toBe("short");
     expect(result.length).toBeGreaterThan(2);
+  });
+});
+
+describe("wrapClassified whitespace", () => {
+  it("preserves leading indentation when preserveWhitespace is true", () => {
+    const code = "function f() {\n    const x = 1;\n        return x;";
+    const out = wrapClassified(code, 80, classifyCodeFences, true);
+    expect(out.map((l) => l.text)).toEqual([
+      "function f() {",
+      "    const x = 1;",
+      "        return x;",
+    ]);
+  });
+
+  it("hard-wraps a long line by width while keeping leading spaces", () => {
+    const line = `${"  "}${"a".repeat(10)}`; // 2 spaces + 10 a's = width 12
+    const out = wrapClassified(line, 6, classifyCodeFences, true);
+    // every original character is preserved across the wrapped chunks
+    expect(out.map((l) => l.text).join("")).toBe(line);
+    expect(out.length).toBeGreaterThan(1);
+    expect(out[0].text.startsWith("  ")).toBe(true);
+  });
+
+  it("still word-wraps (collapsing runs) for prose by default", () => {
+    const out = wrapClassified("    indented prose", 80, classifyCodeFences);
+    expect(out[0].text).toBe("indented prose");
+  });
+});
+
+describe("DetailViewPanel code body indentation", () => {
+  it("preserves indentation when rendering a code detailBody", () => {
+    const { lastFrame } = render(
+      <DetailViewPanel
+        activity={makeActivity({
+          type: "tool",
+          icon: "○",
+          label: "Read",
+          detail: "a.ts L1-3",
+          detailBody: "function f() {\n    const x = 1;\n}",
+          detailKind: "code",
+        })}
+        sessionName="myproject"
+        width={80}
+        visibleRows={10}
+        scrollOffset={0}
+      />,
+    );
+    expect(lastFrame()).toContain("    const x = 1;");
   });
 });


### PR DESCRIPTION
## Summary

The Read/Write content and Edit/commit diffs lost their indentation in the detail view — `wrapClassified` split every line on spaces and rejoined with single spaces, collapsing leading indentation and internal runs (a read source file rendered fully left-aligned).

- `wrapClassified` gains a `preserveWhitespace` mode: a width-based hard wrap (`hardWrapByWidth`) that keeps every character, including leading/internal whitespace.
- `DetailViewPanel` enables it for code/diff/commit bodies (`detailKind === "code" | "diff"`, or `type === "commit"`); prose (responses/thinking) keeps the existing word-wrap.

Found while testing the Read detail-view content from #87.

## Test Plan
- [x] `wrapClassified` preserves leading indentation and hard-wraps long lines without dropping characters (unit)
- [x] prose still word-wraps by default (no regression)
- [x] `DetailViewPanel` renders a code body with `    const x = 1;` indentation intact
- [x] Full suite green (380), `tsc --noEmit` clean
- [ ] Manual: open a Read/Edit in the TUI and confirm indentation (after `npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)