### PR TITLE
fix: Ctrl+U/Ctrl+D half-page scroll in the detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ When tracking is on, the tree panel's title shows `[LIVE ⠧]` and the status ba
 
 | Key | Action |
 |-----|--------|
-| `↑` / `k` / `↓` / `j` | Scroll |
+| `↑` / `k` / `↓` / `j` | Scroll one line |
+| `Ctrl+U` / `Ctrl+D` | Half page up / down |
 | `↵` / `Esc` / `q` | Close |
 
 Detail view colors the content based on activity type:

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -736,6 +736,15 @@ export function App({ mode }: { mode: "watch" | "once" }): React.ReactElement {
     onDetailScrollDown: () => {
       setDetailScrollOffset((o) => o + 1);
     },
+    onDetailScrollHalfPageUp: () => {
+      const step = Math.max(1, Math.floor(viewerRows / 2));
+      setDetailScrollOffset((o) => Math.max(0, o - step));
+    },
+    onDetailScrollHalfPageDown: () => {
+      // DetailViewPanel clamps the upper bound, so overshooting is safe.
+      const step = Math.max(1, Math.floor(viewerRows / 2));
+      setDetailScrollOffset((o) => o + step);
+    },
     onEnter: () => {
       if (focus === "viewer") {
         const act = getSelectedActivity(

--- a/src/ui/hooks/useHotkeys.ts
+++ b/src/ui/hooks/useHotkeys.ts
@@ -18,6 +18,8 @@ interface UseHotkeysOptions {
   onDetailClose: () => void;
   onDetailScrollUp: () => void;
   onDetailScrollDown: () => void;
+  onDetailScrollHalfPageUp: () => void;
+  onDetailScrollHalfPageDown: () => void;
   onFilter: () => void;
   onHelp: () => void;
   onHelpScroll?: (delta: number) => void;
@@ -64,6 +66,8 @@ export function useHotkeys({
   onDetailClose,
   onDetailScrollUp,
   onDetailScrollDown,
+  onDetailScrollHalfPageUp,
+  onDetailScrollHalfPageDown,
   onFilter,
   onHelp,
   onHelpScroll,
@@ -125,6 +129,14 @@ export function useHotkeys({
     }
 
     if (detailMode) {
+      if (key.ctrl && input === "u") {
+        onDetailScrollHalfPageUp();
+        return;
+      }
+      if (key.ctrl && input === "d") {
+        onDetailScrollHalfPageDown();
+        return;
+      }
       if (key.upArrow || input === "k") {
         onDetailScrollUp();
         return;
@@ -235,7 +247,7 @@ export function useHotkeys({
   const statusBarItems = helpMode
     ? ["↑↓/jk: scroll", "PgDn/Space: page", "↵/Esc/q/?: close"]
     : detailMode
-      ? ["↑↓/jk: scroll", "↵/Esc: close", "?: help"]
+      ? ["↑↓/jk: scroll", "C-u/d: ½page", "↵/Esc: close", "?: help"]
       : focus === "tree"
         ? [
             ...trackingItems,

--- a/tests/ui/hooks/useHotkeys.test.ts
+++ b/tests/ui/hooks/useHotkeys.test.ts
@@ -84,6 +84,8 @@ function makeOptions(overrides = {}) {
     onDetailClose: vi.fn(),
     onDetailScrollUp: vi.fn(),
     onDetailScrollDown: vi.fn(),
+    onDetailScrollHalfPageUp: vi.fn(),
+    onDetailScrollHalfPageDown: vi.fn(),
     onFilter: vi.fn(),
     onHelp: vi.fn(),
     filterLabel: "all",
@@ -357,6 +359,7 @@ describe("useHotkeys", () => {
       );
       expect(result.current.statusBarItems).toEqual([
         "↑↓/jk: scroll",
+        "C-u/d: ½page",
         "↵/Esc: close",
         "?: help",
       ]);
@@ -555,6 +558,26 @@ describe("useHotkeys", () => {
       );
       act(() => result.current.handleInput("q", noopKey));
       expect(onQuit).not.toHaveBeenCalled();
+    });
+
+    it("calls onDetailScrollHalfPageUp on Ctrl+U in detail mode", () => {
+      const onDetailScrollHalfPageUp = vi.fn();
+      const { result } = renderHook(() =>
+        useHotkeys(makeOptions({ detailMode: true, onDetailScrollHalfPageUp })),
+      );
+      act(() => result.current.handleInput("u", { ...noopKey, ctrl: true }));
+      expect(onDetailScrollHalfPageUp).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onDetailScrollHalfPageDown on Ctrl+D in detail mode", () => {
+      const onDetailScrollHalfPageDown = vi.fn();
+      const { result } = renderHook(() =>
+        useHotkeys(
+          makeOptions({ detailMode: true, onDetailScrollHalfPageDown }),
+        ),
+      );
+      act(() => result.current.handleInput("d", { ...noopKey, ctrl: true }));
+      expect(onDetailScrollHalfPageDown).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

In the detail view (`↵` on an activity), line scroll (`↑/↓/j/k`) worked but **`Ctrl+U`/`Ctrl+D` (half-page) did nothing** — the detail-mode key handler returned early after handling line scroll/close, so it never reached the Ctrl+U/D branch.

- Added `onDetailScrollHalfPageUp`/`onDetailScrollHalfPageDown` (move the detail scroll offset by ±`viewerRows/2`; `DetailViewPanel` already clamps the bound, so overshoot is safe).
- Handle `Ctrl+U`/`Ctrl+D` in the detail-mode branch of `useHotkeys`.
- Detail status bar gains `C-u/d: ½page`; README detail-view table updated.

## Test Plan
- [x] `useHotkeys` — Ctrl+U → `onDetailScrollHalfPageUp`, Ctrl+D → `onDetailScrollHalfPageDown` in detail mode; detail status bar items updated
- [x] Full suite green (392), `tsc --noEmit` clean, Biome clean
- [ ] Manual: open a long Read in the TUI and confirm Ctrl+U/Ctrl+D jump half a page (after `npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+U and Ctrl+D keyboard shortcuts for half-page up/down scrolling in detail view
  * Clarified arrow keys scroll one line at a time

* **Documentation**
  * Updated keyboard shortcut reference table for detail view

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neochoon/agenthud/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->