### PR TITLE
feat: config-driven defaults for report/summary + summary option surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-05
+
+### Added
+- **Config-driven defaults for `report` and `summary`.** New
+  `report:` and `summary:` sections in
+  `~/.agenthud/config.yaml` carry the include set, detail limit,
+  with-git toggle, and format. CLI flags still win per
+  invocation. `summary:` keys inherit from `report:` when
+  omitted, so most users can pin one shape under `report:` and
+  have summary follow. Resolution order: `CLI flag → summary.* →
+  report.* → built-in default`.
+- **`summary` exposes the same option surface as `report`.** New
+  `--include`, `--detail-limit`, `--with-git`, `--format` flags
+  on the `summary` subcommand let you tune what feeds the LLM
+  payload from the command line.
+- **Effective-options line on stderr** at the start of every
+  `report` / `summary` run, e.g.
+  `agenthud: report → include=[user,response,bash,edit,thinking]
+  detail-limit=120 with-git=off format=markdown`. Tells you what
+  was actually used; no surprises about hidden hardcodes.
+
+### Fixed
+- **`summary` daily payload no longer drops user prompts.** The
+  hardcoded include set inside `summaryRunner.ts` missed `user`,
+  so the LLM saw no prompts even after v0.11.2 added `user` to
+  the `report` default. The include set is now shared via
+  `DEFAULT_INCLUDE_TYPES` and both surfaces resolve it the same
+  way.
+
+### Upgrade notes
+- Existing config files are not migrated — the new `report:` and
+  `summary:` sections are only written when the file does not
+  exist. Behavior is unchanged for upgrading users (built-in
+  defaults). To pin your preferences, add the sections by hand
+  using the example block in the README.
+
 ## [0.11.4] - 2026-06-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -240,7 +240,23 @@ filterPresets:
   - ["all"]
   - ["response", "user"]
   - ["commit"]
