### PR TITLE
fix: include user prompts in report + reach git-merged entries in viewer scroll

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"cbe5773f-769b-485f-98d2-e5c995344234","pid":14664,"procStart":"Fri Jun  5 03:33:13 2026","acquiredAt":1780631460269}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"cbe5773f-769b-485f-98d2-e5c995344234","pid":14664,"procStart":"Fri Jun  5 03:33:13 2026","acquiredAt":1780631460269}

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ vitest.config.ts.timestamp-*
 # .cast file local so we only version the rendered gif.
 demo/.cache/
 
+# Local Claude Code state (scheduled-task locks, transient buffers, etc.).
+.claude/
+
 # Profiling artifacts (Node --prof / clinic / Chrome DevTools exports)
 CPU.*.cpuprofile
 *.heapsnapshot

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const ALL_TYPES = [
   "glob",
   "user",
 ];
-const DEFAULT_TYPES = ["response", "bash", "edit", "thinking"];
+const DEFAULT_TYPES = ["user", "response", "bash", "edit", "thinking"];
 
 export interface CliOptions {
   mode: "watch" | "once" | "report" | "summary";
@@ -84,7 +84,7 @@ Commands:
     --date YYYY-MM-DD|today|yesterday|-Nd     Date to report on
     --include TYPES             Comma-separated types or "all"
                                 Types: response,bash,edit,thinking,read,glob,user
-                                Default: response,bash,edit,thinking
+                                Default: user,response,bash,edit,thinking
     --format FORMAT             Output format: markdown (default) or json
     --detail-limit N            Max chars per activity detail (default: 120, 0 = unlimited)
     --with-git                  Merge git commits from each session's project into the timeline

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -650,10 +650,16 @@ export function App({
         if (viewerCursorLine < viewerRows - 1) {
           setViewerCursorLine((c) => c + 1);
         } else {
-          // cursor at top of viewport — scroll viewport toward older
+          // cursor at top of viewport — scroll viewport toward older.
+          // Clamp against the merged length so git-merged entries at the
+          // head of the stream stay reachable (the viewer renders
+          // mergedActivities, not raw activities).
           setIsLive(false);
           setScrollOffset((o) =>
-            Math.min(o + 1, Math.max(0, activities.length - viewerRows)),
+            Math.min(
+              o + 1,
+              Math.max(0, mergedActivities.length - viewerRows),
+            ),
           );
         }
       }
@@ -692,7 +698,10 @@ export function App({
         setViewerCursorLine(0);
         setIsLive(false);
         setScrollOffset((o) =>
-          Math.min(o + viewerRows, Math.max(0, activities.length - viewerRows)),
+          Math.min(
+            o + viewerRows,
+            Math.max(0, mergedActivities.length - viewerRows),
+          ),
         );
       }
     },
@@ -724,7 +733,7 @@ export function App({
         setScrollOffset((o) =>
           Math.min(
             o + Math.floor(viewerRows / 2),
-            Math.max(0, activities.length - viewerRows),
+            Math.max(0, mergedActivities.length - viewerRows),
           ),
         );
       }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -45,6 +45,14 @@ describe("parseArgs", () => {
     expect(opts.scopeToCwd).toBeUndefined();
   });
 
+  it("includes 'user' in report's default --include set", () => {
+    // Without 'user', report drops every user prompt and 'Thinking' ends
+    // up as the first entry of each session block — the report reads as
+    // if Claude acted out of nowhere.
+    const opts = parseArgs(["report"]);
+    expect(opts.reportInclude).toContain("user");
+  });
+
   describe("unknown commands and flags", () => {
     it("returns error for unknown subcommand", () => {
       const opts = parseArgs(["foobar"]);
@@ -95,6 +103,7 @@ describe("parseArgs", () => {
     it("uses default include types when --include not given", () => {
       const opts = parseArgs(["report"]);
       expect(opts.reportInclude).toEqual([
+        "user",
         "response",
         "bash",
         "edit",


### PR DESCRIPTION
Closes #98
Closes #99

## Summary

Two small bugs that surfaced together while reviewing yesterday's
report:

### #98 — `report` dropped user prompts by default

`agenthud report --date <X>` (no `--include`) excluded the `user`
type, so every session block opened on `Thinking` and the prompt that
actually drove the turn was missing. Reports looked causeless.

Fix: add `user` to `DEFAULT_TYPES` in `src/cli.ts`. Anyone who wants
the prior behavior passes `--include response,bash,edit,thinking`.

### #99 — viewer scroll-up clamped against the wrong array

The activity viewer renders `mergedActivities` (session activities +
git commits, time-sorted), but the scroll-up handlers clamped
`scrollOffset` against the raw `activities.length`. With git commits
in the merged stream, the earliest N entries were unreachable via
k / PgUp / Ctrl+U — only `g` could reach them (it already used
`mergedActivities.length`).

Fix: wire the three handlers (`onScrollUp`, `onScrollPageUp`,
`onScrollHalfPageUp`) to `mergedActivities.length` so the clamp
tracks the data the viewer is showing.

### Bonus tidy

Also gitignored `.claude/` (Claude Code's local state dir) — slipped
into the working tree via a transient scheduler lock file. Not
relevant to anyone else's checkout.

## Tests
- `tests/cli.test.ts`: assert the default `--include` set now
  contains `user`, and update the existing default-set test.
- Manual repro for #99: user confirmed `g` reached the entries that
  `k` couldn't.

## Test plan
- [x] `npx vitest run` — 418/418 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)