### PR TITLE
feat: line numbers in the Read detail view

### DIFF
--- a/src/data/toolDetails.ts
+++ b/src/data/toolDetails.ts
@@ -129,6 +129,18 @@ export function summarizeToolDetail(
   return getToolDetail(name, input);
 }
 
+// Prefix each line with its real file line number, right-aligned so the
+// colons line up (cat -n style). A single trailing-newline phantom line is
+// dropped so the count matches the lines actually read.
+function numberLines(content: string, start: number): string {
+  const lines = content.split("\n");
+  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();
+  const width = String(start + lines.length - 1).length;
+  return lines
+    .map((line, i) => `${String(start + i).padStart(width)}: ${line}`)
+    .join("\n");
+}
+
 export function buildToolDetailBody(
   name: string,
   input: ToolInput | undefined,
@@ -142,7 +154,10 @@ export function buildToolDetailBody(
   }
   if (name === "Read") {
     const content = result?.file?.content;
-    if (content) return { text: content, kind: "code" };
+    if (content) {
+      const start = result?.file?.startLine ?? input?.offset ?? 1;
+      return { text: numberLines(content, start), kind: "code" };
+    }
   }
   if (name === "Edit" || name === "Write") {
     const hunks = result?.structuredPatch;

--- a/tests/data/toolDetails.test.ts
+++ b/tests/data/toolDetails.test.ts
@@ -225,14 +225,54 @@ describe("buildToolDetailBody", () => {
     expect(body).toEqual({ text: "@@ -0,0 +1,2 @@\n+a\n+b", kind: "diff" });
   });
 
-  it("Read: shows the read content as code", () => {
+  it("Read: shows the read content as code with line numbers from startLine", () => {
     expect(
       buildToolDetailBody(
         "Read",
-        { file_path: "/x/a.ts", offset: 1, limit: 2 },
-        { file: { content: "line1\nline2", startLine: 1, numLines: 2 } },
+        { file_path: "/x/a.ts", offset: 38, limit: 2 },
+        { file: { content: "first\nsecond", startLine: 38, numLines: 2 } },
       ),
-    ).toEqual({ text: "line1\nline2", kind: "code" });
+    ).toEqual({ text: "38: first\n39: second", kind: "code" });
+  });
+
+  it("Read: right-aligns line numbers when the range crosses digit widths", () => {
+    expect(
+      buildToolDetailBody(
+        "Read",
+        { file_path: "/x/a.ts" },
+        { file: { content: "a\nb\nc", startLine: 99, numLines: 3 } },
+      ),
+    ).toEqual({ text: " 99: a\n100: b\n101: c", kind: "code" });
+  });
+
+  it("Read: preserves indentation after the line-number prefix", () => {
+    expect(
+      buildToolDetailBody(
+        "Read",
+        { file_path: "/x/a.ts" },
+        { file: { content: "fn() {\n    x = 1;", startLine: 1, numLines: 2 } },
+      ),
+    ).toEqual({ text: "1: fn() {\n2:     x = 1;", kind: "code" });
+  });
+
+  it("Read: drops the phantom trailing line from a final newline", () => {
+    expect(
+      buildToolDetailBody(
+        "Read",
+        { file_path: "/x/a.ts" },
+        { file: { content: "x\ny\n", startLine: 5, numLines: 2 } },
+      ),
+    ).toEqual({ text: "5: x\n6: y", kind: "code" });
+  });
+
+  it("Read: falls back to input offset for the start line when startLine is absent", () => {
+    expect(
+      buildToolDetailBody(
+        "Read",
+        { file_path: "/x/a.ts", offset: 10, limit: 1 },
+        { file: { content: "only" } },
+      ),
+    ).toEqual({ text: "10: only", kind: "code" });
   });
 
   it("Read without file content, and Task/Bash tools, have no body", () => {


### PR DESCRIPTION
## Summary

Follow-up to #87. The Read detail body (`↵` on a Read row) now prefixes each line with its real file line number, starting from the read's `startLine` — so a `Read foo.ts L60-189` shows:

```
 60: }
 61:
 62: function getStatusColor(status: SessionStatus): string {
 63:   switch (status) {
```

- Numbers are right-aligned (cat -n style) so the colons line up even when the range crosses digit widths (e.g. 99 → 100).
- Start line comes from `toolUseResult.file.startLine`, falling back to the input `offset`, then 1.
- A phantom trailing line from a final newline is dropped so the numbering matches the lines actually read.
- Indentation after the prefix is preserved (works with the #88 whitespace fix). Row summary unchanged.

## Test Plan
- [x] `toolDetails.test.ts` — numbering from startLine, right-align across digit widths, indentation preserved after prefix, trailing-newline drop, offset fallback
- [x] Full suite green (384), `tsc --noEmit` clean, Biome clean
- [x] End-to-end: real session Read body renders `60: …` for an L60-189 read with indentation intact
- [ ] Manual: open a Read in the TUI and confirm numbered lines (after `npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)