### PR TITLE
feat: summary --open / -o launches the result in the OS default app

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,22 @@ Run this in a separate terminal while using Claude Code. Press `?` inside the TU
 AgentHUD's TUI splits the screen into a project tree and an activity viewer:
 
 ```
-┌─ Projects ───────────────────────────────────────────────┐
-│ > agenthud  ~/WestbrookAI/agenthud                   13m │
-│     #864f [hot] Fix the auth bug in login flow           │
-│         ├─ » code-reviewer                               │
-│     (#398c [warm])                                       │
-│   myproject  ~/work/myproject                         2d │
-│     #def4 [hot] Add OAuth support                        │
-│ ... 12 cold projects                                     │
-└──────────────────────────────────────────────────────────┘
-┌─ Activity · agenthud ────────────────────────────────────┐
-│ [10:23] ○ Read  src/ui/App.tsx                           │
-│ [10:23] ~ Edit  src/ui/App.tsx                           │
-│ [10:23] $ Bash  npm test                                 │
-│ [10:23] < Response  Tests passed successfully            │
+┌─ Projects ─────────────────────────────────────────────────┐
+│ > agenthud  ~/WestbrookAI/agenthud                     13m │
+│     #864f [hot] Fix the auth bug in login flow             │
+│         ├─ » code-reviewer                                 │
+│     (#398c [warm])                                         │
+│   myproject  ~/work/myproject                           2d │
+│     #def4 [hot] Add OAuth support                          │
+│ ... 12 cold projects                                       │
+└────────────────────────────────────────────────────────────┘
+┌─ Activity · agenthud ──────────────────────────────────────┐
+│ [10:23] ○ Read  src/ui/App.tsx                             │
+│ [10:23] ~ Edit  src/ui/App.tsx                             │
+│ [10:23] $ Bash  npm test                                   │
+│ [10:23] < Response  Tests passed successfully              │
 │ [10:25] ⠧ Edit  src/auth/oauth.ts  ← bold + spinner = live │
-└──────────────────────────────────────────────────────────┘
+└────────────────────────────────────────────────────────────┘
 ```
 
 **Project tree (top pane)**
@@ -207,6 +207,9 @@ agenthud summary --last 7d -y                       # skip per-day confirmations
 # Cheaper model — summarization doesn't need Opus-tier reasoning
 agenthud summary --date today --model sonnet        # ~40% cheaper than Opus
 agenthud summary --last 7d --model haiku            # ~80% cheaper, 200K context
