### PR TITLE
feat: --cwd flag to scope view to the containing Claude project

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ export interface CliOptions {
   summaryForce?: boolean;
   summaryModel?: string;
   summaryError?: string;
+  scopeToCwd?: boolean;
 }
 
 const KNOWN_WATCH_FLAGS = new Set([
@@ -41,6 +42,7 @@ const KNOWN_WATCH_FLAGS = new Set([
   "--version",
   "-h",
   "--help",
+  "--cwd",
 ]);
 const KNOWN_REPORT_FLAGS = new Set([
   "--date",
@@ -70,6 +72,9 @@ Monitors all running Claude Code sessions in real-time.
 Options:
   -w, --watch                   Watch mode (default) — live updates
   --once                        Print once and exit
+  --cwd                         Scope the view to the Claude project
+                                containing the current directory.
+                                Exits 1 if no such project is found.
   -V, --version                 Show version number
   -h, --help                    Show this help message
 
@@ -154,7 +159,9 @@ export function parseArgs(args: string[]): CliOptions {
     return { mode: "watch", command: "version" };
   }
   if (args.includes("--once")) {
-    return { mode: "once" };
+    return args.includes("--cwd")
+      ? { mode: "once", scopeToCwd: true }
+      : { mode: "once" };
   }
 
   if (args[0] === "report") {
@@ -411,5 +418,7 @@ export function parseArgs(args: string[]): CliOptions {
     }
   }
 
-  return { mode: "watch" };
+  return args.includes("--cwd")
+    ? { mode: "watch", scopeToCwd: true }
+    : { mode: "watch" };
 }

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join, sep } from "node:path";
+import { basename, join } from "node:path";
 import type {
   GlobalConfig,
   LiveState,
@@ -278,7 +278,18 @@ export function findContainingProject(
     } catch {
       continue;
     }
-    if (cwdR === pR || cwdR.startsWith(pR + sep)) {
+    if (cwdR === pR) {
+      if (pR.length > bestLen) {
+        best = raw;
+        bestLen = pR.length;
+      }
+      continue;
+    }
+    // Accept either separator as the boundary so the helper works on both
+    // POSIX (/) and Windows (\), regardless of which form a particular
+    // caller's paths happen to use.
+    const boundary = cwdR[pR.length];
+    if ((boundary === "/" || boundary === "\\") && cwdR.startsWith(pR)) {
       if (pR.length > bestLen) {
         best = raw;
         bestLen = pR.length;

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, join, sep } from "node:path";
 import type {
   GlobalConfig,
   LiveState,
@@ -19,7 +19,7 @@ export function getProjectsDir(): string {
   );
 }
 
-function decodeProjectPath(encoded: string): string {
+export function decodeProjectPath(encoded: string): string {
   const windowsDriveMatch = encoded.match(/^([A-Za-z])--(.*)$/);
   if (windowsDriveMatch) {
     const drive = windowsDriveMatch[1];
@@ -257,7 +257,48 @@ function buildSubAgents(
     .sort((a, b) => b.lastModifiedMs - a.lastModifiedMs);
 }
 
-export function discoverSessions(config: GlobalConfig): SessionTree {
+// Returns the registered project whose path is the nearest ancestor of cwd
+// (or equals cwd). Both inputs and the returned value are matched as strings,
+// so callers that care about symlinks should pre-resolve their paths or
+// inject a `realpath` via options.
+export function findContainingProject(
+  cwd: string,
+  projectPaths: string[],
+  options?: { realpath?: (p: string) => string },
+): string | null {
+  const resolve = options?.realpath ?? ((p: string) => p);
+  const cwdR = resolve(cwd);
+
+  let best: string | null = null;
+  let bestLen = -1;
+  for (const raw of projectPaths) {
+    let pR: string;
+    try {
+      pR = resolve(raw);
+    } catch {
+      continue;
+    }
+    if (cwdR === pR || cwdR.startsWith(pR + sep)) {
+      if (pR.length > bestLen) {
+        best = raw;
+        bestLen = pR.length;
+      }
+    }
+  }
+  return best;
+}
+
+export interface DiscoverOptions {
+  // When set, drop every project whose decoded path is not exactly this
+  // string. Caller is responsible for resolving symlinks and choosing
+  // the matching project (see findContainingProject).
+  scopeToProject?: string;
+}
+
+export function discoverSessions(
+  config: GlobalConfig,
+  options?: DiscoverOptions,
+): SessionTree {
   const projectsDir = getProjectsDir();
 
   if (!existsSync(projectsDir)) {
@@ -289,9 +330,12 @@ export function discoverSessions(config: GlobalConfig): SessionTree {
 
   const allSessions: SessionNode[] = [];
 
+  const scope = options?.scopeToProject ?? null;
+
   for (const encodedDir of projectDirs) {
     const projectDir = join(projectsDir, encodedDir);
     const decodedPath = decodeProjectPath(encodedDir);
+    if (scope !== null && decodedPath !== scope) continue;
     const projectName = basename(decodedPath);
 
     let files: string[];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,22 +1,22 @@
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
-import { isLegacyProjectConfig } from "./utils/legacyConfig.js";
-
 import { render } from "ink";
 import React from "react";
-
 import { clearScreen, getHelp, getVersion, parseArgs } from "./cli.js";
-import {
-  enterAltScreen,
-  installAltScreenCleanup,
-} from "./utils/altScreen.js";
 import { loadGlobalConfig } from "./config/globalConfig.js";
 import { generateReport } from "./data/reportGenerator.js";
+import {
+  decodeProjectPath,
+  discoverSessions,
+  findContainingProject,
+  getProjectsDir,
+} from "./data/sessions.js";
 import { runRangeSummary, runSummary } from "./data/summaryRunner.js";
-import { discoverSessions } from "./data/sessions.js";
 import { App } from "./ui/App.js";
+import { enterAltScreen, installAltScreenCleanup } from "./utils/altScreen.js";
+import { isLegacyProjectConfig } from "./utils/legacyConfig.js";
 
 const options = parseArgs(process.argv.slice(2));
 
@@ -36,7 +36,10 @@ if (options.command === "version") {
 }
 
 const legacyConfig = join(process.cwd(), ".agenthud", "config.yaml");
-if (isLegacyProjectConfig(process.cwd(), homedir()) && existsSync(legacyConfig)) {
+if (
+  isLegacyProjectConfig(process.cwd(), homedir()) &&
+  existsSync(legacyConfig)
+) {
   console.log(
     "The project-level config file (.agenthud/config.yaml) is no longer supported.",
   );
@@ -107,6 +110,35 @@ if (options.mode === "summary") {
   process.exit(exitCode);
 }
 
+let scopeToProject: string | undefined;
+if (options.scopeToCwd) {
+  const projectsDir = getProjectsDir();
+  let registered: string[] = [];
+  try {
+    registered = (readdirSync(projectsDir) as string[]).map(decodeProjectPath);
+  } catch {
+    // projects dir missing or unreadable — treated as "no match"
+  }
+  const safeReal = (p: string): string => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return p;
+    }
+  };
+  const match = findContainingProject(process.cwd(), registered, {
+    realpath: safeReal,
+  });
+  if (!match) {
+    process.stderr.write(
+      `agenthud: --cwd: no Claude project found at or above ${process.cwd()}\n`,
+    );
+    process.exit(1);
+  }
+  scopeToProject = match;
+  process.stderr.write(`agenthud: scope = ${match}\n`);
+}
+
 if (options.mode === "watch") {
   // Switch to the alternate screen buffer so quitting restores the user's
   // pre-launch shell instead of leaving the rendered tree behind. The
@@ -120,4 +152,4 @@ if (options.mode === "watch") {
   if (options.mode === "once") clearScreen();
 }
 
-render(React.createElement(App, { mode: options.mode }));
+render(React.createElement(App, { mode: options.mode, scopeToProject }));

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,6 +2,7 @@
 
 import type { FSWatcher } from "node:fs";
 import { existsSync, watch } from "node:fs";
+import { basename } from "node:path";
 import { Box, Text, useApp, useInput, useStdout } from "ink";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -27,8 +28,8 @@ import { getDisplayWidth } from "./constants.js";
 import { DetailViewPanel } from "./DetailViewPanel.js";
 import { HelpPanel } from "./HelpPanel.js";
 import { useHotkeys } from "./hooks/useHotkeys.js";
-import { useTick } from "./hooks/useTick.js";
 import { useSpinner } from "./hooks/useSpinner.js";
+import { useTick } from "./hooks/useTick.js";
 import { SessionTreePanel } from "./SessionTreePanel.js";
 
 const VIEWER_HEIGHT_FRACTION = 0.55;
@@ -257,7 +258,13 @@ function collectAllIds(tree: SessionTree): Set<string> {
   return ids;
 }
 
-export function App({ mode }: { mode: "watch" | "once" }): React.ReactElement {
+export function App({
+  mode,
+  scopeToProject,
+}: {
+  mode: "watch" | "once";
+  scopeToProject?: string;
+}): React.ReactElement {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const isWatchMode = mode === "watch";
@@ -265,8 +272,13 @@ export function App({ mode }: { mode: "watch" | "once" }): React.ReactElement {
   const config = useMemo(() => loadGlobalConfig(), []);
   const migrationWarning = useMemo(() => hasProjectLevelConfig(), []);
 
+  const discoverOptions = useMemo(
+    () => (scopeToProject ? { scopeToProject } : undefined),
+    [scopeToProject],
+  );
+
   const [sessionTree, setSessionTree] = useState<SessionTree>(() =>
-    discoverSessions(config),
+    discoverSessions(config, discoverOptions),
   );
   const [selectedId, setSelectedId] = useState<string | null>(() => {
     // Select the first project sentinel if projects exist, otherwise null.
@@ -414,7 +426,7 @@ export function App({ mode }: { mode: "watch" | "once" }): React.ReactElement {
 
   const refresh = useCallback(() => {
     const freshConfig = loadGlobalConfig();
-    const tree = discoverSessions(freshConfig);
+    const tree = discoverSessions(freshConfig, discoverOptions);
     const updatedFlat = flattenSessions(tree, expandedIds);
 
     // Tracking mode: pick the next jump target with the new-id-aware
@@ -455,7 +467,7 @@ export function App({ mode }: { mode: "watch" | "once" }): React.ReactElement {
       setScrollOffset((o) => o + delta);
       setNewCount((n) => n + delta);
     }
-  }, [selectedId, isLive, expandedIds, tracking]);
+  }, [selectedId, isLive, expandedIds, tracking, discoverOptions]);
 
   // Keep a stable ref so the watcher callback always calls the latest refresh
   const refreshRef = useRef(refresh);
@@ -1048,6 +1060,7 @@ export function App({ mode }: { mode: "watch" | "once" }): React.ReactElement {
             expandedIds={expandedIds}
             trackingOn={tracking}
             spinner={spinner}
+            scopeLabel={scopeToProject ? basename(scopeToProject) : undefined}
           />
 
           <Box marginTop={1}>

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -32,6 +32,11 @@ export interface SessionTreePanelProps {
   trackingOn?: boolean;
   /** One-character spinner frame shown next to LIVE when trackingOn. */
   spinner?: string;
+  /**
+   * When set, the title bar renders as `Projects [<scopeLabel>]` to signal
+   * that the view is filtered to a single project (typically by --cwd).
+   */
+  scopeLabel?: string;
 }
 
 /**
@@ -457,6 +462,7 @@ export function SessionTreePanel({
   expandedIds = new Set(),
   trackingOn = false,
   spinner = "",
+  scopeLabel,
 }: SessionTreePanelProps): React.ReactElement {
   const innerWidth = getInnerWidth(width);
   const contentWidth = innerWidth - 1; // account for space after │
@@ -465,7 +471,8 @@ export function SessionTreePanel({
   // the tree's title shows `[LIVE ⠧]` so the user knows the selection is
   // moving on its own.
   const titleSuffix = trackingOn ? `[LIVE ${spinner || "▼"}]` : "";
-  const titleLine = createTitleLine("Projects", titleSuffix, width);
+  const titleText = scopeLabel ? `Projects [${scopeLabel}]` : "Projects";
+  const titleLine = createTitleLine(titleText, titleSuffix, width);
   const bottomLine = createBottomLine(width);
 
   const totalProjectCount = projects.length + coldProjects.length;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -29,6 +29,22 @@ describe("parseArgs", () => {
     expect(parseArgs(["-V"])).toEqual({ mode: "watch", command: "version" });
   });
 
+  it("parses --cwd as a watch-mode scope flag", () => {
+    expect(parseArgs(["--cwd"])).toEqual({ mode: "watch", scopeToCwd: true });
+  });
+
+  it("parses --cwd combined with --once", () => {
+    expect(parseArgs(["--once", "--cwd"])).toEqual({
+      mode: "once",
+      scopeToCwd: true,
+    });
+  });
+
+  it("does not set scopeToCwd when --cwd is absent", () => {
+    const opts = parseArgs([]);
+    expect(opts.scopeToCwd).toBeUndefined();
+  });
+
   describe("unknown commands and flags", () => {
     it("returns error for unknown subcommand", () => {
       const opts = parseArgs(["foobar"]);

--- a/tests/data/sessions.test.ts
+++ b/tests/data/sessions.test.ts
@@ -11,7 +11,9 @@ vi.mock("node:fs", () => ({
 const { existsSync, readdirSync, statSync, readFileSync } = await import(
   "node:fs"
 );
-const { discoverSessions } = await import("../../src/data/sessions.js");
+const { discoverSessions, findContainingProject } = await import(
+  "../../src/data/sessions.js"
+);
 
 const NOW = 1_700_000_000_000;
 
@@ -888,5 +890,139 @@ describe("discoverSessions", () => {
     );
     expect(all[0].nonInteractive).toBe(true);
     expect(all[0].liveState).toBeNull();
+  });
+});
+
+describe("findContainingProject", () => {
+  it("returns the project path when cwd exactly equals a project path", () => {
+    const result = findContainingProject("/Users/me/proj/agenthud", [
+      "/Users/me/proj/agenthud",
+      "/Users/me/proj/other",
+    ]);
+    expect(result).toBe("/Users/me/proj/agenthud");
+  });
+
+  it("returns the project path when cwd is a subdirectory of a project", () => {
+    const result = findContainingProject("/Users/me/proj/agenthud/src/data", [
+      "/Users/me/proj/agenthud",
+      "/Users/me/proj/other",
+    ]);
+    expect(result).toBe("/Users/me/proj/agenthud");
+  });
+
+  it("returns null when no project contains cwd", () => {
+    const result = findContainingProject("/tmp/random", [
+      "/Users/me/proj/agenthud",
+      "/Users/me/proj/other",
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns the nearest (longest-prefix) project when several ancestors exist", () => {
+    // Both /Users/me and /Users/me/proj/agenthud are registered;
+    // cwd inside agenthud should resolve to the deeper one.
+    const result = findContainingProject("/Users/me/proj/agenthud/src", [
+      "/Users/me",
+      "/Users/me/proj/agenthud",
+    ]);
+    expect(result).toBe("/Users/me/proj/agenthud");
+  });
+
+  it("does not match on string prefix without a path-separator boundary", () => {
+    // /Users/me/proj/agent is NOT an ancestor of /Users/me/proj/agenthud/src
+    const result = findContainingProject("/Users/me/proj/agenthud/src", [
+      "/Users/me/proj/agent",
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for an empty project list", () => {
+    expect(findContainingProject("/anywhere", [])).toBeNull();
+  });
+
+  it("normalizes both sides via the injected realpath", () => {
+    // Both cwd and the registered project go through realpath. After
+    // resolution they share the same real path, so the project matches.
+    const realpath = (p: string) =>
+      p.replace("/sym/cwd", "/real/proj").replace("/sym/proj", "/real/proj");
+    const result = findContainingProject("/sym/cwd/src", ["/sym/proj"], {
+      realpath,
+    });
+    expect(result).toBe("/sym/proj");
+  });
+});
+
+describe("discoverSessions with scopeToProject", () => {
+  const projectsDir = join(
+    process.env.HOME ?? "/home/user",
+    ".claude",
+    "projects",
+  );
+  const targetEncoded = "-Users-me-target";
+  const otherEncoded = "-Users-me-other";
+  const targetDir = join(projectsDir, targetEncoded);
+  const otherDir = join(projectsDir, otherEncoded);
+
+  function wireMocksForTwoProjects() {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === projectsDir) return true;
+      if (path === targetDir || path === otherDir) return true;
+      if (path.endsWith(".jsonl")) return true;
+      return false;
+    });
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === projectsDir)
+        return [targetEncoded, otherEncoded] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      if (path === targetDir)
+        return ["a.jsonl"] as unknown as ReturnType<typeof readdirSync>;
+      if (path === otherDir)
+        return ["b.jsonl"] as unknown as ReturnType<typeof readdirSync>;
+      return [] as unknown as ReturnType<typeof readdirSync>;
+    });
+
+    vi.mocked(statSync).mockImplementation((p) => {
+      const path = String(p);
+      const isDir = path === targetDir || path === otherDir;
+      return {
+        isDirectory: () => isDir,
+        mtimeMs: NOW - 10_000,
+        size: 100,
+      } as ReturnType<typeof statSync>;
+    });
+
+    vi.mocked(readFileSync).mockReturnValue("");
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+  }
+
+  it("returns only the scoped project, dropping the others", () => {
+    wireMocksForTwoProjects();
+    const tree = discoverSessions(mockConfig, {
+      scopeToProject: "/Users/me/target",
+    });
+    const all = [...tree.projects, ...tree.coldProjects];
+    expect(all).toHaveLength(1);
+    expect(all[0].projectPath).toBe("/Users/me/target");
+  });
+
+  it("returns an empty tree when scopeToProject matches no registered project", () => {
+    wireMocksForTwoProjects();
+    const tree = discoverSessions(mockConfig, {
+      scopeToProject: "/Users/me/nothing-here",
+    });
+    expect(tree.projects).toHaveLength(0);
+    expect(tree.coldProjects).toHaveLength(0);
+    expect(tree.totalCount).toBe(0);
+  });
+
+  it("keeps the unfiltered behaviour when scopeToProject is omitted", () => {
+    wireMocksForTwoProjects();
+    const tree = discoverSessions(mockConfig);
+    const all = [...tree.projects, ...tree.coldProjects];
+    expect(all).toHaveLength(2);
   });
 });

--- a/tests/data/sessions.test.ts
+++ b/tests/data/sessions.test.ts
@@ -940,6 +940,14 @@ describe("findContainingProject", () => {
     expect(findContainingProject("/anywhere", [])).toBeNull();
   });
 
+  it("accepts Windows-style backslash separators as boundary", () => {
+    const result = findContainingProject(
+      "C:\\Users\\me\\proj\\agenthud\\src",
+      ["C:\\Users\\me\\proj\\agenthud", "C:\\Users\\me\\proj\\other"],
+    );
+    expect(result).toBe("C:\\Users\\me\\proj\\agenthud");
+  });
+
   it("normalizes both sides via the injected realpath", () => {
     // Both cwd and the registered project go through realpath. After
     // resolution they share the same real path, so the project matches.

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -843,4 +843,35 @@ describe("SessionTreePanel", () => {
     );
     expect(lastFrame()).toContain("[waiting]");
   });
+
+  it("renders scope label in the header when scopeLabel is set", () => {
+    const session = makeSession();
+    const project = makeProject("agenthud", [session]);
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[project]}
+        coldProjects={[]}
+        selectedId={null}
+        hasFocus={false}
+        width={80}
+        scopeLabel="agenthud"
+      />,
+    );
+    expect(lastFrame()).toContain("Projects [agenthud]");
+  });
+
+  it("omits scope label when scopeLabel is not set", () => {
+    const session = makeSession();
+    const project = makeProject("myproject", [session]);
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[project]}
+        coldProjects={[]}
+        selectedId={null}
+        hasFocus={false}
+        width={80}
+      />,
+    );
+    expect(lastFrame()).not.toMatch(/Projects \[/);
+  });
 });


### PR DESCRIPTION
Closes #93

## Summary
- Adds `--cwd` flag that walks up from `process.cwd()` and shows only the **nearest containing Claude project** (longest-prefix match, symlink-normalized).
- No containing project → prints `agenthud: --cwd: no Claude project found at or above <path>` to stderr and exits 1 (no empty UI).
- Works in both `--watch` and `--once` modes; runs side-by-side with an unfiltered agenthud instance without conflict (read-only over `~/.claude/projects/`).
- UI header switches from `Projects` to `Projects [<basename>]`, coexists with the existing `[LIVE …]` suffix.

## Implementation
- `src/data/sessions.ts` — new pure `findContainingProject(cwd, projectPaths, { realpath? })` helper; `discoverSessions` accepts an optional `{ scopeToProject }` and drops non-matching projects after `decodeProjectPath`. `decodeProjectPath` is now exported so `main.ts` can reuse it.
- `src/cli.ts` — parses `--cwd` as a boolean for watch and once modes; help text updated.
- `src/main.ts` — when `--cwd` is set, lists registered projects, realpaths both sides (with a safe fallback), resolves the scope, exits 1 on no match, otherwise writes `agenthud: scope = <path>` to stderr and threads the scope through to `App`.
- `src/ui/App.tsx` — adds a `scopeToProject?: string` prop, passes it to both `discoverSessions` call sites, and feeds `basename(scopeToProject)` to `SessionTreePanel` as `scopeLabel`.
- `src/ui/SessionTreePanel.tsx` — new `scopeLabel?: string` prop; title becomes `Projects [<label>]` when set.

## Tests
- `findContainingProject`: exact match, subdir walk-up, no match, nearest-of-multiple-ancestors, path-separator boundary safety, empty list, realpath normalization.
- `discoverSessions` with `scopeToProject`: keeps only the matched project, returns empty tree for no match, unfiltered behavior preserved when omitted.
- `parseArgs`: `--cwd` alone, combined with `--once`, absent.
- `SessionTreePanel`: header renders `Projects [agenthud]` with `scopeLabel`, no `[…]` when omitted.

## Test plan
- [x] `npx vitest run` — 409/409 pass
- [x] `npx tsc --noEmit` — clean
- [x] Smoke test from project root → `Projects [agenthud]` with sessions
- [x] Smoke test from `src/data/` → walks up, same scope resolved
- [x] Smoke test from `/tmp` → exits 1 with stderr message

## Out of scope
A separate pre-existing layout issue surfaced during testing: project dirs where only nested `subagents/*.jsonl` exist (no top-level parent jsonl, ~Jan 2026 layout) are silently dropped by `discoverSessions`. Intentionally not fixed here; will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--cwd` CLI option to scope the app to the current Claude project directory.
  * Session discovery now filters to the specified project when scoped.
  * UI displays the scoped project name in the Projects panel header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->