### PR TITLE
feat: dim the line-number gutter in the Read detail view

### DIFF
--- a/src/data/activityParser.ts
+++ b/src/data/activityParser.ts
@@ -181,6 +181,7 @@ export function parseActivitiesFromLines(lines: string[]): ParseResult {
               if (body) {
                 entry.detailBody = body.text;
                 entry.detailKind = body.kind;
+                if (body.numbered) entry.detailNumbered = true;
               }
               activities.push(entry);
             }

--- a/src/data/toolDetails.ts
+++ b/src/data/toolDetails.ts
@@ -145,7 +145,7 @@ export function buildToolDetailBody(
   name: string,
   input: ToolInput | undefined,
   result: ToolUseResult | undefined,
-): { text: string; kind: "diff" | "code" } | null {
+): { text: string; kind: "diff" | "code"; numbered?: boolean } | null {
   // Write intentionally shows the written file content (more useful to read
   // than an all-additions diff); the row summary still uses patch stats.
   if (name === "Write") {
@@ -156,7 +156,7 @@ export function buildToolDetailBody(
     const content = result?.file?.content;
     if (content) {
       const start = result?.file?.startLine ?? input?.offset ?? 1;
-      return { text: numberLines(content, start), kind: "code" };
+      return { text: numberLines(content, start), kind: "code", numbered: true };
     }
   }
   if (name === "Edit" || name === "Write") {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,4 +77,5 @@ export interface ActivityEntry {
   count?: number;
   detailBody?: string; // full multi-line body for the detail view (diff or file content)
   detailKind?: "diff" | "code"; // how the detail view should color detailBody
+  detailNumbered?: boolean; // detailBody lines carry a "NN: " line-number gutter (dim in the view)
 }

--- a/src/ui/DetailViewPanel.tsx
+++ b/src/ui/DetailViewPanel.tsx
@@ -45,6 +45,15 @@ export function wrapText(text: string, maxWidth: number): string[] {
  * piece. Classification happens on raw source lines (before wrapping) so
  * fence/diff heuristics see the original prefixes intact.
  */
+// Split a leading "NN: " line-number gutter from the rest of a row so the
+// gutter can be rendered dim. Returns null when there is no leading gutter
+// (e.g. a hard-wrapped continuation chunk). Only the leading number matches,
+// so number-like content after the gutter is left untouched.
+export function splitLineNumberGutter(text: string): [string, string] | null {
+  const m = text.match(/^(\s*\d+: )(.*)$/);
+  return m ? [m[1], m[2]] : null;
+}
+
 // Hard-wrap a line into chunks no wider than maxWidth display columns,
 // preserving every character (including leading/internal whitespace). Used for
 // code and diff bodies where indentation is meaningful.
@@ -176,12 +185,24 @@ export function DetailViewPanel({
     const entry = visibleSlice[i] ?? { text: "", category: "prose" as const };
     const padding = Math.max(0, contentWidth - getDisplayWidth(entry.text));
     const lineStyle = getLineStyle(entry.category);
+    const gutterSplit = activity.detailNumbered
+      ? splitLineNumberGutter(entry.text)
+      : null;
     contentRows.push(
       <Text key={i}>
         {BOX.v}{" "}
-        <Text color={lineStyle.color} dimColor={lineStyle.dimColor}>
-          {entry.text}
-        </Text>
+        {gutterSplit ? (
+          <>
+            <Text dimColor>{gutterSplit[0]}</Text>
+            <Text color={lineStyle.color} dimColor={lineStyle.dimColor}>
+              {gutterSplit[1]}
+            </Text>
+          </>
+        ) : (
+          <Text color={lineStyle.color} dimColor={lineStyle.dimColor}>
+            {entry.text}
+          </Text>
+        )}
         {" ".repeat(padding)}
         {BOX.v}
       </Text>,

--- a/tests/data/toolDetails.test.ts
+++ b/tests/data/toolDetails.test.ts
@@ -232,7 +232,7 @@ describe("buildToolDetailBody", () => {
         { file_path: "/x/a.ts", offset: 38, limit: 2 },
         { file: { content: "first\nsecond", startLine: 38, numLines: 2 } },
       ),
-    ).toEqual({ text: "38: first\n39: second", kind: "code" });
+    ).toEqual({ text: "38: first\n39: second", kind: "code", numbered: true });
   });
 
   it("Read: right-aligns line numbers when the range crosses digit widths", () => {
@@ -242,7 +242,7 @@ describe("buildToolDetailBody", () => {
         { file_path: "/x/a.ts" },
         { file: { content: "a\nb\nc", startLine: 99, numLines: 3 } },
       ),
-    ).toEqual({ text: " 99: a\n100: b\n101: c", kind: "code" });
+    ).toEqual({ text: " 99: a\n100: b\n101: c", kind: "code", numbered: true });
   });
 
   it("Read: preserves indentation after the line-number prefix", () => {
@@ -252,7 +252,7 @@ describe("buildToolDetailBody", () => {
         { file_path: "/x/a.ts" },
         { file: { content: "fn() {\n    x = 1;", startLine: 1, numLines: 2 } },
       ),
-    ).toEqual({ text: "1: fn() {\n2:     x = 1;", kind: "code" });
+    ).toEqual({ text: "1: fn() {\n2:     x = 1;", kind: "code", numbered: true });
   });
 
   it("Read: drops the phantom trailing line from a final newline", () => {
@@ -262,7 +262,7 @@ describe("buildToolDetailBody", () => {
         { file_path: "/x/a.ts" },
         { file: { content: "x\ny\n", startLine: 5, numLines: 2 } },
       ),
-    ).toEqual({ text: "5: x\n6: y", kind: "code" });
+    ).toEqual({ text: "5: x\n6: y", kind: "code", numbered: true });
   });
 
   it("Read: falls back to input offset for the start line when startLine is absent", () => {
@@ -272,7 +272,7 @@ describe("buildToolDetailBody", () => {
         { file_path: "/x/a.ts", offset: 10, limit: 1 },
         { file: { content: "only" } },
       ),
-    ).toEqual({ text: "10: only", kind: "code" });
+    ).toEqual({ text: "10: only", kind: "code", numbered: true });
   });
 
   it("Read without file content, and Task/Bash tools, have no body", () => {

--- a/tests/ui/DetailViewPanel.test.tsx
+++ b/tests/ui/DetailViewPanel.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { ActivityEntry } from "../../src/types/index.js";
 import {
   DetailViewPanel,
+  splitLineNumberGutter,
   wrapClassified,
   wrapText,
 } from "../../src/ui/DetailViewPanel.js";
@@ -264,5 +265,58 @@ describe("DetailViewPanel code body indentation", () => {
       />,
     );
     expect(lastFrame()).toContain("    const x = 1;");
+  });
+
+  it("renders a numbered Read body with the line numbers visible", () => {
+    const { lastFrame } = render(
+      <DetailViewPanel
+        activity={makeActivity({
+          type: "tool",
+          icon: "○",
+          label: "Read",
+          detail: "a.ts L38-39",
+          detailBody: "38: first line\n39:     indented",
+          detailKind: "code",
+          detailNumbered: true,
+        })}
+        sessionName="myproject"
+        width={80}
+        visibleRows={10}
+        scrollOffset={0}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    // Assert pieces separately: the dim gutter is a distinct text segment, so
+    // gutter and content are not contiguous when colors are emitted (and CI
+    // strips colors entirely). Avoids the ANSI-interleaving brittleness.
+    expect(frame).toContain("38: ");
+    expect(frame).toContain("first line");
+    expect(frame).toContain("    indented");
+  });
+});
+
+describe("splitLineNumberGutter", () => {
+  it("splits a 'NN: ' gutter from the rest of the line", () => {
+    expect(splitLineNumberGutter("38: first line")).toEqual([
+      "38: ",
+      "first line",
+    ]);
+  });
+
+  it("keeps right-aligned padding in the gutter", () => {
+    expect(splitLineNumberGutter(" 99: x")).toEqual([" 99: ", "x"]);
+  });
+
+  it("only matches the leading gutter, not number-like content after it", () => {
+    expect(splitLineNumberGutter("62: 42: foo")).toEqual(["62: ", "42: foo"]);
+  });
+
+  it("handles an empty line body after the gutter", () => {
+    expect(splitLineNumberGutter("61: ")).toEqual(["61: ", ""]);
+  });
+
+  it("returns null for lines without a leading gutter (continuations)", () => {
+    expect(splitLineNumberGutter("    const x = 1;")).toBeNull();
+    expect(splitLineNumberGutter("no number here")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #89. The `NN: ` line-number gutter in the Read detail view now renders **dim**, so the numbers recede behind the actual code (only the gutter is dimmed; the content stays at normal intensity).

- `ActivityEntry` gains `detailNumbered?: boolean`; set for Read bodies (the only ones with a gutter), so the renderer stays tool-agnostic.
- `DetailViewPanel` splits the leading gutter via a pure `splitLineNumberGutter` helper and renders it as a separate `<Text dimColor>` segment. The regex only matches the leading `\s*\d+: `, so number-like content after the gutter is untouched.

## Test Plan
- [x] `splitLineNumberGutter` unit tests — splits `NN: `, keeps right-align padding, matches only the leading gutter (`"62: 42: foo"` → `["62: ", "42: foo"]`), empty body, returns null for continuations/non-gutter lines
- [x] `toolDetails` Read bodies now carry `numbered: true`
- [x] Render test: a numbered Read body shows the numbers + content (asserted piece-wise to stay robust to ANSI/CI color stripping)
- [x] Full suite green (390), `tsc --noEmit` clean, Biome clean
- [ ] Manual: open a Read in the TUI and confirm the numbers are faint (after `npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)