+
+# Open the resulting summary in your OS default app (browser, VS Code, etc.)
+agenthud summary --last 7d --open                   # -o is the short form
 ```
 
 **Daily summaries** are saved to `~/.agenthud/summaries/YYYY-MM-DD.md`. Past dates are cached and returned instantly; today is always regenerated (activity still growing).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -211,7 +211,7 @@ export function formatEffectiveOptionsLine(
   parts.push(`with-git=${fields.withGit ? "on" : "off"}`);
   if (fields.format) parts.push(`format=${fields.format}`);
   if (fields.model) parts.push(`model=${fields.model}`);
-  return `agenthud: ${command} → ${parts.join(" ")}`;
+  return `${command} → ${parts.join(" ")}`;
 }
 
 function todayLocalMidnight(): Date {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,8 @@ export interface CliOptions {
   summaryFormat?: "markdown" | "json";
   summaryDetailLimit?: number;
   summaryWithGit?: boolean;
+  /** Launch the resulting summary in the OS default app after writing. */
+  summaryOpen?: boolean;
   summaryError?: string;
   scopeToCwd?: boolean;
 }
@@ -72,6 +74,8 @@ const KNOWN_SUMMARY_FLAGS = new Set([
   "--format",
   "--detail-limit",
   "--with-git",
+  "-o",
+  "--open",
 ]);
 const KNOWN_SUBCOMMANDS = new Set(["watch", "report", "summary"]);
 
@@ -108,7 +112,7 @@ Commands:
 
   summary [--date DATE | --last Nd | --from DATE --to DATE]
           [--include TYPES] [--detail-limit N] [--with-git]
-          [--prompt TEXT] [--force] [--model NAME] [-y]
+          [--prompt TEXT] [--force] [--model NAME] [-y] [-o]
                                 Generate an LLM summary via the claude
                                 CLI. A single day produces a daily
                                 summary; a date range produces a
@@ -129,6 +133,9 @@ Commands:
                                 "haiku", or a full model id)
     -y, --yes                   Skip confirmation prompts for new daily
                                 summaries
+    -o, --open                  Launch the resulting summary in your OS
+                                default app once it's written (or read
+                                back from cache).
 
   Defaults for report and summary live under \`report:\` and \`summary:\`
   in ~/.agenthud/config.yaml. Flags override config values per-run; the
@@ -468,6 +475,8 @@ export function parseArgs(
 
     if (rest.includes("--force")) summaryForce = true;
     if (rest.includes("-y") || rest.includes("--yes")) summaryAssumeYes = true;
+    const summaryOpen =
+      rest.includes("--open") || rest.includes("-o") || undefined;
 
     // Resolve report-shaped options for summary:
     //   CLI flag → config.summary.X → config.report.X → built-in default.
@@ -552,6 +561,7 @@ export function parseArgs(
       summaryFormat,
       summaryDetailLimit,
       summaryWithGit,
+      summaryOpen,
       summaryError,
     };
   }

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -13,6 +13,7 @@ import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { loadGlobalConfig } from "../config/globalConfig.js";
 import { openInDefaultApp } from "../utils/openInDefaultApp.js";
+import { startStderrTicker } from "../utils/stderrTicker.js";
 import { generateReport } from "./reportGenerator.js";
 import { discoverSessions } from "./sessions.js";
 
@@ -424,7 +425,7 @@ async function generateDailySummary(
     try {
       const content = readFileSync(cached, "utf-8");
       if (opts.announce) {
-        process.stderr.write(`agenthud: cached summary from ${cached}\n`);
+        process.stderr.write(`cached summary from ${cached}\n`);
       }
       if (opts.streamToStdout) {
         process.stdout.write(content);
@@ -443,7 +444,7 @@ async function generateDailySummary(
   }
 
   if (opts.announce) {
-    process.stderr.write(`agenthud: scanning sessions for ${dateLabel}...\n`);
+    process.stderr.write(`scanning sessions for ${dateLabel}...\n`);
   }
 
   const config = loadGlobalConfig();
@@ -477,7 +478,7 @@ async function generateDailySummary(
     ).length;
     const sizeKb = (reportBytes / 1024).toFixed(1);
     process.stderr.write(
-      `agenthud: input: ${sessionCount} sessions, ${activityCount} activities, ${commitCount} commits (${reportLines.length} lines, ${sizeKb}KB ≈ ${estimatedTokens.toLocaleString()} tokens)\n`,
+      `input: ${sessionCount} sessions, ${activityCount} activities, ${commitCount} commits (${reportLines.length} lines, ${sizeKb}KB ≈ ${estimatedTokens.toLocaleString()} tokens)\n`,
     );
   }
 
@@ -518,11 +519,19 @@ async function generateDailySummary(
     }
   }
 
-  if (opts.announce) {
+  // When streamToStdout is on, the streaming markdown itself is the
+  // progress indicator. When it's off (--open suppression) we'd be
+  // staring at a frozen-looking terminal — start a stderr ticker so
+  // the user knows the LLM call is still running.
+  const showTicker = opts.announce && !opts.streamToStdout;
+  if (opts.announce && !showTicker) {
     process.stderr.write(
-      `agenthud: sending to claude (this may take a minute)...\n\n`,
+      `sending to claude (this may take a minute)...\n\n`,
     );
   }
+  const stopTicker = showTicker
+    ? startStderrTicker("sending to claude")
+    : null;
 
   const prompt = resolvePrompt("daily", opts.promptOverride);
   const result = await spawnClaude({
@@ -532,12 +541,13 @@ async function generateDailySummary(
     streamToStdout: opts.streamToStdout,
     model: opts.model,
   });
+  if (stopTicker) stopTicker();
 
   if (opts.announce && result.code === 0) {
     process.stderr.write("\n");
-    process.stderr.write(`agenthud: saved to ${cached}\n`);
+    process.stderr.write(`saved to ${cached}\n`);
     if (result.usage) {
-      process.stderr.write(`agenthud: ${formatUsage(result.usage)}\n`);
+      process.stderr.write(`${formatUsage(result.usage)}\n`);
     }
   }
 
@@ -594,7 +604,7 @@ export async function runRangeSummary(
     try {
       const content = readFileSync(rangeCache, "utf-8");
       process.stderr.write(
-        `agenthud: cached range summary from ${rangeCache}\n`,
+        `cached range summary from ${rangeCache}\n`,
       );
       if (!options.open) {
         process.stdout.write(content);
@@ -617,10 +627,10 @@ export async function runRangeSummary(
   }
 
   process.stderr.write(
-    `agenthud: range ${fromLabel} → ${toLabel} (${dates.length} days)\n`,
+    `range ${fromLabel} → ${toLabel} (${dates.length} days)\n`,
   );
   process.stderr.write(
-    `agenthud: ${cachedCount} cached, ${missingCount} to generate\n`,
+    `${cachedCount} cached, ${missingCount} to generate\n`,
   );
 
   // Generate dailies sequentially. Confirm just-in-time after scan (when --yes is off).
@@ -630,7 +640,7 @@ export async function runRangeSummary(
   for (const d of dates) {
     const label = dateKey(d);
     const isToday = isSameLocalDay(d, options.today);
-    process.stderr.write(`\nagenthud: --- ${label} ---\n`);
+    process.stderr.write(`\n--- ${label} ---\n`);
 
     const willPrompt = !options.assumeYes && (isToday || !existsSync(dailyCachePath(d)));
     const confirmer = willPrompt
@@ -669,7 +679,7 @@ export async function runRangeSummary(
     }
     const text = res.markdown.trim();
     if (text.length === 0 || /^no activity found/i.test(text)) {
-      process.stderr.write(`agenthud: ${label} has no activity — skipping.\n`);
+      process.stderr.write(`${label} has no activity — skipping.\n`);
       continue;
     }
     dailyMarkdowns.push({ date: d, markdown: text });
@@ -686,29 +696,39 @@ export async function runRangeSummary(
     .join("\n\n---\n\n");
 
   process.stderr.write(
-    `\nagenthud: combining ${dailyMarkdowns.length} daily summaries into range summary...\n`,
+    `\ncombining ${dailyMarkdowns.length} daily summaries into range summary...\n`,
   );
-  process.stderr.write(
-    `agenthud: sending to claude (this may take a minute)...\n\n`,
-  );
+  const metaStreams = !options.open;
+  if (!metaStreams) {
+    // -o suppresses the streamed output — show a ticker instead so the
+    // user has visible feedback during the minute-long LLM call.
+  } else {
+    process.stderr.write(
+      `sending to claude (this may take a minute)...\n\n`,
+    );
+  }
+  const stopMetaTicker = metaStreams
+    ? null
+    : startStderrTicker("sending to claude");
 
   const metaPrompt = resolvePrompt("range");
   const metaResult = await spawnClaude({
     prompt: metaPrompt,
     stdin: metaInput,
     cachePath: rangeCache,
-    streamToStdout: !options.open,
+    streamToStdout: metaStreams,
     model: options.model,
   });
+  if (stopMetaTicker) stopMetaTicker();
 
   if (metaResult.code !== 0) {
     return metaResult.code;
   }
 
   process.stderr.write("\n");
-  process.stderr.write(`agenthud: saved to ${rangeCache}\n`);
+  process.stderr.write(`saved to ${rangeCache}\n`);
   if (metaResult.usage) {
-    process.stderr.write(`agenthud: ${formatUsage(metaResult.usage)}\n`);
+    process.stderr.write(`${formatUsage(metaResult.usage)}\n`);
   }
 
   if (options.open) openInDefaultApp(rangeCache);

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { loadGlobalConfig } from "../config/globalConfig.js";
+import { openInDefaultApp } from "../utils/openInDefaultApp.js";
 import { generateReport } from "./reportGenerator.js";
 import { discoverSessions } from "./sessions.js";
 
@@ -28,6 +29,8 @@ export interface SummaryOptions {
   detailLimit: number;
   /** Whether to merge git commits into the LLM payload. */
   withGit: boolean;
+  /** Launch the resulting summary in the OS default app after writing. */
+  open?: boolean;
 }
 
 export interface RangeSummaryOptions {
@@ -43,6 +46,8 @@ export interface RangeSummaryOptions {
   detailLimit: number;
   /** Whether to merge git commits into the per-day payload. */
   withGit: boolean;
+  /** Launch the resulting range summary in the OS default app after writing. */
+  open?: boolean;
 }
 
 type PromptKind = "daily" | "range";
@@ -538,6 +543,9 @@ export async function runSummary(options: SummaryOptions): Promise<number> {
     detailLimit: options.detailLimit,
     withGit: options.withGit,
   });
+  if (options.open && res.code === 0 && !res.skipped) {
+    openInDefaultApp(dailyCachePath(options.date));
+  }
   return res.code;
 }
 
@@ -567,6 +575,7 @@ export async function runRangeSummary(
       );
       process.stdout.write(content);
       if (!content.endsWith("\n")) process.stdout.write("\n");
+      if (options.open) openInDefaultApp(rangeCache);
       return 0;
     } catch {
       // fall through to regenerate
@@ -677,5 +686,6 @@ export async function runRangeSummary(
     process.stderr.write(`agenthud: ${formatUsage(metaResult.usage)}\n`);
   }
 
+  if (options.open) openInDefaultApp(rangeCache);
   return 0;
 }

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -72,6 +72,26 @@ function userPromptPath(kind: PromptKind): string {
   return join(homedir(), ".agenthud", promptFilename(kind));
 }
 
+/**
+ * Compact, user-facing label for the prompt this summary run is using.
+ * - daily/range with no inline override → the user prompt file path,
+ *   abbreviated to `~/...` so the line stays readable.
+ * - daily with `--prompt TEXT` → "<inline> (from --prompt)".
+ *   (Range mode does not accept --prompt, so override is ignored when
+ *   kind is "range".)
+ */
+export function formatPromptSource(
+  kind: "daily" | "range",
+  override?: string,
+): string {
+  if (kind === "daily" && override) {
+    return "<inline> (from --prompt)";
+  }
+  const home = homedir();
+  const path = userPromptPath(kind);
+  return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
+}
+
 function templatePath(kind: PromptKind): string {
   const here = dirname(fileURLToPath(import.meta.url));
   return join(here, "templates", promptFilename(kind));
@@ -531,12 +551,15 @@ async function generateDailySummary(
 }
 
 export async function runSummary(options: SummaryOptions): Promise<number> {
+  // With --open the user is going to read the rendered file in their
+  // default app anyway, so streaming the same markdown to the terminal
+  // is duplicate noise (and breaks downstream piping). Suppress.
   const res = await generateDailySummary({
     date: options.date,
     today: options.today,
     force: options.force,
     promptOverride: options.prompt,
-    streamToStdout: true,
+    streamToStdout: !options.open,
     announce: true,
     model: options.model,
     include: options.include,
@@ -573,8 +596,10 @@ export async function runRangeSummary(
       process.stderr.write(
         `agenthud: cached range summary from ${rangeCache}\n`,
       );
-      process.stdout.write(content);
-      if (!content.endsWith("\n")) process.stdout.write("\n");
+      if (!options.open) {
+        process.stdout.write(content);
+        if (!content.endsWith("\n")) process.stdout.write("\n");
+      }
       if (options.open) openInDefaultApp(rangeCache);
       return 0;
     } catch {
@@ -672,7 +697,7 @@ export async function runRangeSummary(
     prompt: metaPrompt,
     stdin: metaInput,
     cachePath: rangeCache,
-    streamToStdout: true,
+    streamToStdout: !options.open,
     model: options.model,
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,11 @@ import {
   findContainingProject,
   getProjectsDir,
 } from "./data/sessions.js";
-import { runRangeSummary, runSummary } from "./data/summaryRunner.js";
+import {
+  formatPromptSource,
+  runRangeSummary,
+  runSummary,
+} from "./data/summaryRunner.js";
 import { App } from "./ui/App.js";
 import { enterAltScreen, installAltScreenCleanup } from "./utils/altScreen.js";
 import { isLegacyProjectConfig } from "./utils/legacyConfig.js";
@@ -110,6 +114,13 @@ if (options.mode === "summary") {
       withGit: options.summaryWithGit ?? false,
       model: options.summaryModel,
     })}\n`,
