### PR TITLE
fix: report accepts -Nd date + promote watch to a first-class command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,12 +170,23 @@ export function parseArgs(args: string[]): CliOptions {
     let reportInclude = DEFAULT_TYPES;
     let reportError: string | undefined;
 
-    // Check for unknown flags in report subcommand
-    for (const arg of rest) {
-      if (arg.startsWith("-") && !KNOWN_REPORT_FLAGS.has(arg)) {
+    // Check for unknown flags in report subcommand. Skip the value
+    // following any flag that takes one, otherwise a `-Nd` date like
+    // `-1d` gets misread as an unknown flag.
+    const FLAGS_WITH_VALUE = new Set([
+      "--date",
+      "--include",
+      "--format",
+      "--detail-limit",
+    ]);
+    for (let i = 0; i < rest.length; i++) {
+      const arg = rest[i];
+      if (!arg.startsWith("-")) continue;
+      if (!KNOWN_REPORT_FLAGS.has(arg)) {
         reportError = `Unknown option: "${arg}". Run agenthud --help for usage.`;
         break;
       }
+      if (FLAGS_WITH_VALUE.has(arg)) i++;
     }
 
     const dateIdx = rest.indexOf("--date");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,48 +62,63 @@ const KNOWN_SUMMARY_FLAGS = new Set([
   "-y",
   "--yes",
 ]);
-const KNOWN_SUBCOMMANDS = new Set(["report", "summary"]);
+const KNOWN_SUBCOMMANDS = new Set(["watch", "report", "summary"]);
 
 export function getHelp(): string {
-  return `Usage: agenthud [options]
+  return `Usage: agenthud [command] [options]
 
-Monitors all running Claude Code sessions in real-time.
+Monitors all running Claude Code sessions.
 
-Options:
-  -w, --watch                   Watch mode (default) — live updates
-  --once                        Print once and exit
-  --cwd                         Scope the view to the Claude project
-                                containing the current directory.
-                                Exits 1 if no such project is found.
+Commands:
+  watch (default)               Live TUI — project tree on top, activity
+                                viewer on bottom, both updating in real
+                                time. Running \`agenthud\` with no
+                                command does this.
+    -w, --watch                 Explicit alias for the default
+    --once                      Print one frame and exit
+    --cwd                       Scope to the Claude project containing
+                                the current directory. Exits 1 if no
+                                such project is found.
+
+  report [--date DATE] [--include TYPES] [--format FORMAT]
+         [--detail-limit N] [--with-git]
+                                Print activity report for a date
+                                (default: today). Markdown or JSON.
+    --date YYYY-MM-DD|today|yesterday|-Nd     Date to report on
+    --include TYPES             Comma-separated types or "all"
+                                Types:   user, response, bash, edit,
+                                         thinking, read, glob
+                                Default: user, response, bash, edit, thinking
+    --format FORMAT             markdown (default) or json
+    --detail-limit N            Max chars per detail (default 120;
+                                0 = unlimited)
+    --with-git                  Merge git commits from each session's
+                                project into the timeline
+
+  summary [--date DATE | --last Nd | --from DATE --to DATE]
+          [--prompt TEXT] [--force] [--model NAME] [-y]
+                                Generate an LLM summary via the claude
+                                CLI. A single day produces a daily
+                                summary; a date range produces a
+                                meta-summary built from daily summaries.
+    --date YYYY-MM-DD|today|yesterday|-Nd     Date to summarize (default: today)
+    --last Nd                   Date range: last N days, ending today
+                                (e.g. --last 7d)
+    --from YYYY-MM-DD           Range start (use with --to)
+    --to YYYY-MM-DD             Range end (use with --from)
+    --prompt TEXT               Override prompt for this run (daily only)
+    --force                     Regenerate even if cached
+    --model NAME                Pass --model to claude (e.g. "sonnet",
+                                "haiku", or a full model id)
+    -y, --yes                   Skip confirmation prompts for new daily
+                                summaries
+
+Global options:
   -V, --version                 Show version number
   -h, --help                    Show this help message
 
-Commands:
-  report [--date DATE] [--include TYPES] [--format FORMAT] [--detail-limit N] [--with-git]
-                                Print activity report for a date (default: today)
-    --date YYYY-MM-DD|today|yesterday|-Nd     Date to report on
-    --include TYPES             Comma-separated types or "all"
-                                Types: response,bash,edit,thinking,read,glob,user
-                                Default: user,response,bash,edit,thinking
-    --format FORMAT             Output format: markdown (default) or json
-    --detail-limit N            Max chars per activity detail (default: 120, 0 = unlimited)
-    --with-git                  Merge git commits from each session's project into the timeline
-
-  summary [--date DATE | --last Nd | --from DATE --to DATE] [--prompt TEXT] [--force] [-y]
-                                Generate LLM summary via claude CLI.
-                                Single day produces a daily summary;
-                                a date range produces a meta-summary built from daily summaries.
-    --date YYYY-MM-DD|today|yesterday|-Nd     Date to summarize (default: today)
-    --last Nd                   Date range: last N days, ending today (e.g. --last 7d)
-    --from YYYY-MM-DD           Date range: start date (use with --to)
-    --to YYYY-MM-DD             Date range: end date (use with --from)
-    --prompt TEXT               Override prompt for this run (daily only)
-    --force                     Regenerate even if cached
-    --model NAME                Pass --model to claude (e.g. "sonnet", "haiku", or a full model ID)
-    -y, --yes                   Skip confirmation prompts for new daily summaries
-
 Environment:
-  CLAUDE_PROJECTS_DIR           Path to Claude projects directory
+  CLAUDE_PROJECTS_DIR           Path to the Claude projects directory
                                 (default: ~/.claude/projects)
 
 Config: ~/.agenthud/config.yaml
@@ -152,6 +167,9 @@ function todayLocalMidnight(): Date {
 }
 
 export function parseArgs(args: string[]): CliOptions {
+  // `watch` is the explicit form of the default mode — strip it so the
+  // rest of parsing sees the same shape it always has.
+  if (args[0] === "watch") args = args.slice(1);
   if (args.includes("--help") || args.includes("-h")) {
     return { mode: "watch", command: "help" };
   }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -45,6 +45,21 @@ describe("parseArgs", () => {
     expect(opts.scopeToCwd).toBeUndefined();
   });
 
+  it("parses 'watch' as a positional command (equivalent to no command)", () => {
+    expect(parseArgs(["watch"])).toEqual({ mode: "watch" });
+  });
+
+  it("parses 'watch --once' the same as bare --once", () => {
+    expect(parseArgs(["watch", "--once"])).toEqual({ mode: "once" });
+  });
+
+  it("parses 'watch --cwd' as scoped watch mode", () => {
+    expect(parseArgs(["watch", "--cwd"])).toEqual({
+      mode: "watch",
+      scopeToCwd: true,
+    });
+  });
+
   it("includes 'user' in report's default --include set", () => {
     // Without 'user', report drops every user prompt and 'Thinking' ends
     // up as the first entry of each session block — the report reads as

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -129,6 +129,19 @@ describe("parseArgs", () => {
       expect(opts.reportInclude).toEqual(["response", "edit"]);
     });
 
+    it("accepts a -Nd value to --date without flagging it as unknown", () => {
+      // The unknown-flag scan must skip values that follow flags taking
+      // a value (otherwise `-1d` as a documented --date format is read
+      // as an unknown flag).
+      const opts = parseArgs(["report", "--date", "-1d"]);
+      expect(opts.reportError).toBeUndefined();
+      // -1d → yesterday at local midnight
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      yesterday.setHours(0, 0, 0, 0);
+      expect(opts.reportDate?.getTime()).toBe(yesterday.getTime());
+    });
+
     it("returns error for an unknown --include type (typo)", () => {
       const opts = parseArgs(["report", "--include", "response,bas"]);
       expect(opts.reportError).toBeDefined();


### PR DESCRIPTION
Closes #101

Two CLI / docs changes bundled for v0.11.3.

## 1. report accepts `-Nd` as a `--date` value

\`agenthud report --date -1d\` was rejected with
\`Unknown option: "-1d"\` even though the help documented \`-Nd\`
as a valid \`--date\` value. The report subcommand's unknown-flag
scan didn't skip values after value-taking flags, so the \`-1d\`
value tripped the check. Mirrors the summary subcommand's existing
\`FLAGS_WITH_VALUE\` + \`i++\` pattern.

## 2. \`watch\` is now a first-class command in help + CLI

The help layout treated watch (the headline mode) as a generic
option alongside \`--version\` and \`--help\`, while less-central
modes (report, summary) got top billing as Commands. Restructure:

- watch is a Commands entry with \`(default)\` annotation; its flags
  (\`-w/--watch\`, \`--once\`, \`--cwd\`) sit under it the way
  report's and summary's flags do.
- Global \`-V\` / \`-h\` move to a separate "Global options" section.
- Accept \`agenthud watch\` as an explicit positional (today it
  errors as "Unknown command"). The implementation strips the
  leading \`watch\` token so the rest of parseArgs sees the same
  shape it always has — \`agenthud watch --once\` parses the same
  as bare \`--once\`.

## Tests
- New: \`parseArgs(["report", "--date", "-1d"])\` returns no error
  and the date matches yesterday at local midnight.
- New: \`parseArgs(["watch"])\`, \`parseArgs(["watch", "--once"])\`,
  \`parseArgs(["watch", "--cwd"])\` all parse to the equivalent
  bare-flag shape.

## Test plan
- [x] \`npx vitest run\` — 422/422 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [x] Smoke: \`node dist/index.js report --date -1d\` prints
      yesterday's report; \`node dist/index.js watch --once\` shows
      the live tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)