### PR TITLE
fix: find git commits when the project is nested in a repo

### DIFF
--- a/src/data/gitCommits.ts
+++ b/src/data/gitCommits.ts
@@ -13,7 +13,7 @@ export function getCommitDetail(
   if (!projectPath) return null;
   try {
     return execSync(
-      `git --git-dir="${projectPath}/.git" show --stat --patch --no-color ${hash}`,
+      `git -C "${projectPath}" show --stat --patch --no-color ${hash}`,
       { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
     ).trim();
   } catch {
@@ -33,7 +33,7 @@ export function parseGitCommits(
   let raw: string;
   try {
     raw = execSync(
-      `git --git-dir="${projectPath}/.git" log --format="%ct|%h|%s" --after="${start} 00:00:00" --before="${end} 23:59:59"`,
+      `git -C "${projectPath}" log --format="%ct|%h|%s" --after="${start} 00:00:00" --before="${end} 23:59:59"`,
       { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
     ).trim();
   } catch {

--- a/tests/data/gitCommits.test.ts
+++ b/tests/data/gitCommits.test.ts
@@ -63,6 +63,17 @@ describe("parseGitCommits", () => {
     expect(cmd).toContain("2026-05-14 23:59:59");
   });
 
+  it("runs git from the project dir so subdirectory projects find the ancestor repo", () => {
+    vi.mocked(execSync).mockReturnValue("");
+    parseGitCommits("/some/project", DAY);
+    const cmd = vi.mocked(execSync).mock.calls[0][0] as string;
+    // -C lets git discover the repo from the dir upward (handles a project
+    // that is a subdirectory of a repo, or a worktree). --git-dir=<path>/.git
+    // wrongly assumed the project path was always the repo root.
+    expect(cmd).toContain('-C "/some/project"');
+    expect(cmd).not.toContain("--git-dir");
+  });
+
   it("uses endDate for --before when provided", () => {
     vi.mocked(execSync).mockReturnValue("");
     const endDay = new Date(2026, 4, 16); // May 16
@@ -118,5 +129,13 @@ describe("getCommitDetail", () => {
     });
     const result = getCommitDetail("/not/a/repo", "abc1234");
     expect(result).toBeNull();
+  });
+
+  it("runs git from the project dir so subdirectory/worktree projects resolve", () => {
+    vi.mocked(execSync).mockReturnValue("out");
+    getCommitDetail("/some/project", "abc1234");
+    const cmd = vi.mocked(execSync).mock.calls[0][0] as string;
+    expect(cmd).toContain('-C "/some/project"');
+    expect(cmd).not.toContain("--git-dir");
   });
 });


### PR DESCRIPTION
## Summary

A live session whose project is a **subdirectory of a git repo** (e.g. `…/zipsa/launcher`, where `.git` lives at `…/zipsa`) showed an **empty commit feed/filter** even while actively committing.

Root cause: `parseGitCommits`/`getCommitDetail` ran git with `--git-dir="<projectPath>/.git"`, assuming the session's project path is always the repo root. For a nested project that path has no `.git`, so git errored (`fatal: not a git repository`) and the result was silently empty.

Fix: run git with `-C "<projectPath>"` so git discovers the repo from that directory upward. This fixes nested-subdirectory projects and worktrees, and is unchanged for top-level repos.

## Test Plan
- [x] `gitCommits.test.ts` — asserts the command uses `-C "<path>"` (not `--git-dir`); existing parse/sort/date-range tests still pass
- [x] Full suite green (394), `tsc --noEmit` clean, Biome clean
- [x] Repro: `parseGitCommits("…/zipsa/launcher", …)` returned 0 before, **15 commits** after (the real active commits)
- [ ] Manual: select the nested-project session in the TUI, cycle to the `commit` filter, confirm commits appear (after `npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal Git command execution method for improved repository access.

* **Tests**
  * Added test coverage verifying the updated Git command invocation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neochoon/agenthud/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->