+
+# Defaults for `agenthud report` (CLI flags still win per-invocation).
+report:
+  include: [user, response, bash, edit, thinking]
+  detailLimit: 120
+  withGit: false
+  format: markdown
+
+# Defaults for `agenthud summary`. Any field omitted here is inherited
+# from `report` above. `model` is summary-specific.
+summary:
+  withGit: true
+  detailLimit: 0
+  # model: sonnet
 ```
+
+`report` / `summary` resolve each option as **CLI flag → `summary:` key → `report:` key → built-in default**. The effective set is printed to stderr at the start of each run (e.g. `agenthud: report → include=[user,response,bash,edit,thinking] detail-limit=120 with-git=off format=markdown`), so the actual values are always visible.
 
 App-managed state (hidden items) lives separately in `~/.agenthud/state.yaml` so your config file stays clean. You shouldn't need to edit it manually — use `h` in the TUI to hide things.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenthud",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenthud",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "ink": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenthud",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "description": "CLI tool to monitor agent status in real-time. Works with Claude Code, multi-agent workflows, and any AI agent system.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { DEFAULT_INCLUDE_TYPES } from "./config/globalConfig.js";
+import type { GlobalConfig } from "./types/index.js";
 
 const ALL_TYPES = [
   "response",
@@ -11,7 +13,6 @@ const ALL_TYPES = [
   "glob",
   "user",
 ];
-const DEFAULT_TYPES = ["user", "response", "bash", "edit", "thinking"];
 
 export interface CliOptions {
   mode: "watch" | "once" | "report" | "summary";
@@ -30,6 +31,12 @@ export interface CliOptions {
   summaryPrompt?: string;
   summaryForce?: boolean;
   summaryModel?: string;
+  // Report-shaped options on summary. Resolved as
+  // CLI flag → config.summary.X → config.report.X → built-in default.
+  summaryInclude?: string[];
+  summaryFormat?: "markdown" | "json";
+  summaryDetailLimit?: number;
+  summaryWithGit?: boolean;
   summaryError?: string;
   scopeToCwd?: boolean;
 }
@@ -61,6 +68,10 @@ const KNOWN_SUMMARY_FLAGS = new Set([
   "--model",
   "-y",
   "--yes",
+  "--include",
+  "--format",
+  "--detail-limit",
+  "--with-git",
 ]);
 const KNOWN_SUBCOMMANDS = new Set(["watch", "report", "summary"]);
 
@@ -96,6 +107,7 @@ Commands:
                                 project into the timeline
 
   summary [--date DATE | --last Nd | --from DATE --to DATE]
+          [--include TYPES] [--detail-limit N] [--with-git]
           [--prompt TEXT] [--force] [--model NAME] [-y]
                                 Generate an LLM summary via the claude
                                 CLI. A single day produces a daily
@@ -106,12 +118,21 @@ Commands:
                                 (e.g. --last 7d)
     --from YYYY-MM-DD           Range start (use with --to)
     --to YYYY-MM-DD             Range end (use with --from)
+    --include TYPES             Activity types fed to the LLM
+                                (same shape as report's --include)
+    --detail-limit N            Max chars per activity detail in the
+                                LLM payload (0 = unlimited)
+    --with-git                  Merge git commits into the LLM payload
     --prompt TEXT               Override prompt for this run (daily only)
     --force                     Regenerate even if cached
     --model NAME                Pass --model to claude (e.g. "sonnet",
                                 "haiku", or a full model id)
     -y, --yes                   Skip confirmation prompts for new daily
                                 summaries
+
+  Defaults for report and summary live under \`report:\` and \`summary:\`
+  in ~/.agenthud/config.yaml. Flags override config values per-run; the
+  effective values are printed to stderr at the start of each run.
 
 Global options:
   -V, --version                 Show version number
@@ -157,12 +178,44 @@ function parseLocalMidnight(dateStr: string): Date | null {
   return date;
 }
 
+/**
+ * One-line stderr summary of the options that report/summary just
+ * resolved through the flag → config → default hierarchy. The line is
+ * informational, not actionable — values only, no `(flag)`/`(config)`
+ * source markers (read the yaml if you need to know).
+ */
+export function formatEffectiveOptionsLine(
+  command: "report" | "summary",
+  fields: {
+    include: string[];
+    detailLimit?: number;
+    withGit: boolean;
+    format?: "markdown" | "json";
+    model?: string;
+  },
+): string {
+  const parts: string[] = [];
+  parts.push(`include=[${fields.include.join(",")}]`);
+  if (fields.detailLimit !== undefined) {
+    parts.push(
+      `detail-limit=${fields.detailLimit === 0 ? "∞" : fields.detailLimit}`,
+    );
+  }
+  parts.push(`with-git=${fields.withGit ? "on" : "off"}`);
+  if (fields.format) parts.push(`format=${fields.format}`);
+  if (fields.model) parts.push(`model=${fields.model}`);
+  return `agenthud: ${command} → ${parts.join(" ")}`;
+}
+
 function todayLocalMidnight(): Date {
   const now = new Date();
   return new Date(now.getFullYear(), now.getMonth(), now.getDate());
 }
 
-export function parseArgs(args: string[]): CliOptions {
+export function parseArgs(
+  args: string[],
+  config?: GlobalConfig,
+): CliOptions {
   // `watch` is the explicit form of the default mode — strip it so the
   // rest of parsing sees the same shape it always has.
   if (args[0] === "watch") args = args.slice(1);
@@ -181,7 +234,7 @@ export function parseArgs(args: string[]): CliOptions {
   if (args[0] === "report") {
     const rest = args.slice(1);
     let reportDate = todayLocalMidnight();
-    let reportInclude = DEFAULT_TYPES;
+    let reportInclude = config?.report.include ?? DEFAULT_INCLUDE_TYPES;
     let reportError: string | undefined;
 
     // Check for unknown flags in report subcommand. Skip the value
@@ -239,7 +292,7 @@ export function parseArgs(args: string[]): CliOptions {
       }
     }
 
-    let reportFormat: "markdown" | "json" = "markdown";
+    let reportFormat: "markdown" | "json" = config?.report.format ?? "markdown";
     const formatIdx = rest.indexOf("--format");
     if (formatIdx !== -1) {
       const fmt = rest[formatIdx + 1];
@@ -252,7 +305,7 @@ export function parseArgs(args: string[]): CliOptions {
       }
     }
 
-    let reportDetailLimit: number | undefined;
+    let reportDetailLimit: number | undefined = config?.report.detailLimit;
     const detailLimitIdx = rest.indexOf("--detail-limit");
     if (detailLimitIdx !== -1) {
       const val = rest[detailLimitIdx + 1];
@@ -264,7 +317,8 @@ export function parseArgs(args: string[]): CliOptions {
       }
     }
 
-    const reportWithGit = rest.includes("--with-git");
+    const reportWithGit =
+      rest.includes("--with-git") || (config?.report.withGit ?? false);
 
     return {
       mode: "report",
@@ -295,6 +349,9 @@ export function parseArgs(args: string[]): CliOptions {
       "--to",
       "--prompt",
       "--model",
+      "--include",
+      "--format",
+      "--detail-limit",
     ]);
 
     for (let i = 0; i < rest.length; i++) {
@@ -412,6 +469,76 @@ export function parseArgs(args: string[]): CliOptions {
     if (rest.includes("--force")) summaryForce = true;
     if (rest.includes("-y") || rest.includes("--yes")) summaryAssumeYes = true;
 
+    // Resolve report-shaped options for summary:
+    //   CLI flag → config.summary.X → config.report.X → built-in default.
+    let summaryInclude: string[] =
+      config?.summary.include ??
+      config?.report.include ??
+      DEFAULT_INCLUDE_TYPES;
+    const summaryIncludeIdx = rest.indexOf("--include");
+    if (summaryIncludeIdx !== -1) {
+      const includeStr = rest[summaryIncludeIdx + 1];
+      if (!includeStr) {
+        summaryError = summaryError ?? "Invalid --include: missing value.";
+      } else if (includeStr === "all") {
+        summaryInclude = ALL_TYPES;
+      } else {
+        const tokens = includeStr
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const unknown = tokens.filter((t) => !ALL_TYPES.includes(t));
+        if (unknown.length > 0) {
+          summaryError =
+            summaryError ??
+            `Unknown --include type${unknown.length > 1 ? "s" : ""}: ${unknown
+              .map((u) => `"${u}"`)
+              .join(", ")}. Valid types: ${ALL_TYPES.join(", ")} (or "all").`;
+        } else {
+          summaryInclude = tokens;
+        }
+      }
+    }
+
+    let summaryFormat: "markdown" | "json" =
+      config?.summary.format ?? config?.report.format ?? "markdown";
+    const summaryFormatIdx = rest.indexOf("--format");
+    if (summaryFormatIdx !== -1) {
+      const fmt = rest[summaryFormatIdx + 1];
+      if (fmt === "json" || fmt === "markdown") {
+        summaryFormat = fmt;
+      } else if (fmt) {
+        summaryError =
+          summaryError ?? `Invalid format: "${fmt}". Use "markdown" or "json".`;
+      } else {
+        summaryError =
+          summaryError ?? "Invalid format: missing value for --format.";
+      }
+    }
+
+    let summaryDetailLimit: number | undefined =
+      config?.summary.detailLimit ?? config?.report.detailLimit;
+    const summaryDetailLimitIdx = rest.indexOf("--detail-limit");
+    if (summaryDetailLimitIdx !== -1) {
+      const val = rest[summaryDetailLimitIdx + 1];
+      const n = Number(val);
+      if (!val || Number.isNaN(n) || n < 0 || !Number.isInteger(n)) {
+        summaryError =
+          summaryError ??
+          `Invalid --detail-limit: "${val}". Must be a non-negative integer.`;
+      } else {
+        summaryDetailLimit = n;
+      }
+    }
+
+    const summaryWithGit =
+      rest.includes("--with-git") ||
+      (config?.summary.withGit ?? config?.report.withGit ?? false);
+
+    if (summaryModel === undefined && config?.summary.model) {
+      summaryModel = config.summary.model;
+    }
+
     return {
       mode: "summary",
       summaryDate,
@@ -421,6 +548,10 @@ export function parseArgs(args: string[]): CliOptions {
       summaryForce,
       summaryAssumeYes,
       summaryModel,
+      summaryInclude,
+      summaryFormat,
+      summaryDetailLimit,
+      summaryWithGit,
       summaryError,
     };
   }

--- a/src/config/globalConfig.ts
+++ b/src/config/globalConfig.ts
@@ -7,6 +7,27 @@ import type { GlobalConfig } from "../types/index.js";
 const CONFIG_PATH = join(homedir(), ".agenthud", "config.yaml");
 const STATE_PATH = join(homedir(), ".agenthud", "state.yaml");
 
+// The canonical built-in include set. report and summary both lean on
+// this when neither the CLI flag nor the user config narrows it down.
+export const DEFAULT_INCLUDE_TYPES = [
+  "user",
+  "response",
+  "bash",
+  "edit",
+  "thinking",
+];
+
+const ALLOWED_INCLUDE_TYPES = new Set([
+  "user",
+  "response",
+  "bash",
+  "edit",
+  "thinking",
+  "read",
+  "glob",
+  "commit",
+]);
+
 export const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {
   refreshIntervalMs: 2000,
   hiddenSessions: [],
@@ -15,6 +36,13 @@ export const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {
   // commits-only preset filters down to git activity.
   filterPresets: [[], ["response", "user"], ["commit"]],
   hiddenProjects: [],
+  report: {
+    include: [...DEFAULT_INCLUDE_TYPES],
+    detailLimit: 120,
+    withGit: false,
+    format: "markdown",
+  },
+  summary: {},
 };
 
 const ALL_PRESET_KEYWORDS = new Set(["all", "*", "any"]);
@@ -51,6 +79,26 @@ filterPresets:
   - ["all"]
   - ["response", "user"]
   - ["commit"]
+
+# Defaults for \`agenthud report\` (CLI flags still win per-invocation).
+# include: activity types to keep. Types: user, response, bash, edit,
+#          thinking, read, glob.
+# detailLimit: max chars per activity detail (0 = unlimited).
+# withGit: merge git commits from each session's project.
+# format: markdown | json.
+report:
+  include: [user, response, bash, edit, thinking]
+  detailLimit: 120
+  withGit: false
+  format: markdown
+
+# Defaults for \`agenthud summary\`. Any field omitted here is inherited
+# from \`report\` above. \`model\` is summary-specific and passed to
+# \`claude --model\` (e.g. sonnet, haiku, or a full model id).
+summary:
+  withGit: true
+  detailLimit: 0
+  # model: sonnet
 `;
   try {
     writeFileSync(CONFIG_PATH, defaultYaml, "utf-8");
@@ -92,7 +140,20 @@ function rewriteConfigWithoutHideFields(raw: Record<string, unknown>): void {
 }
 
 export function loadGlobalConfig(): GlobalConfig {
-  const config = { ...DEFAULT_GLOBAL_CONFIG };
+  // Deep-clone the defaults so per-call mutations (e.g. assigning
+  // config.report.withGit) don't leak into the shared default record.
+  const config: GlobalConfig = {
+    ...DEFAULT_GLOBAL_CONFIG,
+    hiddenSessions: [...DEFAULT_GLOBAL_CONFIG.hiddenSessions],
+    hiddenSubAgents: [...DEFAULT_GLOBAL_CONFIG.hiddenSubAgents],
+    hiddenProjects: [...DEFAULT_GLOBAL_CONFIG.hiddenProjects],
+    filterPresets: DEFAULT_GLOBAL_CONFIG.filterPresets.map((p) => [...p]),
+    report: {
+      ...DEFAULT_GLOBAL_CONFIG.report,
+      include: [...DEFAULT_GLOBAL_CONFIG.report.include],
+    },
+    summary: { ...DEFAULT_GLOBAL_CONFIG.summary },
+  };
 
   // Read config.yaml (non-hide settings)
   let configRaw: Record<string, unknown> = {};
@@ -124,6 +185,44 @@ export function loadGlobalConfig(): GlobalConfig {
         return normalizePreset(tokens);
       });
     if (presets.length > 0) config.filterPresets = presets;
+  }
+
+  if (configRaw.report && typeof configRaw.report === "object") {
+    const r = configRaw.report as Record<string, unknown>;
+    // Each field is validated independently — a single bogus key drops
+    // back to the built-in default for that field, leaving the rest of
+    // the section intact.
+    if (Array.isArray(r.include)) {
+      const tokens = (r.include as unknown[]).filter(
+        (t): t is string => typeof t === "string",
+      );
+      const cleaned = tokens.filter((t) => ALLOWED_INCLUDE_TYPES.has(t));
+      if (cleaned.length > 0) config.report.include = cleaned;
+    }
+    if (typeof r.detailLimit === "number" && Number.isInteger(r.detailLimit) && r.detailLimit >= 0) {
+      config.report.detailLimit = r.detailLimit;
+    }
+    if (typeof r.withGit === "boolean") config.report.withGit = r.withGit;
+    if (r.format === "markdown" || r.format === "json") config.report.format = r.format;
+  }
+
+  if (configRaw.summary && typeof configRaw.summary === "object") {
+    const s = configRaw.summary as Record<string, unknown>;
+    if (Array.isArray(s.include)) {
+      const tokens = (s.include as unknown[]).filter(
+        (t): t is string => typeof t === "string",
+      );
+      const cleaned = tokens.filter((t) => ALLOWED_INCLUDE_TYPES.has(t));
+      if (cleaned.length > 0) config.summary.include = cleaned;
+    }
+    if (typeof s.detailLimit === "number" && Number.isInteger(s.detailLimit) && s.detailLimit >= 0) {
+      config.summary.detailLimit = s.detailLimit;
+    }
+    if (typeof s.withGit === "boolean") config.summary.withGit = s.withGit;
+    if (s.format === "markdown" || s.format === "json") config.summary.format = s.format;
+    if (typeof s.model === "string" && s.model.trim().length > 0) {
+      config.summary.model = s.model.trim();
+    }
   }
 
   // Detect legacy hide fields in config.yaml for migration

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -22,6 +22,12 @@ export interface SummaryOptions {
   today: Date;
   /** Forwarded to `claude --model` (e.g. "sonnet", "haiku", or full model ID). */
   model?: string;
+  /** Activity types fed into the LLM payload (resolved by CLI + config). */
+  include: string[];
+  /** Max chars per activity detail (0 = unlimited). */
+  detailLimit: number;
+  /** Whether to merge git commits into the LLM payload. */
+  withGit: boolean;
 }
 
 export interface RangeSummaryOptions {
@@ -31,6 +37,12 @@ export interface RangeSummaryOptions {
   force: boolean;
   assumeYes: boolean;
   model?: string;
+  /** Activity types fed into the per-day LLM payload. */
+  include: string[];
+  /** Max chars per activity detail in the per-day payload (0 = unlimited). */
+  detailLimit: number;
+  /** Whether to merge git commits into the per-day payload. */
+  withGit: boolean;
 }
 
 type PromptKind = "daily" | "range";
@@ -349,6 +361,12 @@ interface DailyGenOpts {
   assumeYes?: boolean;
   /** Forwarded to `claude --model`. */
   model?: string;
+  /** Activity types fed into the LLM payload. */
+  include: string[];
+  /** Max chars per activity detail (0 = unlimited). */
+  detailLimit: number;
+  /** Whether to merge git commits into the LLM payload. */
+  withGit: boolean;
 }
 
 /**
@@ -411,10 +429,13 @@ async function generateDailySummary(
   ];
   const reportMarkdown = generateReport(flatSessions, {
     date: opts.date,
-    include: ["response", "bash", "edit", "thinking"],
+    include: opts.include,
+    // The LLM only ingests markdown — the format option on summary is
+    // for the report-extraction *export* surface (post-LLM), not for
+    // the payload itself, so this stays fixed.
     format: "markdown",
-    detailLimit: 0,
-    withGit: true,
+    detailLimit: opts.detailLimit,
+    withGit: opts.withGit,
   });
 
   const reportBytes = Buffer.byteLength(reportMarkdown, "utf-8");
@@ -513,6 +534,9 @@ export async function runSummary(options: SummaryOptions): Promise<number> {
     streamToStdout: true,
     announce: true,
     model: options.model,
+    include: options.include,
+    detailLimit: options.detailLimit,
+    withGit: options.withGit,
   });
   return res.code;
 }
@@ -593,6 +617,9 @@ export async function runRangeSummary(
       confirmBeforeSpawn: confirmer,
       assumeYes: options.assumeYes,
       model: options.model,
+      include: options.include,
+      detailLimit: options.detailLimit,
+      withGit: options.withGit,
     });
 
     if (res.skipped) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,12 @@ import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { render } from "ink";
 import React from "react";
-import { getHelp, getVersion, parseArgs } from "./cli.js";
+import {
+  formatEffectiveOptionsLine,
+  getHelp,
+  getVersion,
+  parseArgs,
+} from "./cli.js";
 import { loadGlobalConfig } from "./config/globalConfig.js";
 import { generateReport } from "./data/reportGenerator.js";
 import {
@@ -18,7 +23,10 @@ import { App } from "./ui/App.js";
 import { enterAltScreen, installAltScreenCleanup } from "./utils/altScreen.js";
 import { isLegacyProjectConfig } from "./utils/legacyConfig.js";
 
-const options = parseArgs(process.argv.slice(2));
+// Load config up front so parseArgs can layer flags over user defaults
+// (report.* / summary.* keys in ~/.agenthud/config.yaml).
+const globalConfig = loadGlobalConfig();
+const options = parseArgs(process.argv.slice(2), globalConfig);
 
 if (options.error) {
   process.stderr.write(`agenthud: ${options.error}\n`);
@@ -65,8 +73,15 @@ if (options.mode === "report") {
     process.stderr.write(`agenthud: ${options.reportError}\n`);
     process.exit(1);
   }
-  const config = loadGlobalConfig();
-  const tree = discoverSessions(config);
+  process.stderr.write(
+    `${formatEffectiveOptionsLine("report", {
+      include: options.reportInclude!,
+      detailLimit: options.reportDetailLimit,
+      withGit: options.reportWithGit ?? false,
+      format: options.reportFormat,
+    })}\n`,
+  );
+  const tree = discoverSessions(globalConfig);
   const flatSessions = [
     ...tree.projects.flatMap((p) => p.sessions),
     ...tree.coldProjects.flatMap((p) => p.sessions),
@@ -88,6 +103,14 @@ if (options.mode === "summary") {
     process.stderr.write(`agenthud: ${options.summaryError}\n`);
     process.exit(1);
   }
+  process.stderr.write(
+    `${formatEffectiveOptionsLine("summary", {
+      include: options.summaryInclude!,
+      detailLimit: options.summaryDetailLimit,
+      withGit: options.summaryWithGit ?? false,
+      model: options.summaryModel,
+    })}\n`,
+  );
   const today = new Date();
   if (options.summaryFrom && options.summaryTo) {
     const exitCode = await runRangeSummary({
@@ -97,6 +120,9 @@ if (options.mode === "summary") {
       force: options.summaryForce ?? false,
       assumeYes: options.summaryAssumeYes ?? false,
       model: options.summaryModel,
+      include: options.summaryInclude!,
+      detailLimit: options.summaryDetailLimit!,
+      withGit: options.summaryWithGit!,
     });
     process.exit(exitCode);
   }
@@ -106,6 +132,9 @@ if (options.mode === "summary") {
     force: options.summaryForce ?? false,
     today,
     model: options.summaryModel,
+    include: options.summaryInclude!,
+    detailLimit: options.summaryDetailLimit!,
+    withGit: options.summaryWithGit!,
   });
   process.exit(exitCode);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,12 +39,41 @@ export interface SessionTree {
 }
 
 // Global config (~/.agenthud/config.yaml)
+/**
+ * Defaults shared by `agenthud report` and (via inheritance) by the
+ * report half of `agenthud summary`. CLI flags override these per
+ * invocation; this struct is what the user puts in
+ * `~/.agenthud/config.yaml` under the `report:` key.
+ */
+export interface ReportConfig {
+  include: string[]; // activity types to include
+  detailLimit: number; // max chars per activity detail (0 = unlimited)
+  withGit: boolean; // merge git commits into the timeline
+  format: "markdown" | "json"; // output format
+}
+
+/**
+ * Per-config overrides for `agenthud summary`. Any field left
+ * undefined falls back to the matching `ReportConfig` field — so the
+ * user can pin one shape under `report:` and have summary inherit it.
+ * The `model` key is summary-specific (no equivalent on report).
+ */
+export interface SummaryConfig {
+  include?: string[];
+  detailLimit?: number;
+  withGit?: boolean;
+  format?: "markdown" | "json";
+  model?: string;
+}
+
 export interface GlobalConfig {
   refreshIntervalMs: number; // default: 2000
   hiddenSessions: string[];
   hiddenSubAgents: string[];
   filterPresets: string[][]; // [] = all; default: [[], ["response", "user"], ["commit"]]
   hiddenProjects: string[]; // by projectName
+  report: ReportConfig;
+  summary: SummaryConfig;
 }
 
 // Centralized icon definitions

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { getHelp, parseArgs } from "../src/cli.js";
+import { DEFAULT_GLOBAL_CONFIG } from "../src/config/globalConfig.js";
+import {
+  formatEffectiveOptionsLine,
+  getHelp,
+  parseArgs,
+} from "../src/cli.js";
+import type { GlobalConfig } from "../src/types/index.js";
+
+function makeConfig(overrides: Partial<GlobalConfig> = {}): GlobalConfig {
+  return {
+    ...DEFAULT_GLOBAL_CONFIG,
+    ...overrides,
+    report: { ...DEFAULT_GLOBAL_CONFIG.report, ...(overrides.report ?? {}) },
+    summary: { ...DEFAULT_GLOBAL_CONFIG.summary, ...(overrides.summary ?? {}) },
+  };
+}
 
 describe("parseArgs", () => {
   it("defaults to watch mode", () => {
@@ -227,6 +242,47 @@ describe("parseArgs", () => {
       const opts = parseArgs(["report"]);
       expect(opts.reportWithGit).toBeFalsy();
     });
+
+    describe("config-driven defaults", () => {
+      it("uses config.report values when no flag is given", () => {
+        const config = makeConfig({
+          report: {
+            include: ["bash", "edit"],
+            detailLimit: 50,
+            withGit: true,
+            format: "json",
+          },
+        });
+        const opts = parseArgs(["report"], config);
+        expect(opts.reportInclude).toEqual(["bash", "edit"]);
+        expect(opts.reportDetailLimit).toBe(50);
+        expect(opts.reportWithGit).toBe(true);
+        expect(opts.reportFormat).toBe("json");
+      });
+
+      it("CLI flag overrides config for --include", () => {
+        const config = makeConfig({
+          report: { ...DEFAULT_GLOBAL_CONFIG.report, include: ["bash"] },
+        });
+        const opts = parseArgs(["report", "--include", "edit"], config);
+        expect(opts.reportInclude).toEqual(["edit"]);
+      });
+
+      it("CLI flag overrides config for --with-git (--with-git on)", () => {
+        const config = makeConfig({
+          report: { ...DEFAULT_GLOBAL_CONFIG.report, withGit: false },
+        });
+        const opts = parseArgs(["report", "--with-git"], config);
+        expect(opts.reportWithGit).toBe(true);
+      });
+
+      it("falls back to the built-in defaults when no config is passed", () => {
+        const opts = parseArgs(["report"]);
+        expect(opts.reportInclude).toEqual(
+          DEFAULT_GLOBAL_CONFIG.report.include,
+        );
+      });
+    });
   });
 
   describe("summary subcommand", () => {
@@ -382,6 +438,138 @@ describe("parseArgs", () => {
       const opts = parseArgs(["summary"]);
       expect(opts.summaryModel).toBeUndefined();
     });
+
+    describe("report-shaped options on summary", () => {
+      it("parses --include and threads it through", () => {
+        const opts = parseArgs(["summary", "--include", "response,user"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryInclude).toEqual(["response", "user"]);
+      });
+
+      it("parses --include all", () => {
+        const opts = parseArgs(["summary", "--include", "all"]);
+        expect(opts.summaryInclude).toEqual([
+          "response",
+          "bash",
+          "edit",
+          "thinking",
+          "read",
+          "glob",
+          "user",
+        ]);
+      });
+
+      it("parses --detail-limit", () => {
+        const opts = parseArgs(["summary", "--detail-limit", "0"]);
+        expect(opts.summaryDetailLimit).toBe(0);
+      });
+
+      it("parses --with-git", () => {
+        const opts = parseArgs(["summary", "--with-git"]);
+        expect(opts.summaryWithGit).toBe(true);
+      });
+
+      it("parses --format json", () => {
+        const opts = parseArgs(["summary", "--format", "json"]);
+        expect(opts.summaryFormat).toBe("json");
+      });
+    });
+
+    describe("config-driven defaults", () => {
+      it("inherits report.* when summary section is empty", () => {
+        const config = makeConfig({
+          report: {
+            include: ["bash", "edit"],
+            detailLimit: 50,
+            withGit: true,
+            format: "json",
+          },
+          summary: {},
+        });
+        const opts = parseArgs(["summary"], config);
+        expect(opts.summaryInclude).toEqual(["bash", "edit"]);
+        expect(opts.summaryDetailLimit).toBe(50);
+        expect(opts.summaryWithGit).toBe(true);
+        expect(opts.summaryFormat).toBe("json");
+      });
+
+      it("summary.* overrides report.* field-by-field", () => {
+        const config = makeConfig({
+          report: {
+            include: ["bash"],
+            detailLimit: 50,
+            withGit: false,
+            format: "markdown",
+          },
+          summary: {
+            include: ["edit"],
+            detailLimit: 0,
+            withGit: true,
+            model: "haiku",
+          },
+        });
+        const opts = parseArgs(["summary"], config);
+        expect(opts.summaryInclude).toEqual(["edit"]);
+        expect(opts.summaryDetailLimit).toBe(0);
+        expect(opts.summaryWithGit).toBe(true);
+        // format unset on summary → falls back to report
+        expect(opts.summaryFormat).toBe("markdown");
+        expect(opts.summaryModel).toBe("haiku");
+      });
+
+      it("CLI flag beats both summary and report config", () => {
+        const config = makeConfig({
+          report: { ...DEFAULT_GLOBAL_CONFIG.report, include: ["bash"] },
+          summary: { include: ["edit"] },
+        });
+        const opts = parseArgs(["summary", "--include", "user"], config);
+        expect(opts.summaryInclude).toEqual(["user"]);
+      });
+
+      it("falls back to the built-in defaults when no config is passed", () => {
+        const opts = parseArgs(["summary"]);
+        expect(opts.summaryInclude).toEqual(
+          DEFAULT_GLOBAL_CONFIG.report.include,
+        );
+      });
+    });
+  });
+});
+
+describe("formatEffectiveOptionsLine", () => {
+  it("formats report defaults compactly", () => {
+    const line = formatEffectiveOptionsLine("report", {
+      include: ["user", "response", "bash", "edit", "thinking"],
+      detailLimit: 120,
+      withGit: false,
+      format: "markdown",
+    });
+    expect(line).toBe(
+      "agenthud: report → include=[user,response,bash,edit,thinking] detail-limit=120 with-git=off format=markdown",
+    );
+  });
+
+  it("renders detailLimit=0 as ∞ and with-git=true as on", () => {
+    const line = formatEffectiveOptionsLine("summary", {
+      include: ["bash"],
+      detailLimit: 0,
+      withGit: true,
+      model: "sonnet",
+    });
+    expect(line).toBe(
+      "agenthud: summary → include=[bash] detail-limit=∞ with-git=on model=sonnet",
+    );
+  });
+
+  it("omits format/model when not set", () => {
+    const line = formatEffectiveOptionsLine("report", {
+      include: ["response"],
+      detailLimit: 120,
+      withGit: false,
+    });
+    expect(line).toContain("include=[response]");
+    expect(line).not.toContain("format=");
+    expect(line).not.toContain("model=");
   });
 });
 

--- a/tests/config/globalConfig.test.ts
+++ b/tests/config/globalConfig.test.ts
@@ -324,6 +324,102 @@ describe("hasProjectLevelConfig", () => {
   });
 });
 