+  );
+  const isRangeMode = !!(options.summaryFrom && options.summaryTo);
+  process.stderr.write(
+    `agenthud: prompt = ${formatPromptSource(
+      isRangeMode ? "range" : "daily",
+      options.summaryPrompt,
+    )}\n`,
   );
   const today = new Date();
   if (options.summaryFrom && options.summaryTo) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,7 +117,7 @@ if (options.mode === "summary") {
   );
   const isRangeMode = !!(options.summaryFrom && options.summaryTo);
   process.stderr.write(
-    `agenthud: prompt = ${formatPromptSource(
+    `prompt = ${formatPromptSource(
       isRangeMode ? "range" : "daily",
       options.summaryPrompt,
     )}\n`,
@@ -178,7 +178,7 @@ if (options.scopeToCwd) {
     process.exit(1);
   }
   scopeToProject = match;
-  process.stderr.write(`agenthud: scope = ${match}\n`);
+  process.stderr.write(`scope = ${match}\n`);
 }
 
 if (options.mode === "watch") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,6 +123,7 @@ if (options.mode === "summary") {
       include: options.summaryInclude!,
       detailLimit: options.summaryDetailLimit!,
       withGit: options.summaryWithGit!,
+      open: options.summaryOpen,
     });
     process.exit(exitCode);
   }
@@ -135,6 +136,7 @@ if (options.mode === "summary") {
     include: options.summaryInclude!,
     detailLimit: options.summaryDetailLimit!,
     withGit: options.summaryWithGit!,
+    open: options.summaryOpen,
   });
   process.exit(exitCode);
 }

--- a/src/utils/openInDefaultApp.ts
+++ b/src/utils/openInDefaultApp.ts
@@ -1,0 +1,63 @@
+import { spawn } from "node:child_process";
+
+export interface OpenCommand {
+  command: string;
+  args: string[];
+}
+
+/**
+ * Build the OS-specific command needed to open a file with the user's
+ * default application. Returns null on platforms we don't recognize so
+ * the caller can fall back to a warning + the printed path.
+ *
+ * Paths are passed through verbatim — `spawn` handles quoting at the
+ * argument boundary, so caller-supplied spaces / unicode are fine.
+ */
+export function buildOpenCommand(
+  platform: NodeJS.Platform | string,
+  path: string,
+): OpenCommand | null {
+  switch (platform) {
+    case "darwin":
+      return { command: "open", args: [path] };
+    case "linux":
+      return { command: "xdg-open", args: [path] };
+    case "win32":
+      // The empty-string after `start` is the window title — Windows
+      // treats the first quoted argument to `start` as the title, so a
+      // path with spaces would otherwise be eaten as the title and the
+      // file would never open.
+      return { command: "cmd", args: ["/c", "start", "", path] };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Launch the OS default app on `path` and return immediately. Failures
+ * (no command, spawn error, missing handler like `xdg-open` on
+ * minimal Linux) are reported on stderr; the agenthud process keeps
+ * going so the path it already printed remains the user's fallback.
+ */
+export function openInDefaultApp(path: string): void {
+  const cmd = buildOpenCommand(process.platform, path);
+  if (!cmd) {
+    process.stderr.write(
+      `agenthud: --open: no known opener for platform "${process.platform}"\n`,
+    );
+    return;
+  }
+  try {
+    const child = spawn(cmd.command, cmd.args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", (err) => {
+      process.stderr.write(`agenthud: --open failed: ${err.message}\n`);
+    });
+    child.unref();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`agenthud: --open failed: ${msg}\n`);
+  }
+}

--- a/src/utils/stderrTicker.ts
+++ b/src/utils/stderrTicker.ts
@@ -1,0 +1,51 @@
+/**
+ * Live "still working" feedback on stderr while a long-running task
+ * (LLM call, big build, etc.) blocks. Renders the same line repeatedly
+ * using a carriage return so the spinner doesn't scroll past the
+ * pre-line content.
+ *
+ * Use case in agenthud: when --open suppresses the streamed claude
+ * output, the user is otherwise staring at a frozen-looking terminal
+ * for 30–60+ seconds. A ticking line tells them the process is alive.
+ */
+
+/** Pure helper used to render the ticker line. Exported for testing. */
+export function formatTickerLine(
+  label: string,
+  elapsedSeconds: number,
+  dots: number,
+): string {
+  // dots ∈ [0..3]; pad to 3 chars so the trailing text doesn't jitter.
+  const tail = ".".repeat(dots % 4).padEnd(3, " ");
+  return `${label}${tail} ${elapsedSeconds}s`;
+}
+
+/**
+ * Start writing a ticker to stderr. Returns a `stop()` function that
+ * clears the line and stops the interval. Safe to call stop() even if
+ * the ticker never wrote anything (e.g. the task finished before the
+ * first tick).
+ */
+export function startStderrTicker(
+  label: string,
+  options: { intervalMs?: number; stream?: NodeJS.WritableStream } = {},
+): () => void {
+  const intervalMs = options.intervalMs ?? 500;
+  const stream = options.stream ?? process.stderr;
+  const start = Date.now();
+  let ticks = 0;
+
+  const id = setInterval(() => {
+    ticks++;
+    const elapsed = Math.floor((Date.now() - start) / 1000);
+    stream.write(`\r${formatTickerLine(label, elapsed, ticks)}`);
+  }, intervalMs);
+
+  return function stop(): void {
+    clearInterval(id);
+    // Wipe whatever the spinner wrote so the next stderr line starts
+    // clean at column 0. \r returns to column start, \x1b[K erases to
+    // end-of-line.
+    if (ticks > 0) stream.write("\r\x1b[K");
+  };
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -439,6 +439,32 @@ describe("parseArgs", () => {
       expect(opts.summaryModel).toBeUndefined();
     });
 
+    describe("--open / -o flag", () => {
+      it("parses --open", () => {
+        const opts = parseArgs(["summary", "--open"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryOpen).toBe(true);
+      });
+
+      it("parses -o", () => {
+        const opts = parseArgs(["summary", "-o"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryOpen).toBe(true);
+      });
+
+      it("works alongside --last", () => {
+        const opts = parseArgs(["summary", "--last", "7d", "--open"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryOpen).toBe(true);
+        expect(opts.summaryFrom).toBeDefined();
+      });
+
+      it("defaults to undefined when neither flag is given", () => {
+        const opts = parseArgs(["summary"]);
+        expect(opts.summaryOpen).toBeUndefined();
+      });
+    });
+
     describe("report-shaped options on summary", () => {
       it("parses --include and threads it through", () => {
         const opts = parseArgs(["summary", "--include", "response,user"]);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -571,7 +571,7 @@ describe("formatEffectiveOptionsLine", () => {
       format: "markdown",
     });
     expect(line).toBe(
-      "agenthud: report → include=[user,response,bash,edit,thinking] detail-limit=120 with-git=off format=markdown",
+      "report → include=[user,response,bash,edit,thinking] detail-limit=120 with-git=off format=markdown",
     );
   });
 
@@ -583,7 +583,7 @@ describe("formatEffectiveOptionsLine", () => {
       model: "sonnet",
     });
     expect(line).toBe(
-      "agenthud: summary → include=[bash] detail-limit=∞ with-git=on model=sonnet",
+      "summary → include=[bash] detail-limit=∞ with-git=on model=sonnet",
     );
   });
 

--- a/tests/data/summaryRunner.formatPromptSource.test.ts
+++ b/tests/data/summaryRunner.formatPromptSource.test.ts
@@ -1,0 +1,37 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { formatPromptSource } from "../../src/data/summaryRunner.js";
+
+describe("formatPromptSource", () => {
+  it("returns the daily prompt path with ~ abbreviation when no override", () => {
+    expect(formatPromptSource("daily")).toBe("~/.agenthud/summary-prompt.md");
+  });
+
+  it("returns the range prompt path with ~ abbreviation when no override", () => {
+    expect(formatPromptSource("range")).toBe(
+      "~/.agenthud/summary-range-prompt.md",
+    );
+  });
+
+  it("returns an inline marker when the user passed --prompt on daily", () => {
+    expect(formatPromptSource("daily", "Only commits")).toBe(
+      "<inline> (from --prompt)",
+    );
+  });
+
+  it("ignores inline override on range (range does not accept --prompt)", () => {
+    expect(formatPromptSource("range", "ignored")).toBe(
+      "~/.agenthud/summary-range-prompt.md",
+    );
+  });
+
+  it("falls back to the absolute path when homedir is not a prefix", () => {
+    // Sanity: the helper still produces a usable label even if the user's
+    // homedir somehow doesn't match the path (rare in practice, e.g.
+    // sandboxed test runners with a custom XDG layout).
+    const path = formatPromptSource("daily");
+    if (!path.startsWith("~")) {
+      expect(path).toContain(homedir());
+    }
+  });
+});

--- a/tests/utils/openInDefaultApp.test.ts
+++ b/tests/utils/openInDefaultApp.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildOpenCommand } from "../../src/utils/openInDefaultApp.js";
+
+describe("buildOpenCommand", () => {
+  it("uses `open <path>` on macOS", () => {
+    expect(buildOpenCommand("darwin", "/tmp/foo.md")).toEqual({
+      command: "open",
+      args: ["/tmp/foo.md"],
+    });
+  });
+
+  it("uses `xdg-open <path>` on Linux", () => {
+    expect(buildOpenCommand("linux", "/tmp/foo.md")).toEqual({
+      command: "xdg-open",
+      args: ["/tmp/foo.md"],
+    });
+  });
+
+  it("uses `cmd /c start \"\" <path>` on Windows", () => {
+    // The empty-string first arg to `start` is the window title — required
+    // because Windows treats the first quoted argument as the title.
+    expect(buildOpenCommand("win32", "C:/tmp/foo.md")).toEqual({
+      command: "cmd",
+      args: ["/c", "start", "", "C:/tmp/foo.md"],
+    });
+  });
+
+  it("returns null for an unsupported platform so the caller can warn", () => {
+    expect(buildOpenCommand("aix", "/tmp/foo.md")).toBeNull();
+  });
+
+  it("preserves paths containing spaces verbatim (spawn handles quoting)", () => {
+    const result = buildOpenCommand(
+      "darwin",
+      "/Users/me/Library/Application Support/agenthud/summary.md",
+    );
+    expect(result).toEqual({
+      command: "open",
+      args: ["/Users/me/Library/Application Support/agenthud/summary.md"],
+    });
+  });
+});

