### PR TITLE
fix: usable tree when only cold projects exist at boot

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -258,6 +258,32 @@ function collectAllIds(tree: SessionTree): Set<string> {
   return ids;
 }
 
+/**
+ * Pick the initial selection for the tree. Prefers the first live
+ * project; falls back to the cold-group sentinel when only cold
+ * projects exist so j/k aren't silent no-ops at boot (selectedIndex
+ * would be -1 against an empty hot list and the navigation handlers
+ * short-circuit on that).
+ */
+export function initialSelectedId(tree: SessionTree): string | null {
+  const firstProject = tree.projects[0];
+  if (firstProject) return `__proj-${firstProject.name}__`;
+  if (tree.coldProjects.length > 0) return "__cold__";
+  return null;
+}
+
+/**
+ * Auto-expand the cold group when there are no live projects so the
+ * user lands on a visible list of projects instead of a single
+ * "N cold" summary row.
+ */
+export function initialExpandedIds(tree: SessionTree): Set<string> {
+  if (tree.projects.length === 0 && tree.coldProjects.length > 0) {
+    return new Set(["__cold__"]);
+  }
+  return new Set();
+}
+
 export function App({
   mode,
   scopeToProject,
@@ -280,19 +306,18 @@ export function App({
   const [sessionTree, setSessionTree] = useState<SessionTree>(() =>
     discoverSessions(config, discoverOptions),
   );
-  const [selectedId, setSelectedId] = useState<string | null>(() => {
-    // Select the first project sentinel if projects exist, otherwise null.
-    const firstProject = sessionTree.projects[0];
-    if (firstProject) return `__proj-${firstProject.name}__`;
-    return null;
-  });
+  const [selectedId, setSelectedId] = useState<string | null>(() =>
+    initialSelectedId(sessionTree),
+  );
   const [focus, setFocus] = useState<"tree" | "viewer">("tree");
   const [scrollOffset, setScrollOffset] = useState(0);
   const [isLive, setIsLive] = useState(true);
   const [activities, setActivities] = useState<ActivityEntry[]>([]);
   const [gitActivities, setGitActivities] = useState<ActivityEntry[]>([]);
   const [newCount, setNewCount] = useState(0);
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() =>
+    initialExpandedIds(sessionTree),
+  );
   const [viewerCursorLine, setViewerCursorLine] = useState(0);
   const [detailMode, setDetailMode] = useState(false);
   const [detailActivity, setDetailActivity] = useState<ActivityEntry | null>(

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -1,6 +1,11 @@
 // tests/ui/App.test.tsx
 import { render } from "ink-testing-library";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ProjectNode,
+  SessionNode,
+  SessionTree,
+} from "../../src/types/index.js";
 
 vi.mock("../../src/config/globalConfig.js", () => ({
   loadGlobalConfig: () => ({
@@ -12,13 +17,15 @@ vi.mock("../../src/config/globalConfig.js", () => ({
   hasProjectLevelConfig: () => false,
 }));
 
+let mockTree: SessionTree = {
+  projects: [],
+  coldProjects: [],
+  totalCount: 0,
+  timestamp: new Date().toISOString(),
+};
+
 vi.mock("../../src/data/sessions.js", () => ({
-  discoverSessions: () => ({
-    projects: [],
-    coldProjects: [],
-    totalCount: 0,
-    timestamp: new Date().toISOString(),
-  }),
+  discoverSessions: () => mockTree,
   getProjectsDir: () => "/tmp/nonexistent-projects-dir",
 }));
 
@@ -26,7 +33,45 @@ vi.mock("../../src/data/sessionHistory.js", () => ({
   parseSessionHistory: () => [],
 }));
 
-const { App } = await import("../../src/ui/App.js");
+const { App, initialSelectedId, initialExpandedIds } = await import(
+  "../../src/ui/App.js"
+);
+
+const emptyTree = (): SessionTree => ({
+  projects: [],
+  coldProjects: [],
+  totalCount: 0,
+  timestamp: new Date().toISOString(),
+});
+
+const makeColdSession = (
+  projectName: string,
+  id: string,
+): SessionNode => ({
+  id,
+  hideKey: `${projectName}/${id}`,
+  filePath: `/tmp/${projectName}/${id}.jsonl`,
+  projectPath: `/tmp/${projectName}`,
+  projectName,
+  lastModifiedMs: Date.now() - 7 * 24 * 60 * 60 * 1000, // a week ago
+  status: "cold",
+  modelName: null,
+  subAgents: [],
+  nonInteractive: false,
+  firstUserPrompt: null,
+  liveState: null,
+});
+
+const makeColdProject = (name: string): ProjectNode => ({
+  name,
+  projectPath: `/tmp/${name}`,
+  sessions: [makeColdSession(name, `${name}-sess`)],
+  hotness: "cold",
+});
+
+beforeEach(() => {
+  mockTree = emptyTree();
+});
 
 describe("App", () => {
   it("renders without crashing when there are no sessions", () => {
@@ -42,5 +87,83 @@ describe("App", () => {
     // mode rendered SOMETHING by checking for any of the always-present
     // status-bar / panel indicators.
     expect(out).toMatch(/(Tab:|Projects|q: quit)/);
+  });
+});
+
+describe("App with only cold projects (post-vacation boot)", () => {
+  beforeEach(() => {
+    mockTree = {
+      projects: [],
+      coldProjects: [
+        makeColdProject("alpha"),
+        makeColdProject("beta"),
+        makeColdProject("gamma"),
+      ],
+      totalCount: 3,
+      timestamp: new Date().toISOString(),
+    };
+  });
+
+  it("expands the cold group at boot so the cold projects are visible", () => {
+    const { lastFrame } = render(<App mode="once" />);
+    const out = lastFrame() ?? "";
+    // Without the fix, only the "3 cold" summary row renders and the
+    // individual project names stay hidden behind the collapsed sentinel.
+    expect(out).toContain("alpha");
+    expect(out).toContain("beta");
+    expect(out).toContain("gamma");
+  });
+
+});
+
+describe("initialSelectedId", () => {
+  it("returns the first hot project's sentinel when hot projects exist", () => {
+    const tree: SessionTree = {
+      projects: [makeColdProject("hot1")], // shape only — sit-in for any project
+      coldProjects: [makeColdProject("cold1")],
+      totalCount: 2,
+      timestamp: new Date().toISOString(),
+    };
+    expect(initialSelectedId(tree)).toBe("__proj-hot1__");
+  });
+
+  it("falls back to __cold__ when only cold projects exist", () => {
+    const tree: SessionTree = {
+      projects: [],
+      coldProjects: [makeColdProject("cold1"), makeColdProject("cold2")],
+      totalCount: 2,
+      timestamp: new Date().toISOString(),
+    };
+    expect(initialSelectedId(tree)).toBe("__cold__");
+  });
+
+  it("returns null when no projects exist at all", () => {
+    expect(initialSelectedId(emptyTree())).toBeNull();
+  });
+});
+
+describe("initialExpandedIds", () => {
+  it("expands __cold__ when only cold projects exist", () => {
+    const tree: SessionTree = {
+      projects: [],
+      coldProjects: [makeColdProject("cold1")],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+    };
+    expect(initialExpandedIds(tree).has("__cold__")).toBe(true);
+  });
+
+  it("leaves __cold__ collapsed when hot projects exist", () => {
+    const tree: SessionTree = {
+      projects: [makeColdProject("hot1")],
+      coldProjects: [makeColdProject("cold1")],
+      totalCount: 2,
+      timestamp: new Date().toISOString(),
+    };
+    expect(initialExpandedIds(tree).has("__cold__")).toBe(false);
+  });
+
+  it("returns an empty set when there are no projects at all", () => {
+    expect(initialExpandedIds(emptyTree()).size).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #96

## Summary
After a few days away from the machine, every session ages past today
and the project tree ends up entirely in `coldProjects`. Boot in that
state was unusable: nothing was highlighted, j/k were silent no-ops
(`selectedIndex === -1` short-circuit), and only a Tab→Tab refocus
revived the selection.

This PR fixes the boot state in two places, both inside `App`'s
`useState` initializers:

1. **Initial selection** falls back to the `__cold__` sentinel when no
   hot project exists, so navigation handlers have a row to anchor to.
2. **Initial `expandedIds`** opens the `__cold__` group in the same
   case, so the user sees their cold projects instead of just a
   "N cold" summary row.

Both initializers are extracted as pure helpers (`initialSelectedId`,
`initialExpandedIds`) and exported so they can be unit-tested without
the full React tree.

## Tests
- `initialSelectedId`: hot-present, cold-only, empty.
- `initialExpandedIds`: cold-only expands, hot-present does not,
  empty stays empty.
- App: cold-only boot renders the cold project names (was hidden
  behind the collapsed sentinel before).

## Test plan
- [x] `npx vitest run` — 417/417 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed initial UI state to automatically expand inactive project groups on startup when no active projects are available, ensuring all projects remain visible.

* **Tests**
  * Expanded test coverage for app initialization behavior and handling of inactive projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->