+describe("report/summary config", () => {
+  it("returns built-in report defaults when the section is absent", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue("refreshInterval: 2s\n");
+    const cfg = loadGlobalConfig();
+    expect(cfg.report.include).toEqual([
+      "user",
+      "response",
+      "bash",
+      "edit",
+      "thinking",
+    ]);
+    expect(cfg.report.detailLimit).toBe(120);
+    expect(cfg.report.withGit).toBe(false);
+    expect(cfg.report.format).toBe("markdown");
+  });
+
+  it("parses a report section and overrides defaults field-by-field", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(`report:
+  include: [response, edit]
+  detailLimit: 0
+  withGit: true
+  format: json
+`);
+    const cfg = loadGlobalConfig();
+    expect(cfg.report.include).toEqual(["response", "edit"]);
+    expect(cfg.report.detailLimit).toBe(0);
+    expect(cfg.report.withGit).toBe(true);
+    expect(cfg.report.format).toBe("json");
+  });
+
+  it("partial report section overrides only the named fields", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(`report:
+  withGit: true
+`);
+    const cfg = loadGlobalConfig();
+    expect(cfg.report.withGit).toBe(true);
+    // unspecified fields fall back to the built-in default
+    expect(cfg.report.include).toEqual([
+      "user",
+      "response",
+      "bash",
+      "edit",
+      "thinking",
+    ]);
+    expect(cfg.report.detailLimit).toBe(120);
+    expect(cfg.report.format).toBe("markdown");
+  });
+
+  it("summary section is empty when absent (inherits from report at use-site)", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue("refreshInterval: 2s\n");
+    const cfg = loadGlobalConfig();
+    expect(cfg.summary).toEqual({});
+  });
+
+  it("summary section captures the keys the user pinned", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(`summary:
+  withGit: true
+  detailLimit: 0
+  model: sonnet
+`);
+    const cfg = loadGlobalConfig();
+    expect(cfg.summary.withGit).toBe(true);
+    expect(cfg.summary.detailLimit).toBe(0);
+    expect(cfg.summary.model).toBe("sonnet");
+    // include/format unset → undefined so the caller can fall back to report.*
+    expect(cfg.summary.include).toBeUndefined();
+    expect(cfg.summary.format).toBeUndefined();
+  });
+
+  it("rejects bogus values silently and falls back to defaults", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(`report:
+  include: "not-an-array"
+  detailLimit: "not-a-number"
+  withGit: "yes"
+  format: "html"
+`);
+    const cfg = loadGlobalConfig();
+    expect(cfg.report.include).toEqual([
+      "user",
+      "response",
+      "bash",
+      "edit",
+      "thinking",
+    ]);
+    expect(cfg.report.detailLimit).toBe(120);
+    expect(cfg.report.withGit).toBe(false);
+    expect(cfg.report.format).toBe("markdown");
+  });
+});
+
 describe("hideSession - writes to state.yaml (explicit path check)", () => {
   it("writes to state.yaml path", () => {
     vi.mocked(existsSync).mockReturnValue(false);


### PR DESCRIPTION
Closes #105

## Summary
v0.12.0. Two related changes that kill the drift bug from v0.11.2 and
give users real control over the LLM payload.

### 1. report/summary defaults move into the user config

New `report:` and `summary:` sections in `~/.agenthud/config.yaml`:

\`\`\`yaml
report:
  include: [user, response, bash, edit, thinking]
  detailLimit: 120
  withGit: false
  format: markdown

summary:
  withGit: true   # LLM benefits from commit context
  detailLimit: 0  # unlimited
  # model: sonnet
\`\`\`

Resolution order: \`CLI flag → summary.* → report.* → built-in default\`.
\`summary:\` inherits any field omitted from it.

A single shared \`DEFAULT_INCLUDE_TYPES\` constant means v0.11.2's "add
user to default" fix actually reaches summary now (it was lost behind
a hardcoded literal).

### 2. \`summary\` exposes the same option surface as \`report\`

New flags: \`--include\`, \`--detail-limit\`, \`--with-git\`,
\`--format\`. Same parser as \`report\`, same defaults. Lets you tune
what claude actually sees from the command line.

### 3. Effective options on stderr

Every \`report\` / \`summary\` run now prints one line on stderr at
startup:

\`\`\`
agenthud: report → include=[user,response,bash,edit,thinking] detail-limit=120 with-git=off format=markdown
\`\`\`

Values only, no \`(flag)\` / \`(config)\` source tags — read the yaml
if you need to know where a value came from. Removes the "wait, what
default am I using?" friction.

## Implementation
- New types: \`ReportConfig\`, \`SummaryConfig\` in \`types/index.ts\`.
- \`DEFAULT_INCLUDE_TYPES\` and per-field validators in
  \`globalConfig.ts\`. Bogus yaml values are silently dropped back to
  the built-in default for that field.
- \`parseArgs(args, config?)\` — config arg is optional so existing
  tests keep their bare-args calls and still pass.
- \`summaryRunner.runSummary\` / \`runRangeSummary\` take
  include/detailLimit/withGit through to \`generateDailySummary\`. The
  hardcoded \`["response","bash","edit","thinking"]\` literal is gone.
- \`formatEffectiveOptionsLine\` helper in \`cli.ts\`, unit-tested.
- \`main.ts\` loads \`globalConfig\` once and threads it.

## Upgrade
Existing config files are NOT auto-migrated. The new sections are
written only when the file does not yet exist (\`writeDefaultConfig\`).
Upgrading users keep the v0.11.4 behavior (built-in defaults). To
pin preferences, paste the example block from the README.

## Tests
- Config parser: defaults when section absent, full override, partial
  override, summary inheritance, bogus-value rejection.
- CLI: flag wins over config; config.summary wins over config.report;
  config.report wins over built-in; bare \`parseArgs\` (no config)
  falls back to built-in. New summary option parsers + validators.
- \`formatEffectiveOptionsLine\`: defaults, \`∞\`/\`on\` rendering,
  optional fields.
- 444/444 tests pass.

## Test plan
- [x] \`npx vitest run\` — 444/444 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [x] Smoke: \`node dist/index.js report --date -1d\` prints the
      effective-options line + the report; user prompts now appear at
      the head of each session block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.12.0

* **New Features**
  * Added configurable defaults for `report` and `summary` commands via `~/.agenthud/config.yaml`.
  * Summary command now supports the same options as report: `--include`, `--detail-limit`, `--format`, `--with-git`.
  * Effective resolved options now printed to stderr at start of each run.

* **Bug Fixes**
  * Fixed summary daily payload generation no longer dropping user prompts.

* **Documentation**
  * Updated configuration guide with new report/summary default sections and option precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->