--- a/tests/utils/stderrTicker.test.ts
+++ b/tests/utils/stderrTicker.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatTickerLine } from "../../src/utils/stderrTicker.js";
+
+describe("formatTickerLine", () => {
+  it("renders zero dots padded to 3 chars so the suffix doesn't jitter", () => {
+    // No dots → 3 spaces of padding so "0s" sits in the same column
+    // whether dots is 0, 1, 2, or 3.
+    expect(formatTickerLine("sending to claude", 0, 0)).toBe(
+      "sending to claude    0s",
+    );
+  });
+
+  it("renders one dot and pads with two spaces", () => {
+    expect(formatTickerLine("sending to claude", 1, 1)).toBe(
+      "sending to claude.   1s",
+    );
+  });
+
+  it("renders three dots with no padding", () => {
+    expect(formatTickerLine("sending to claude", 3, 3)).toBe(
+      "sending to claude... 3s",
+    );
+  });
+
+  it("wraps the dot count at 4 so the cycle is 0,1,2,3,0,1,...", () => {
+    expect(formatTickerLine("x", 4, 4)).toBe("x    4s"); // 4 % 4 === 0 dots
+    expect(formatTickerLine("x", 5, 5)).toBe("x.   5s"); // 5 % 4 === 1 dot
+  });
+
+  it("accepts arbitrary labels and elapsed values", () => {
+    expect(formatTickerLine("waiting", 47, 9)).toBe("waiting.   47s");
+  });
+});


