### PR TITLE
fix: cold sub-agent nav + add left-arrow "jump to parent"

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -51,7 +51,17 @@ function subSummarySentinel(parentId: string): SessionNode {
   };
 }
 
-function appendSubAgentRows(
+/**
+ * Append the sub-agent rows for `session` onto `result` per the same
+ * expand-state rules the renderer uses. Exported for unit testing.
+ *
+ * Cold sessions hide their sub-agents by default and only show them
+ * when the user explicitly expanded the session (Enter on the row,
+ * which adds `__expanded-session-<id>` to expandedIds). When that flag
+ * is present the entire sub-agent list is included — not just
+ * hot/warm — to match the renderer.
+ */
+export function appendSubAgentRows(
   result: SessionNode[],
   session: SessionNode,
   expandedIds: Set<string>,
@@ -65,7 +75,16 @@ function appendSubAgentRows(
 
   if (sessionHidden) return;
 
-  if (expandedIds.has(session.id)) {
+  // Match SessionTreePanel's "subAgentsFullyExpanded" rule. A cold
+  // session expanded via Enter writes `__expanded-session-<id>` to
+  // expandedIds — that should produce the full sub-agent list here
+  // too, otherwise the renderer shows every sub-agent but App's
+  // allFlat misses them and j/k go silent (selectedIndex = -1).
+  const subAgentsFullyExpanded =
+    expandedIds.has(session.id) ||
+    (isCold && expandedIds.has(sessionExpandedKey));
+
+  if (subAgentsFullyExpanded) {
     result.push(...session.subAgents);
   } else {
     result.push(
@@ -265,6 +284,52 @@ function collectAllIds(tree: SessionTree): Set<string> {
  * would be -1 against an empty hot list and the navigation handlers
  * short-circuit on that).
  */
+/**
+ * Pick the selection target for "jump up one level" (left arrow / `h`)
+ * given the current selected id.
+ *
+ * - Sub-agent row → the parent session it belongs to.
+ * - Sub-summary sentinel (`__sub-<sid>__`) → that session.
+ * - Plain session row → the project sentinel that contains it.
+ * - Project sentinel / cold-projects sentinel → the previous flat row
+ *   (acts like an up-arrow at the top level so users can still climb
+ *   out of the project group they're sitting in).
+ */
+export function findParentTarget(
+  currentId: string,
+  tree: SessionTree,
+  flat: SessionNode[],
+): string | null {
+  // sub-summary sentinel → parent session id encoded in the sentinel
+  if (currentId.startsWith("__sub-") && currentId.endsWith("__")) {
+    return currentId.slice("__sub-".length, -"__".length);
+  }
+
+  const allProjects = [...tree.projects, ...tree.coldProjects];
+  const allSessions = allProjects.flatMap((p) => p.sessions);
+
+  // sub-agent → containing session
+  for (const session of allSessions) {
+    if (session.subAgents.some((sa) => sa.id === currentId)) {
+      return session.id;
+    }
+  }
+
+  // session → project sentinel
+  for (const project of allProjects) {
+    if (project.sessions.some((s) => s.id === currentId)) {
+      return `__proj-${project.name}__`;
+    }
+  }
+
+  // project sentinel / cold-projects sentinel / unknown row →
+  // previous row in the flat list. Falls back to current when already
+  // at the top so the cursor doesn't jump to a phantom id.
+  const idx = flat.findIndex((row) => row.id === currentId);
+  if (idx <= 0) return currentId;
+  return flat[idx - 1]?.id ?? currentId;
+}
+
 export function initialSelectedId(tree: SessionTree): string | null {
   const firstProject = tree.projects[0];
   if (firstProject) return `__proj-${firstProject.name}__`;
@@ -636,6 +701,13 @@ export function App({
       });
     },
     trackingOn: tracking,
+    onJumpToParent: () => {
+      if (focus !== "tree") return;
+      stopTracking();
+      if (!selectedId) return;
+      const target = findParentTarget(selectedId, sessionTree, allFlat);
+      if (target && target !== selectedId) setSelectedId(target);
+    },
     onSwitchFocus: () => setFocus((f) => (f === "tree" ? "viewer" : "tree")),
     // cursorLine = "entries back from the newest" (0 = newest = bottom row).
     // Up arrow moves visually upward = older direction = cursorLine++.

--- a/src/ui/HelpPanel.tsx
+++ b/src/ui/HelpPanel.tsx
@@ -14,6 +14,7 @@ const SECTIONS: HelpSection[] = [
     title: "Project tree",
     rows: [
       ["↑ ↓ / k j", "Move selection"],
+      ["←", "Jump to parent (sub-agent → session, session → project)"],
       ["PgUp / Ctrl+B", "Page up"],
       ["PgDn / Ctrl+F", "Page down"],
       ["↵", "Expand/collapse project, session, or summary"],

--- a/src/ui/hooks/useHotkeys.ts
+++ b/src/ui/hooks/useHotkeys.ts
@@ -25,6 +25,9 @@ interface UseHotkeysOptions {
   onHelpScroll?: (delta: number) => void;
   onHelpScrollToTop?: () => void;
   onToggleTracking?: () => void;
+  /** Tree only: jump to the parent of the current row (sub-agent →
+   * session, session → project, project → previous row). */
+  onJumpToParent?: () => void;
   filterLabel: string; // e.g. "all", "response", "commit"
   trackingOn?: boolean;
 }
@@ -41,6 +44,8 @@ export interface UseHotkeysResult {
       return: boolean;
       ctrl: boolean;
       escape?: boolean;
+      leftArrow?: boolean;
+      rightArrow?: boolean;
     },
   ) => void;
   statusBarItems: string[];
@@ -73,6 +78,7 @@ export function useHotkeys({
   onHelpScroll,
   onHelpScrollToTop,
   onToggleTracking,
+  onJumpToParent,
   filterLabel,
   trackingOn = false,
 }: UseHotkeysOptions): UseHotkeysResult {
@@ -87,6 +93,8 @@ export function useHotkeys({
       return: boolean;
       ctrl: boolean;
       escape?: boolean;
+      leftArrow?: boolean;
+      rightArrow?: boolean;
     },
   ) => {
     if (helpMode) {
@@ -210,6 +218,10 @@ export function useHotkeys({
         onHide();
         return;
       }
+      if (key.leftArrow && onJumpToParent) {
+        onJumpToParent();
+        return;
+      }
       if (key.upArrow || input === "k") {
         onScrollUp();
         return;
@@ -253,6 +265,7 @@ export function useHotkeys({
             ...trackingItems,
             "Tab: viewer",
             "↑↓/jk: select",
+            "←: parent",
             "PgUp/Dn: page",
             "↵: expand",
             "h: hide",

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -33,9 +33,13 @@ vi.mock("../../src/data/sessionHistory.js", () => ({
   parseSessionHistory: () => [],
 }));
 
-const { App, initialSelectedId, initialExpandedIds } = await import(
-  "../../src/ui/App.js"
-);
+const {
+  App,
+  appendSubAgentRows,
+  findParentTarget,
+  initialSelectedId,
+  initialExpandedIds,
+} = await import("../../src/ui/App.js");
 
 const emptyTree = (): SessionTree => ({
   projects: [],
@@ -165,5 +169,237 @@ describe("initialExpandedIds", () => {
 
   it("returns an empty set when there are no projects at all", () => {
     expect(initialExpandedIds(emptyTree()).size).toBe(0);
+  });
+});
+
+describe("appendSubAgentRows", () => {
+  const baseSubAgent = (
+    id: string,
+    status: SessionNode["status"],
+  ): SessionNode => ({
+    id,
+    hideKey: `parent/${id}`,
+    filePath: `/tmp/${id}.jsonl`,
+    projectPath: "/tmp/p",
+    projectName: "p",
+    lastModifiedMs: 0,
+    status,
+    modelName: null,
+    subAgents: [],
+    nonInteractive: false,
+    firstUserPrompt: null,
+    liveState: null,
+  });
+
+  const sessionWith = (
+    id: string,
+    status: SessionNode["status"],
+    subs: SessionNode[],
+  ): SessionNode => ({
+    id,
+    hideKey: `p/${id}`,
+    filePath: `/tmp/p/${id}.jsonl`,
+    projectPath: "/tmp/p",
+    projectName: "p",
+    lastModifiedMs: 0,
+    status,
+    modelName: null,
+    subAgents: subs,
+    nonInteractive: false,
+    firstUserPrompt: null,
+    liveState: null,
+  });
+
+  it("cold session with no expand keys appends nothing (hidden by default)", () => {
+    const session = sessionWith("s1", "cold", [
+      baseSubAgent("a", "hot"),
+      baseSubAgent("b", "cold"),
+    ]);
+    const result: SessionNode[] = [];
+    appendSubAgentRows(result, session, new Set());
+    expect(result).toEqual([]);
+  });
+
+  it("cold session expanded via sessionExpandedKey appends ALL sub-agents", () => {
+    // This is the bug we're fixing: the previous code only checked
+    // expandedIds.has(session.id), so a cold session expanded with Enter
+    // (which sets `__expanded-session-<id>`) returned only hot/warm +
+    // sentinel — the cold sub-agents that the renderer was showing
+    // were missing from the navigable flat list.
+    const subs = [
+      baseSubAgent("a", "hot"),
+      baseSubAgent("b", "cold"),
+      baseSubAgent("c", "cold"),
+    ];
+    const session = sessionWith("s1", "cold", subs);
+    const result: SessionNode[] = [];
+    appendSubAgentRows(
+      result,
+      session,
+      new Set(["__expanded-session-s1"]),
+    );
+    expect(result.map((n) => n.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("alive session default appends hot/warm sub-agents plus a sub-summary sentinel for the rest", () => {
+    const session = sessionWith("s1", "warm", [
+      baseSubAgent("a", "hot"),
+      baseSubAgent("b", "warm"),
+      baseSubAgent("c", "cold"),
+    ]);
+    const result: SessionNode[] = [];
+    appendSubAgentRows(result, session, new Set());
+    expect(result.map((n) => n.id)).toEqual(["a", "b", "__sub-s1__"]);
+  });
+
+  it("alive session with session.id in expandedIds appends ALL sub-agents", () => {
+    const session = sessionWith("s1", "warm", [
+      baseSubAgent("a", "hot"),
+      baseSubAgent("b", "cold"),
+    ]);
+    const result: SessionNode[] = [];
+    appendSubAgentRows(result, session, new Set(["s1"]));
+    expect(result.map((n) => n.id)).toEqual(["a", "b"]);
+  });
+
+  it("alive session with sessionCollapsedKey appends nothing", () => {
+    const session = sessionWith("s1", "warm", [
+      baseSubAgent("a", "hot"),
+      baseSubAgent("b", "cold"),
+    ]);
+    const result: SessionNode[] = [];
+    appendSubAgentRows(
+      result,
+      session,
+      new Set(["__collapsed-session-s1"]),
+    );
+    expect(result).toEqual([]);
+  });
+});
+
+describe("findParentTarget", () => {
+  const sub = (id: string): SessionNode => ({
+    id,
+    hideKey: "",
+    filePath: "",
+    projectPath: "",
+    projectName: "",
+    lastModifiedMs: 0,
+    status: "cold",
+    modelName: null,
+    subAgents: [],
+    nonInteractive: false,
+    firstUserPrompt: null,
+    liveState: null,
+  });
+
+  const session = (id: string, subs: SessionNode[] = []): SessionNode => ({
+    id,
+    hideKey: `p/${id}`,
+    filePath: `/tmp/p/${id}.jsonl`,
+    projectPath: "/tmp/p",
+    projectName: "p",
+    lastModifiedMs: 0,
+    status: "warm",
+    modelName: null,
+    subAgents: subs,
+    nonInteractive: false,
+    firstUserPrompt: null,
+    liveState: null,
+  });
+
+  const project = (
+    name: string,
+    sessions: SessionNode[],
+  ): ProjectNode => ({
+    name,
+    projectPath: `/tmp/${name}`,
+    sessions,
+    hotness: sessions[0]?.status ?? "cold",
+  });
+
+  it("sub-agent row → containing session id", () => {
+    const sa = sub("a1");
+    const s = session("s1", [sa]);
+    const tree: SessionTree = {
+      projects: [project("p1", [s])],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+    };
+    expect(findParentTarget("a1", tree, [])).toBe("s1");
+  });
+
+  it("sub-summary sentinel → encoded parent session id", () => {
+    const tree: SessionTree = {
+      projects: [],
+      coldProjects: [],
+      totalCount: 0,
+      timestamp: new Date().toISOString(),
+    };
+    expect(findParentTarget("__sub-s1__", tree, [])).toBe("s1");
+  });
+
+  it("session row → containing project sentinel", () => {
+    const s = session("s1");
+    const tree: SessionTree = {
+      projects: [project("myproj", [s])],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+    };
+    expect(findParentTarget("s1", tree, [])).toBe("__proj-myproj__");
+  });
+
+  it("project sentinel → previous row in the flat list", () => {
+    const s1 = session("s1");
+    const s2 = session("s2");
+    const tree: SessionTree = {
+      projects: [project("alpha", [s1]), project("beta", [s2])],
+      coldProjects: [],
+      totalCount: 2,
+      timestamp: new Date().toISOString(),
+    };
+    const flat: SessionNode[] = [
+      // Skip the synthetic sentinel struct details — only id is used.
+      { ...s1, id: "__proj-alpha__" } as SessionNode,
+      s1,
+      { ...s2, id: "__proj-beta__" } as SessionNode,
+      s2,
+    ];
+    expect(findParentTarget("__proj-beta__", tree, flat)).toBe("s1");
+  });
+
+  it("topmost project sentinel falls back to itself (no phantom id)", () => {
+    const s1 = session("s1");
+    const tree: SessionTree = {
+      projects: [project("alpha", [s1])],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+    };
+    const flat: SessionNode[] = [
+      { ...s1, id: "__proj-alpha__" } as SessionNode,
+      s1,
+    ];
+    expect(findParentTarget("__proj-alpha__", tree, flat)).toBe(
+      "__proj-alpha__",
+    );
+  });
+
+  it("cold-projects sentinel → previous row", () => {
+    const s1 = session("s1");
+    const tree: SessionTree = {
+      projects: [project("alpha", [s1])],
+      coldProjects: [project("oldproj", [session("old1")])],
+      totalCount: 2,
+      timestamp: new Date().toISOString(),
+    };
+    const flat: SessionNode[] = [
+      { ...s1, id: "__proj-alpha__" } as SessionNode,
+      s1,
+      { ...s1, id: "__cold__" } as SessionNode,
+    ];
+    expect(findParentTarget("__cold__", tree, flat)).toBe("s1");
   });
 });

--- a/tests/ui/hooks/useHotkeys.test.ts
+++ b/tests/ui/hooks/useHotkeys.test.ts
@@ -230,6 +230,27 @@ describe("useHotkeys", () => {
       expect(onScrollDown).toHaveBeenCalledTimes(1);
     });
 
+    it("calls onJumpToParent when leftArrow is pressed", () => {
+      const onJumpToParent = vi.fn();
+      const { result } = renderHook(() =>
+        useHotkeys(makeOptions({ focus: "tree", onJumpToParent })),
+      );
+      act(() =>
+        result.current.handleInput("", { ...noopKey, leftArrow: true }),
+      );
+      expect(onJumpToParent).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores leftArrow gracefully when onJumpToParent is not provided", () => {
+      const { result } = renderHook(() =>
+        useHotkeys(makeOptions({ focus: "tree" })),
+      );
+      expect(() =>
+        act(() =>
+          result.current.handleInput("", { ...noopKey, leftArrow: true }),
+        ),
+      ).not.toThrow();
+    });
   });
 
   describe("viewer focus", () => {
@@ -318,6 +339,7 @@ describe("useHotkeys", () => {
         "t: track",
         "Tab: viewer",
         "↑↓/jk: select",
+        "←: parent",
         "PgUp/Dn: page",
         "↵: expand",
         "h: hide",


### PR DESCRIPTION
## Summary
Two related tree-nav fixes triggered by a real-world stuck-selection
case (cold session #864f with 108 sub-agents, selection landed on the
first sub-agent and j/k/PgUp/PgDn all went silent).

### 1. Cold sub-agents were rendered but unreachable
\`SessionTreePanel\` treats a cold session as fully expanded if either
\`expandedIds.has(session.id)\` **or**
\`expandedIds.has(\`__expanded-session-<id>\`)\`. \`appendSubAgentRows\` in
App.tsx only checked the first form, so a cold session expanded via
Enter (which writes the second form) produced a tree where the
sub-agents were visible but **missing from \`allFlat\`** — and the
j/k/PgUp/PgDn handlers short-circuit on \`selectedIndex === -1\`,
leaving the user with a highlighted-but-unmovable selection.

Aligning \`appendSubAgentRows\` with the renderer's rule fixes it.

### 2. Add left-arrow "jump to parent"
There was no shortcut for climbing out of a deep selection (only
sibling-walk with k/PgUp). Vim/tree-UI convention is \`←\` /
\`h\`, and \`h\` is already taken for "hide", so just left-arrow.

- sub-agent → containing session
- sub-summary sentinel (\`__sub-<sid>__\`) → parent session
- session → containing project sentinel
- project / cold-projects sentinel → previous flat row (acts like Up
  at the top level so the user can still climb out of a project group)

## Implementation
- \`appendSubAgentRows\` now exports for testing; the only behavior
  change is the wider "fully expanded" condition.
- New \`findParentTarget(currentId, tree, flat)\` pure helper, exported.
- \`useHotkeys\` accepts an optional \`onJumpToParent\` callback and
  fires it on \`key.leftArrow\` when focus is on the tree. Status bar
  picks up a new \`←: parent\` hint.
- \`HelpPanel\` adds the \`←\` row under "Project tree".

## Tests
- \`appendSubAgentRows\`: 5 cases — cold default-hidden, cold expanded
  shows all (this is the bug), alive default hot/warm + sentinel,
  alive force-expanded shows all, alive force-collapsed shows nothing.
- \`findParentTarget\`: 6 cases — sub-agent → session, sub-summary
  sentinel → session, session → project, project sentinel →
  previous, topmost sentinel → self (no phantom id), cold-projects
  sentinel → previous.
- \`useHotkeys\`: left-arrow dispatches \`onJumpToParent\` (and is a
  no-op when no handler is provided).

## Test plan
- [x] \`npx vitest run\` — 435/435 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean

Note: not bundled into a release. Per user instruction, paused on
shipping for a beat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added left-arrow keyboard shortcut to navigate up one level in the project tree hierarchy, jumping from sub-agents to their session, or from sessions to their project.
  * Tree expansion behavior now consistently displays the complete sub-agent list when a session is expanded.

* **Documentation**
  * Updated help documentation to include the new left-arrow navigation key binding and its function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->