### PR TITLE
fix: --once preserves terminal scrollback

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,10 +133,6 @@ export function getVersion(): string {
   return packageJson.version;
 }
 
-export function clearScreen(): void {
-  console.clear();
-}
-
 function parseLocalMidnight(dateStr: string): Date | null {
   if (dateStr === "today") {
     const now = new Date();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { render } from "ink";
 import React from "react";
-import { clearScreen, getHelp, getVersion, parseArgs } from "./cli.js";
+import { getHelp, getVersion, parseArgs } from "./cli.js";
 import { loadGlobalConfig } from "./config/globalConfig.js";
 import { generateReport } from "./data/reportGenerator.js";
 import {
@@ -146,10 +146,9 @@ if (options.mode === "watch") {
   // uncaught errors.
   installAltScreenCleanup();
   enterAltScreen();
-} else {
-  // Non-watch modes (--once, report, summary) keep their output on the
-  // user's normal terminal, just like any CLI utility.
-  if (options.mode === "once") clearScreen();
 }
+// Non-watch modes (--once, report, summary) render in place at the
+// cursor so the user's existing scrollback is preserved — like any
+// CLI utility.
 
 render(React.createElement(App, { mode: options.mode, scopeToProject }));


### PR DESCRIPTION
Closes #103

## Summary
\`agenthud --once\` called \`console.clear()\` before rendering,
emitting the clear-screen + clear-scrollback escape on modern
terminals. The user's working context disappeared even though
\`--once\` never enters an alt-screen. The neighboring comment in
main.ts already claimed \`--once\` "keeps output on the user's
normal terminal, just like any CLI utility" — the call directly
contradicted that. Drop it.

Also removes the now-unused \`clearScreen\` export from cli.ts and
the matching import in main.ts.

## Test plan
- [x] \`npx vitest run\` — 422/422 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [ ] Smoke (interactive): \`agenthud --once\` snapshot appears at
      cursor, prior scrollback intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic terminal clearing in single-run modes (`--once`, `report`, `summary`). Output now renders in place with cursor preservation for better log continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->