### PR DESCRIPTION
Closes #108

## Summary
Add \`--open\` / \`-o\` to \`agenthud summary\`. Once the summary
markdown is written (or returned from cache), agenthud spawns the
OS's default app on the file so the user lands on a rendered view
instantly — typically a browser with a markdown extension or VS Code.

Covers every shape of summary:
- daily (\`--date\`)
- range (\`--last\`, \`--from\`/\`--to\`)
- cache hits — the user asked for \`--open\`, so the cached file is
  launched too.

## Implementation
Native, no npm dep.

\`buildOpenCommand(platform, path)\` returns the OS-specific
command/args:
- darwin → \`open\`, \`[path]\`
- linux  → \`xdg-open\`, \`[path]\`
- win32  → \`cmd\`, \`["/c", "start", "", path]\`
- other  → \`null\` (caller falls back to a stderr warning)

\`openInDefaultApp(path)\` runs \`spawn(...)\` with \`detached: true\`,
\`stdio: "ignore"\`, then \`unref()\` so agenthud exits immediately and
the launched viewer stays alive. Spawn errors print one stderr line —
the printed path acts as the user's fallback.

## Files
- New: \`src/utils/openInDefaultApp.ts\` (pure helper + spawn wrapper).
- \`src/cli.ts\`: \`-o\`/\`--open\` parsing, \`summaryOpen?\` on
  CliOptions, help text.
- \`src/data/summaryRunner.ts\`: \`open?\` on SummaryOptions /
  RangeSummaryOptions, fires \`openInDefaultApp\` on success paths
  (daily, range cache-hit, range fresh-generation).
- \`src/main.ts\` threads the flag through.
- README: new example.

## Tests
- \`buildOpenCommand\`: 5 cases — darwin, linux, win32 quoting,
  unknown platform → null, paths with spaces preserved verbatim.
- \`parseArgs\` summary: \`--open\`, \`-o\`, alongside \`--last\`,
  default undefined.
- Spawn side-effect: covered by manual smoke
  (\`node dist/index.js summary --last 2d -o\`).

## Test plan
- [x] \`npx vitest run\` — 466/466 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [x] Help text shows the new flag

Note: not bundled into a release. Per user instruction, paused on
shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-o` / `--open` flag to the `summary` command so generated summaries open in your OS default app after creation or cache retrieval.

* **Documentation**
  * Updated "Summary" docs with the `--open` example usage (e.g., `agenthud summary --last 7d --open`).
  * Updated "Live monitor" docs to reflect current TUI layout/styling and spinner/"alive" behavior in the activity feed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->