### PR TITLE
feat: summaries index + per-summary backlinks + --open-index / -I

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,22 @@ Run this in a separate terminal while using Claude Code. Press `?` inside the TU
 AgentHUD's TUI splits the screen into a project tree and an activity viewer:
 
 ```
-┌─ Projects ───────────────────────────────────────────────┐
-│ > agenthud  ~/WestbrookAI/agenthud                   13m │
-│     #864f [hot] Fix the auth bug in login flow           │
-│         ├─ » code-reviewer                               │
-│     (#398c [warm])                                       │
-│   myproject  ~/work/myproject                         2d │
-│     #def4 [hot] Add OAuth support                        │
-│ ... 12 cold projects                                     │
-└──────────────────────────────────────────────────────────┘
-┌─ Activity · agenthud ────────────────────────────────────┐
-│ [10:23] ○ Read  src/ui/App.tsx                           │
-│ [10:23] ~ Edit  src/ui/App.tsx                           │
-│ [10:23] $ Bash  npm test                                 │
-│ [10:23] < Response  Tests passed successfully            │
+┌─ Projects ─────────────────────────────────────────────────┐
+│ > agenthud  ~/WestbrookAI/agenthud                     13m │
+│     #864f [hot] Fix the auth bug in login flow             │
+│         ├─ » code-reviewer                                 │
+│     (#398c [warm])                                         │
+│   myproject  ~/work/myproject                           2d │
+│     #def4 [hot] Add OAuth support                          │
+│ ... 12 cold projects                                       │
+└────────────────────────────────────────────────────────────┘
+┌─ Activity · agenthud ──────────────────────────────────────┐
+│ [10:23] ○ Read  src/ui/App.tsx                             │
+│ [10:23] ~ Edit  src/ui/App.tsx                             │
+│ [10:23] $ Bash  npm test                                   │
+│ [10:23] < Response  Tests passed successfully              │
 │ [10:25] ⠧ Edit  src/auth/oauth.ts  ← bold + spinner = live │
-└──────────────────────────────────────────────────────────┘
+└────────────────────────────────────────────────────────────┘
 ```
 
 **Project tree (top pane)**
@@ -207,6 +207,9 @@ agenthud summary --last 7d -y                       # skip per-day confirmations
 # Cheaper model — summarization doesn't need Opus-tier reasoning
 agenthud summary --date today --model sonnet        # ~40% cheaper than Opus
 agenthud summary --last 7d --model haiku            # ~80% cheaper, 200K context
+
+# Open the resulting summary in your OS default app (browser, VS Code, etc.)
+agenthud summary --last 7d --open                   # -o is the short form
 ```
 
 **Daily summaries** are saved to `~/.agenthud/summaries/YYYY-MM-DD.md`. Past dates are cached and returned instantly; today is always regenerated (activity still growing).

--- a/README.md
+++ b/README.md
@@ -210,7 +210,14 @@ agenthud summary --last 7d --model haiku            # ~80% cheaper, 200K context
 
 # Open the resulting summary in your OS default app (browser, VS Code, etc.)
 agenthud summary --last 7d --open                   # -o is the short form
+
+# Open the index (~/.agenthud/summaries/index.md) instead — a hub
+# listing every daily and range summary, grouped by year/month.
+agenthud summary --open-index                       # -I is the short form
+agenthud summary -oI                                # open today + the index
 ```
+
+The index is auto-regenerated whenever a summary writes, and each summary file gets a one-line backlink footer at the top (`← all summaries · ← prev · next →`) so any markdown viewer is enough to navigate the whole corpus without leaving the file.
 
 **Daily summaries** are saved to `~/.agenthud/summaries/YYYY-MM-DD.md`. Past dates are cached and returned instantly; today is always regenerated (activity still growing).
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -211,7 +211,7 @@ export function formatEffectiveOptionsLine(
   parts.push(`with-git=${fields.withGit ? "on" : "off"}`);
   if (fields.format) parts.push(`format=${fields.format}`);
   if (fields.model) parts.push(`model=${fields.model}`);
-  return `agenthud: ${command} → ${parts.join(" ")}`;
+  return `${command} → ${parts.join(" ")}`;
 }
 
 function todayLocalMidnight(): Date {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,8 @@ export interface CliOptions {
   summaryFormat?: "markdown" | "json";
   summaryDetailLimit?: number;
   summaryWithGit?: boolean;
+  /** Launch the resulting summary in the OS default app after writing. */
+  summaryOpen?: boolean;
   summaryError?: string;
   scopeToCwd?: boolean;
 }
@@ -72,6 +74,8 @@ const KNOWN_SUMMARY_FLAGS = new Set([
   "--format",
   "--detail-limit",
   "--with-git",
+  "-o",
+  "--open",
 ]);
 const KNOWN_SUBCOMMANDS = new Set(["watch", "report", "summary"]);
 
@@ -108,7 +112,7 @@ Commands:
 
   summary [--date DATE | --last Nd | --from DATE --to DATE]
           [--include TYPES] [--detail-limit N] [--with-git]
-          [--prompt TEXT] [--force] [--model NAME] [-y]
+          [--prompt TEXT] [--force] [--model NAME] [-y] [-o]
                                 Generate an LLM summary via the claude
                                 CLI. A single day produces a daily
                                 summary; a date range produces a
@@ -129,6 +133,9 @@ Commands:
                                 "haiku", or a full model id)
     -y, --yes                   Skip confirmation prompts for new daily
                                 summaries
+    -o, --open                  Launch the resulting summary in your OS
+                                default app once it's written (or read
+                                back from cache).
 
   Defaults for report and summary live under \`report:\` and \`summary:\`
   in ~/.agenthud/config.yaml. Flags override config values per-run; the
@@ -468,6 +475,8 @@ export function parseArgs(
 
     if (rest.includes("--force")) summaryForce = true;
     if (rest.includes("-y") || rest.includes("--yes")) summaryAssumeYes = true;
+    const summaryOpen =
+      rest.includes("--open") || rest.includes("-o") || undefined;
 
     // Resolve report-shaped options for summary:
     //   CLI flag → config.summary.X → config.report.X → built-in default.
@@ -552,6 +561,7 @@ export function parseArgs(
       summaryFormat,
       summaryDetailLimit,
       summaryWithGit,
+      summaryOpen,
       summaryError,
     };
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,8 @@ export interface CliOptions {
   summaryWithGit?: boolean;
   /** Launch the resulting summary in the OS default app after writing. */
   summaryOpen?: boolean;
+  /** Launch ~/.agenthud/summaries/index.md in the OS default app. */
+  summaryOpenIndex?: boolean;
   summaryError?: string;
   scopeToCwd?: boolean;
 }
@@ -76,6 +78,8 @@ const KNOWN_SUMMARY_FLAGS = new Set([
   "--with-git",
   "-o",
   "--open",
+  "-I",
+  "--open-index",
 ]);
 const KNOWN_SUBCOMMANDS = new Set(["watch", "report", "summary"]);
 
@@ -136,6 +140,9 @@ Commands:
     -o, --open                  Launch the resulting summary in your OS
                                 default app once it's written (or read
                                 back from cache).
+    -I, --open-index            Launch ~/.agenthud/summaries/index.md
+                                in your OS default app. Combinable with
+                                -o (e.g. -oI opens both).
 
   Defaults for report and summary live under \`report:\` and \`summary:\`
   in ~/.agenthud/config.yaml. Flags override config values per-run; the
@@ -477,6 +484,10 @@ export function parseArgs(
     if (rest.includes("-y") || rest.includes("--yes")) summaryAssumeYes = true;
     const summaryOpen =
       rest.includes("--open") || rest.includes("-o") || undefined;
+    const summaryOpenIndex =
+      rest.includes("--open-index") ||
+      rest.includes("-I") ||
+      undefined;
 
     // Resolve report-shaped options for summary:
     //   CLI flag → config.summary.X → config.report.X → built-in default.
@@ -562,6 +573,7 @@ export function parseArgs(
       summaryDetailLimit,
       summaryWithGit,
       summaryOpen,
+      summaryOpenIndex,
       summaryError,
     };
   }

--- a/src/data/summariesIndex.ts
+++ b/src/data/summariesIndex.ts
@@ -1,0 +1,294 @@
+/**
+ * Maintenance for ~/.agenthud/summaries/ as a navigable knowledge base:
+ *
+ * - `index.md` is an auto-regenerated hub listing every daily and range
+ *   summary, grouped year → month → entry (newest first).
+ * - Each summary file gets a one-line backlink footer prepended at the
+ *   top so a reader can hop back to the index or to neighboring dates
+ *   without leaving their markdown viewer.
+ *
+ * Markdown only — VS Code preview and browser markdown extensions
+ * render relative links inline, so we never need to ship HTML.
+ *
+ * The pure helpers in this module are exported individually so each
+ * one is unit-testable; the side-effect orchestrator `regenerateIndex`
+ * sits at the bottom and is exercised end-to-end via manual smoke.
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface DailyEntry {
+  kind: "daily";
+  date: Date; // local midnight of the summary day
+  filename: string; // e.g. "2026-06-07.md"
+}
+
+export interface RangeEntry {
+  kind: "range";
+  from: Date;
+  to: Date;
+  filename: string; // e.g. "range-2026-06-01_2026-06-07.md"
+}
+
+export type SummaryEntry = DailyEntry | RangeEntry;
+
+// ─── Markers ─────────────────────────────────────────────────────────────────
+
+const INDEX_HEADER_MARKER = "<!-- agenthud-summaries-index -->";
+const BACKLINK_START_MARKER = "<!-- agenthud-backlinks-start -->";
+const BACKLINK_END_MARKER = "<!-- agenthud-backlinks-end -->";
+
+// ─── Date helpers ────────────────────────────────────────────────────────────
+
+const DAILY_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
+const RANGE_RE = /^range-(\d{4})-(\d{2})-(\d{2})_(\d{4})-(\d{2})-(\d{2})\.md$/;
+
+function makeLocalDate(y: number, m: number, d: number): Date | null {
+  // Validate by round-tripping through the Date constructor — out-of-range
+  // values (e.g. month=13, day=99) get normalised, so we detect them by
+  // re-reading the components.
+  const date = new Date(y, m - 1, d);
+  if (
+    date.getFullYear() !== y ||
+    date.getMonth() !== m - 1 ||
+    date.getDate() !== d
+  ) {
+    return null;
+  }
+  return date;
+}
+
+// ─── parseSummaryFilename ────────────────────────────────────────────────────
+
+export function parseSummaryFilename(name: string): SummaryEntry | null {
+  const range = RANGE_RE.exec(name);
+  if (range) {
+    const from = makeLocalDate(
+      Number(range[1]),
+      Number(range[2]),
+      Number(range[3]),
+    );
+    const to = makeLocalDate(
+      Number(range[4]),
+      Number(range[5]),
+      Number(range[6]),
+    );
+    if (!from || !to) return null;
+    return { kind: "range", from, to, filename: name };
+  }
+  const daily = DAILY_RE.exec(name);
+  if (daily) {
+    const date = makeLocalDate(
+      Number(daily[1]),
+      Number(daily[2]),
+      Number(daily[3]),
+    );
+    if (!date) return null;
+    return { kind: "daily", date, filename: name };
+  }
+  return null;
+}
+
+// ─── listSummaries ───────────────────────────────────────────────────────────
+
+/**
+ * Scan the summaries directory and return every recognized entry.
+ *
+ * Sort order — newest first throughout:
+ *   - by year (desc)
+ *   - within a year by month (desc)
+ *   - within a month, range entries before dailies; dailies by day (desc).
+ */
+export function listSummaries(dir: string): SummaryEntry[] {
+  if (!existsSync(dir)) return [];
+  let names: string[];
+  try {
+    names = readdirSync(dir) as string[];
+  } catch {
+    return [];
+  }
+  const entries = names
+    .map((n) => parseSummaryFilename(n))
+    .filter((e): e is SummaryEntry => e !== null);
+
+  // For the chronological anchor of each entry, ranges sort by their
+  // `from` date — that's what places them at the head of their month.
+  const anchor = (e: SummaryEntry): Date =>
+    e.kind === "range" ? e.from : e.date;
+
+  entries.sort((a, b) => {
+    const da = anchor(a);
+    const db = anchor(b);
+    if (da.getFullYear() !== db.getFullYear()) {
+      return db.getFullYear() - da.getFullYear();
+    }
+    if (da.getMonth() !== db.getMonth()) {
+      return db.getMonth() - da.getMonth();
+    }
+    // Same month: ranges win.
+    if (a.kind !== b.kind) return a.kind === "range" ? -1 : 1;
+    return db.getTime() - da.getTime();
+  });
+  return entries;
+}
+
+// ─── buildIndexMarkdown ──────────────────────────────────────────────────────
+
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+function formatDateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function entryAnchor(e: SummaryEntry): Date {
+  return e.kind === "range" ? e.from : e.date;
+}
+
+export function buildIndexMarkdown(entries: SummaryEntry[]): string {
+  const lines: string[] = [INDEX_HEADER_MARKER, "", "# AgentHUD summaries", ""];
+  if (entries.length === 0) {
+    lines.push("_No summaries yet. Run `agenthud summary` to create one._");
+    return `${lines.join("\n")}\n`;
+  }
+
+  // Group by year, then by month, preserving the input sort order.
+  const byYear = new Map<number, Map<number, SummaryEntry[]>>();
+  for (const entry of entries) {
+    const a = entryAnchor(entry);
+    const y = a.getFullYear();
+    const m = a.getMonth();
+    const months = byYear.get(y) ?? new Map<number, SummaryEntry[]>();
+    const bucket = months.get(m) ?? [];
+    bucket.push(entry);
+    months.set(m, bucket);
+    byYear.set(y, months);
+  }
+
+  for (const [year, months] of byYear) {
+    lines.push(`## ${year}`, "");
+    for (const [month, bucket] of months) {
+      lines.push(`### ${MONTHS[month]}`);
+      for (const entry of bucket) {
+        if (entry.kind === "range") {
+          const fromIso = formatDateKey(entry.from);
+          const toIso = formatDateKey(entry.to);
+          lines.push(
+            `- [Range: ${fromIso} → ${toIso}](./${entry.filename}) · weekly`,
+          );
+        } else {
+          const iso = formatDateKey(entry.date);
+          lines.push(`- [${iso}](./${entry.filename})`);
+        }
+      }
+      lines.push("");
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+// ─── buildBacklinkFooter ─────────────────────────────────────────────────────
+
+export function buildBacklinkFooter(
+  currentFilename: string,
+  entries: SummaryEntry[],
+): string {
+  const parts = ["[← all summaries](./index.md)"];
+  const me = entries.find((e) => e.filename === currentFilename);
+
+  if (me && me.kind === "daily") {
+    // Walk only the dailies — range entries skipped so the chain reads
+    // as a day-by-day sequence.
+    const dailies = entries
+      .filter((e): e is DailyEntry => e.kind === "daily")
+      .sort((a, b) => a.date.getTime() - b.date.getTime()); // oldest → newest
+
+    const idx = dailies.findIndex((e) => e.filename === currentFilename);
+    if (idx > 0) {
+      const prev = dailies[idx - 1];
+      parts.push(
+        `[← ${formatDateKey(prev.date)}](./${prev.filename})`,
+      );
+    }
+    if (idx >= 0 && idx < dailies.length - 1) {
+      const next = dailies[idx + 1];
+      parts.push(
+        `[${formatDateKey(next.date)} →](./${next.filename})`,
+      );
+    }
+  }
+
+  const line = parts.join(" · ");
+  return `${BACKLINK_START_MARKER}\n${line}\n${BACKLINK_END_MARKER}\n\n`;
+}
+
+// ─── strip / prepend backlink footer ─────────────────────────────────────────
+
+export function stripExistingBacklinkFooter(content: string): string {
+  if (!content.startsWith(BACKLINK_START_MARKER)) return content;
+  const endIdx = content.indexOf(BACKLINK_END_MARKER);
+  if (endIdx === -1) return content; // defensive: orphan start marker, leave alone
+  // Cut from start through end marker, then chew one trailing newline-pair
+  // we inserted ourselves.
+  let cut = endIdx + BACKLINK_END_MARKER.length;
+  while (cut < content.length && (content[cut] === "\n" || content[cut] === "\r")) {
+    cut++;
+  }
+  return content.slice(cut);
+}
+
+export function prependBacklinkFooter(content: string, footer: string): string {
+  return footer + stripExistingBacklinkFooter(content);
+}
+
+// ─── Orchestrator ────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort: rewrite index.md and refresh every summary's backlink
+ * footer. Failures on individual files are swallowed so a stale or
+ * permission-denied summary never blocks the post-LLM path.
+ */
+export function regenerateIndex(summariesDir: string): void {
+  const entries = listSummaries(summariesDir);
+
+  // 1. Write the hub.
+  const indexPath = join(summariesDir, "index.md");
+  try {
+    writeFileSync(indexPath, buildIndexMarkdown(entries), "utf-8");
+  } catch (err) {
+    process.stderr.write(
+      `warning: cannot write summaries index (${(err as Error).message})\n`,
+    );
+  }
+
+  // 2. Update each summary's backlink footer.
+  for (const entry of entries) {
+    const path = join(summariesDir, entry.filename);
+    try {
+      const content = readFileSync(path, "utf-8");
+      const footer = buildBacklinkFooter(entry.filename, entries);
+      const updated = prependBacklinkFooter(content, footer);
+      if (updated !== content) {
+        writeFileSync(path, updated, "utf-8");
+      }
+    } catch {
+      // Best-effort: skip files we can't read/write. The LLM call's
+      // success is what matters; the index/backlink layer is decorative.
+    }
+  }
+}

--- a/src/data/summariesIndex.ts
+++ b/src/data/summariesIndex.ts
@@ -152,15 +152,30 @@ const MONTHS = [
   "December",
 ];
 
+const WEEKDAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
 function formatDateKey(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/** `YYYY-MM-DD (Sun)` — what the index and backlink labels render. */
+function formatDateLabel(d: Date): string {
+  return `${formatDateKey(d)} (${WEEKDAYS_SHORT[d.getDay()]})`;
 }
 
 function entryAnchor(e: SummaryEntry): Date {
   return e.kind === "range" ? e.from : e.date;
 }
 
-export function buildIndexMarkdown(entries: SummaryEntry[]): string {
+/**
+ * `snippets` (optional) maps filename → one-line preview. When a
+ * matching entry exists it's rendered as `— preview` after the date
+ * label. Files without a snippet just get the link, no separator.
+ */
+export function buildIndexMarkdown(
+  entries: SummaryEntry[],
+  snippets?: Map<string, string>,
+): string {
   const lines: string[] = [INDEX_HEADER_MARKER, "", "# AgentHUD summaries", ""];
   if (entries.length === 0) {
     lines.push("_No summaries yet. Run `agenthud summary` to create one._");
@@ -185,15 +200,18 @@ export function buildIndexMarkdown(entries: SummaryEntry[]): string {
     for (const [month, bucket] of months) {
       lines.push(`### ${MONTHS[month]}`);
       for (const entry of bucket) {
+        const snippet = snippets?.get(entry.filename);
+        const trail = snippet ? ` — ${snippet}` : "";
         if (entry.kind === "range") {
           const fromIso = formatDateKey(entry.from);
           const toIso = formatDateKey(entry.to);
           lines.push(
-            `- [Range: ${fromIso} → ${toIso}](./${entry.filename}) · weekly`,
+            `- [Range: ${fromIso} → ${toIso}](./${entry.filename}) · weekly${trail}`,
           );
         } else {
-          const iso = formatDateKey(entry.date);
-          lines.push(`- [${iso}](./${entry.filename})`);
+          lines.push(
+            `- [${formatDateLabel(entry.date)}](./${entry.filename})${trail}`,
+          );
         }
       }
       lines.push("");
@@ -222,13 +240,13 @@ export function buildBacklinkFooter(
     if (idx > 0) {
       const prev = dailies[idx - 1];
       parts.push(
-        `[← ${formatDateKey(prev.date)}](./${prev.filename})`,
+        `[← ${formatDateLabel(prev.date)}](./${prev.filename})`,
       );
     }
     if (idx >= 0 && idx < dailies.length - 1) {
       const next = dailies[idx + 1];
       parts.push(
-        `[${formatDateKey(next.date)} →](./${next.filename})`,
+        `[${formatDateLabel(next.date)} →](./${next.filename})`,
       );
     }
   }
@@ -256,6 +274,30 @@ export function prependBacklinkFooter(content: string, footer: string): string {
   return footer + stripExistingBacklinkFooter(content);
 }
 
+// ─── extractContextSnippet ───────────────────────────────────────────────────
+
+/**
+ * One-line preview pulled from a summary file: the first non-empty,
+ * non-heading, non-comment line in the body (after stripping any
+ * leading backlink footer). Truncates to `maxChars` with an ellipsis.
+ * Returns `null` for empty files or files with no prose.
+ */
+export function extractContextSnippet(
+  content: string,
+  maxChars = 200,
+): string | null {
+  const body = stripExistingBacklinkFooter(content);
+  for (const raw of body.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith("#")) continue;
+    if (line.startsWith("<!--")) continue;
+    if (line.length <= maxChars) return line;
+    return `${line.slice(0, maxChars - 1).trimEnd()}…`;
+  }
+  return null;
+}
+
 // ─── Orchestrator ────────────────────────────────────────────────────────────
 
 /**
@@ -266,21 +308,18 @@ export function prependBacklinkFooter(content: string, footer: string): string {
 export function regenerateIndex(summariesDir: string): void {
   const entries = listSummaries(summariesDir);
 
-  // 1. Write the hub.
-  const indexPath = join(summariesDir, "index.md");
-  try {
-    writeFileSync(indexPath, buildIndexMarkdown(entries), "utf-8");
-  } catch (err) {
-    process.stderr.write(
-      `warning: cannot write summaries index (${(err as Error).message})\n`,
-    );
-  }
-
-  // 2. Update each summary's backlink footer.
+  // Single pass over the files: for each one, extract the snippet for
+  // the index, refresh the backlink footer, and (only if changed) write
+  // the file back. The snippet extraction operates on the
+  // backlink-stripped body so the preview is the real first prose line,
+  // not the navigation row.
+  const snippets = new Map<string, string>();
   for (const entry of entries) {
     const path = join(summariesDir, entry.filename);
     try {
       const content = readFileSync(path, "utf-8");
+      const snippet = extractContextSnippet(content);
+      if (snippet) snippets.set(entry.filename, snippet);
       const footer = buildBacklinkFooter(entry.filename, entries);
       const updated = prependBacklinkFooter(content, footer);
       if (updated !== content) {
@@ -290,5 +329,19 @@ export function regenerateIndex(summariesDir: string): void {
       // Best-effort: skip files we can't read/write. The LLM call's
       // success is what matters; the index/backlink layer is decorative.
     }
+  }
+
+  // Write the hub last so its snippets reflect the final on-disk state.
+  const indexPath = join(summariesDir, "index.md");
+  try {
+    writeFileSync(
+      indexPath,
+      buildIndexMarkdown(entries, snippets),
+      "utf-8",
+    );
+  } catch (err) {
+    process.stderr.write(
+      `warning: cannot write summaries index (${(err as Error).message})\n`,
+    );
   }
 }

--- a/src/data/summariesIndex.ts
+++ b/src/data/summariesIndex.ts
@@ -153,6 +153,15 @@ const MONTHS = [
 ];
 
 const WEEKDAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const WEEKDAYS_LONG = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
 
 function formatDateKey(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
@@ -220,9 +229,39 @@ export function buildIndexMarkdown(
   return `${lines.join("\n")}\n`;
 }
 
-// ─── buildBacklinkFooter ─────────────────────────────────────────────────────
+// ─── buildTitleLine ──────────────────────────────────────────────────────────
 
-export function buildBacklinkFooter(
+/**
+ * H1 title for the summary file — added inside the header block so a
+ * reader landing on the file directly knows what date / span it covers
+ * without consulting the filename or breadcrumbs above.
+ *
+ * - Daily: `# 2026-05-15 (Friday)` — long weekday for at-a-glance
+ *   reading; the index rows use the short form to keep them tight.
+ * - Range: `# Range: 2026-05-11 → 2026-05-17` — the span itself is
+ *   the meaning; weekdays would just be noise.
+ */
+export function buildTitleLine(entry: SummaryEntry): string {
+  if (entry.kind === "range") {
+    return `# Range: ${formatDateKey(entry.from)} → ${formatDateKey(entry.to)}`;
+  }
+  const iso = formatDateKey(entry.date);
+  const weekday = WEEKDAYS_LONG[entry.date.getDay()];
+  return `# ${iso} (${weekday})`;
+}
+
+// ─── buildHeaderBlock ────────────────────────────────────────────────────────
+
+/**
+ * The auto-managed block at the top of every summary file: backlinks
+ * (index + prev/next chain) plus the H1 title. Bracketed by HTML-comment
+ * markers so successive regenerations strip-and-replace it cleanly,
+ * leaving the body untouched.
+ *
+ * Marker constants kept under their original `agenthud-backlinks-*`
+ * names — renaming would orphan files written before this change.
+ */
+export function buildHeaderBlock(
   currentFilename: string,
   entries: SummaryEntry[],
 ): string {
@@ -251,13 +290,14 @@ export function buildBacklinkFooter(
     }
   }
 
-  const line = parts.join(" · ");
-  return `${BACKLINK_START_MARKER}\n${line}\n${BACKLINK_END_MARKER}\n\n`;
+  const backlinkLine = parts.join(" · ");
+  const title = me ? buildTitleLine(me) : "";
+  return `${BACKLINK_START_MARKER}\n${backlinkLine}\n\n${title}\n${BACKLINK_END_MARKER}\n\n`;
 }
 
-// ─── strip / prepend backlink footer ─────────────────────────────────────────
+// ─── strip / prepend header block ────────────────────────────────────────────
 
-export function stripExistingBacklinkFooter(content: string): string {
+export function stripExistingHeaderBlock(content: string): string {
   if (!content.startsWith(BACKLINK_START_MARKER)) return content;
   const endIdx = content.indexOf(BACKLINK_END_MARKER);
   if (endIdx === -1) return content; // defensive: orphan start marker, leave alone
@@ -270,8 +310,8 @@ export function stripExistingBacklinkFooter(content: string): string {
   return content.slice(cut);
 }
 
-export function prependBacklinkFooter(content: string, footer: string): string {
-  return footer + stripExistingBacklinkFooter(content);
+export function prependHeaderBlock(content: string, block: string): string {
+  return block + stripExistingHeaderBlock(content);
 }
 
 // ─── extractContextSnippet ───────────────────────────────────────────────────
@@ -286,7 +326,7 @@ export function extractContextSnippet(
   content: string,
   maxChars = 200,
 ): string | null {
-  const body = stripExistingBacklinkFooter(content);
+  const body = stripExistingHeaderBlock(content);
   for (const raw of body.split("\n")) {
     const line = raw.trim();
     if (!line) continue;
@@ -320,8 +360,8 @@ export function regenerateIndex(summariesDir: string): void {
       const content = readFileSync(path, "utf-8");
       const snippet = extractContextSnippet(content);
       if (snippet) snippets.set(entry.filename, snippet);
-      const footer = buildBacklinkFooter(entry.filename, entries);
-      const updated = prependBacklinkFooter(content, footer);
+      const block = buildHeaderBlock(entry.filename, entries);
+      const updated = prependHeaderBlock(content, block);
       if (updated !== content) {
         writeFileSync(path, updated, "utf-8");
       }

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -13,6 +13,7 @@ import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { loadGlobalConfig } from "../config/globalConfig.js";
 import { openInDefaultApp } from "../utils/openInDefaultApp.js";
+import { startStderrTicker } from "../utils/stderrTicker.js";
 import { generateReport } from "./reportGenerator.js";
 import { discoverSessions } from "./sessions.js";
 
@@ -424,7 +425,7 @@ async function generateDailySummary(
     try {
       const content = readFileSync(cached, "utf-8");
       if (opts.announce) {
-        process.stderr.write(`agenthud: cached summary from ${cached}\n`);
+        process.stderr.write(`cached summary from ${cached}\n`);
       }
       if (opts.streamToStdout) {
         process.stdout.write(content);
@@ -443,7 +444,7 @@ async function generateDailySummary(
   }
 
   if (opts.announce) {
-    process.stderr.write(`agenthud: scanning sessions for ${dateLabel}...\n`);
+    process.stderr.write(`scanning sessions for ${dateLabel}...\n`);
   }
 
   const config = loadGlobalConfig();
@@ -477,7 +478,7 @@ async function generateDailySummary(
     ).length;
     const sizeKb = (reportBytes / 1024).toFixed(1);
     process.stderr.write(
-      `agenthud: input: ${sessionCount} sessions, ${activityCount} activities, ${commitCount} commits (${reportLines.length} lines, ${sizeKb}KB ≈ ${estimatedTokens.toLocaleString()} tokens)\n`,
+      `input: ${sessionCount} sessions, ${activityCount} activities, ${commitCount} commits (${reportLines.length} lines, ${sizeKb}KB ≈ ${estimatedTokens.toLocaleString()} tokens)\n`,
     );
   }
 
@@ -518,11 +519,19 @@ async function generateDailySummary(
     }
   }
 
-  if (opts.announce) {
+  // When streamToStdout is on, the streaming markdown itself is the
+  // progress indicator. When it's off (--open suppression) we'd be
+  // staring at a frozen-looking terminal — start a stderr ticker so
+  // the user knows the LLM call is still running.
+  const showTicker = opts.announce && !opts.streamToStdout;
+  if (opts.announce && !showTicker) {
     process.stderr.write(
-      `agenthud: sending to claude (this may take a minute)...\n\n`,
+      `sending to claude (this may take a minute)...\n\n`,
     );
   }
+  const stopTicker = showTicker
+    ? startStderrTicker("sending to claude")
+    : null;
 
   const prompt = resolvePrompt("daily", opts.promptOverride);
   const result = await spawnClaude({
@@ -532,12 +541,13 @@ async function generateDailySummary(
     streamToStdout: opts.streamToStdout,
     model: opts.model,
   });
+  if (stopTicker) stopTicker();
 
   if (opts.announce && result.code === 0) {
     process.stderr.write("\n");
-    process.stderr.write(`agenthud: saved to ${cached}\n`);
+    process.stderr.write(`saved to ${cached}\n`);
     if (result.usage) {
-      process.stderr.write(`agenthud: ${formatUsage(result.usage)}\n`);
+      process.stderr.write(`${formatUsage(result.usage)}\n`);
     }
   }
 
@@ -594,7 +604,7 @@ export async function runRangeSummary(
     try {
       const content = readFileSync(rangeCache, "utf-8");
       process.stderr.write(
-        `agenthud: cached range summary from ${rangeCache}\n`,
+        `cached range summary from ${rangeCache}\n`,
       );
       if (!options.open) {
         process.stdout.write(content);
@@ -617,10 +627,10 @@ export async function runRangeSummary(
   }
 
   process.stderr.write(
-    `agenthud: range ${fromLabel} → ${toLabel} (${dates.length} days)\n`,
+    `range ${fromLabel} → ${toLabel} (${dates.length} days)\n`,
   );
   process.stderr.write(
-    `agenthud: ${cachedCount} cached, ${missingCount} to generate\n`,
+    `${cachedCount} cached, ${missingCount} to generate\n`,
   );
 
   // Generate dailies sequentially. Confirm just-in-time after scan (when --yes is off).
@@ -630,7 +640,7 @@ export async function runRangeSummary(
   for (const d of dates) {
     const label = dateKey(d);
     const isToday = isSameLocalDay(d, options.today);
-    process.stderr.write(`\nagenthud: --- ${label} ---\n`);
+    process.stderr.write(`\n--- ${label} ---\n`);
 
     const willPrompt = !options.assumeYes && (isToday || !existsSync(dailyCachePath(d)));
     const confirmer = willPrompt
@@ -669,7 +679,7 @@ export async function runRangeSummary(
     }
     const text = res.markdown.trim();
     if (text.length === 0 || /^no activity found/i.test(text)) {
-      process.stderr.write(`agenthud: ${label} has no activity — skipping.\n`);
+      process.stderr.write(`${label} has no activity — skipping.\n`);
       continue;
     }
     dailyMarkdowns.push({ date: d, markdown: text });
@@ -686,29 +696,39 @@ export async function runRangeSummary(
     .join("\n\n---\n\n");
 
   process.stderr.write(
-    `\nagenthud: combining ${dailyMarkdowns.length} daily summaries into range summary...\n`,
+    `\ncombining ${dailyMarkdowns.length} daily summaries into range summary...\n`,
   );
-  process.stderr.write(
-    `agenthud: sending to claude (this may take a minute)...\n\n`,
-  );
+  const metaStreams = !options.open;
+  if (!metaStreams) {
+    // -o suppresses the streamed output — show a ticker instead so the
+    // user has visible feedback during the minute-long LLM call.
+  } else {
+    process.stderr.write(
+      `sending to claude (this may take a minute)...\n\n`,
+    );
+  }
+  const stopMetaTicker = metaStreams
+    ? null
+    : startStderrTicker("sending to claude");
 
   const metaPrompt = resolvePrompt("range");
   const metaResult = await spawnClaude({
     prompt: metaPrompt,
     stdin: metaInput,
     cachePath: rangeCache,
-    streamToStdout: !options.open,
+    streamToStdout: metaStreams,
     model: options.model,
   });
+  if (stopMetaTicker) stopMetaTicker();
 
   if (metaResult.code !== 0) {
     return metaResult.code;
   }
 
   process.stderr.write("\n");
-  process.stderr.write(`agenthud: saved to ${rangeCache}\n`);
+  process.stderr.write(`saved to ${rangeCache}\n`);
   if (metaResult.usage) {
-    process.stderr.write(`agenthud: ${formatUsage(metaResult.usage)}\n`);
+    process.stderr.write(`${formatUsage(metaResult.usage)}\n`);
   }
 
   if (options.open) openInDefaultApp(rangeCache);

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -13,6 +13,7 @@ import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { loadGlobalConfig } from "../config/globalConfig.js";
 import { openInDefaultApp } from "../utils/openInDefaultApp.js";
+import { regenerateIndex } from "./summariesIndex.js";
 import { startStderrTicker } from "../utils/stderrTicker.js";
 import { generateReport } from "./reportGenerator.js";
 import { discoverSessions } from "./sessions.js";
@@ -32,6 +33,8 @@ export interface SummaryOptions {
   withGit: boolean;
   /** Launch the resulting summary in the OS default app after writing. */
   open?: boolean;
+  /** Launch ~/.agenthud/summaries/index.md in the OS default app. */
+  openIndex?: boolean;
 }
 
 export interface RangeSummaryOptions {
@@ -49,6 +52,8 @@ export interface RangeSummaryOptions {
   withGit: boolean;
   /** Launch the resulting range summary in the OS default app after writing. */
   open?: boolean;
+  /** Launch ~/.agenthud/summaries/index.md in the OS default app. */
+  openIndex?: boolean;
 }
 
 type PromptKind = "daily" | "range";
@@ -576,8 +581,18 @@ export async function runSummary(options: SummaryOptions): Promise<number> {
     detailLimit: options.detailLimit,
     withGit: options.withGit,
   });
+  if (res.code === 0 && !res.skipped) {
+    try {
+      regenerateIndex(summariesDir());
+    } catch {
+      /* best-effort — index regen never blocks the summary path */
+    }
+  }
   if (options.open && res.code === 0 && !res.skipped) {
     openInDefaultApp(dailyCachePath(options.date));
+  }
+  if (options.openIndex && res.code === 0 && !res.skipped) {
+    openInDefaultApp(join(summariesDir(), "index.md"));
   }
   return res.code;
 }
@@ -610,7 +625,15 @@ export async function runRangeSummary(
         process.stdout.write(content);
         if (!content.endsWith("\n")) process.stdout.write("\n");
       }
+      try {
+        regenerateIndex(summariesDir());
+      } catch {
+        /* best-effort */
+      }
       if (options.open) openInDefaultApp(rangeCache);
+      if (options.openIndex) {
+        openInDefaultApp(join(summariesDir(), "index.md"));
+      }
       return 0;
     } catch {
       // fall through to regenerate
@@ -731,6 +754,14 @@ export async function runRangeSummary(
     process.stderr.write(`${formatUsage(metaResult.usage)}\n`);
   }
 
+  try {
+    regenerateIndex(summariesDir());
+  } catch {
+    /* best-effort */
+  }
   if (options.open) openInDefaultApp(rangeCache);
+  if (options.openIndex) {
+    openInDefaultApp(join(summariesDir(), "index.md"));
+  }
   return 0;
 }

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { loadGlobalConfig } from "../config/globalConfig.js";
+import { openInDefaultApp } from "../utils/openInDefaultApp.js";
 import { generateReport } from "./reportGenerator.js";
 import { discoverSessions } from "./sessions.js";
 
@@ -28,6 +29,8 @@ export interface SummaryOptions {
   detailLimit: number;
   /** Whether to merge git commits into the LLM payload. */
   withGit: boolean;
+  /** Launch the resulting summary in the OS default app after writing. */
+  open?: boolean;
 }
 
 export interface RangeSummaryOptions {
@@ -43,6 +46,8 @@ export interface RangeSummaryOptions {
   detailLimit: number;
   /** Whether to merge git commits into the per-day payload. */
   withGit: boolean;
+  /** Launch the resulting range summary in the OS default app after writing. */
+  open?: boolean;
 }
 
 type PromptKind = "daily" | "range";
@@ -538,6 +543,9 @@ export async function runSummary(options: SummaryOptions): Promise<number> {
     detailLimit: options.detailLimit,
     withGit: options.withGit,
   });
+  if (options.open && res.code === 0 && !res.skipped) {
+    openInDefaultApp(dailyCachePath(options.date));
+  }
   return res.code;
 }
 
@@ -567,6 +575,7 @@ export async function runRangeSummary(
       );
       process.stdout.write(content);
       if (!content.endsWith("\n")) process.stdout.write("\n");
+      if (options.open) openInDefaultApp(rangeCache);
       return 0;
     } catch {
       // fall through to regenerate
@@ -677,5 +686,6 @@ export async function runRangeSummary(
     process.stderr.write(`agenthud: ${formatUsage(metaResult.usage)}\n`);
   }
 
+  if (options.open) openInDefaultApp(rangeCache);
   return 0;
 }

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -72,6 +72,26 @@ function userPromptPath(kind: PromptKind): string {
   return join(homedir(), ".agenthud", promptFilename(kind));
 }
 
+/**
+ * Compact, user-facing label for the prompt this summary run is using.
+ * - daily/range with no inline override → the user prompt file path,
+ *   abbreviated to `~/...` so the line stays readable.
+ * - daily with `--prompt TEXT` → "<inline> (from --prompt)".
+ *   (Range mode does not accept --prompt, so override is ignored when
+ *   kind is "range".)
+ */
+export function formatPromptSource(
+  kind: "daily" | "range",
+  override?: string,
+): string {
+  if (kind === "daily" && override) {
+    return "<inline> (from --prompt)";
+  }
+  const home = homedir();
+  const path = userPromptPath(kind);
+  return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
+}
+
 function templatePath(kind: PromptKind): string {
   const here = dirname(fileURLToPath(import.meta.url));
   return join(here, "templates", promptFilename(kind));
@@ -531,12 +551,15 @@ async function generateDailySummary(
 }
 
 export async function runSummary(options: SummaryOptions): Promise<number> {
+  // With --open the user is going to read the rendered file in their
+  // default app anyway, so streaming the same markdown to the terminal
+  // is duplicate noise (and breaks downstream piping). Suppress.
   const res = await generateDailySummary({
     date: options.date,
     today: options.today,
     force: options.force,
     promptOverride: options.prompt,
-    streamToStdout: true,
+    streamToStdout: !options.open,
     announce: true,
     model: options.model,
     include: options.include,
@@ -573,8 +596,10 @@ export async function runRangeSummary(
       process.stderr.write(
         `agenthud: cached range summary from ${rangeCache}\n`,
       );
-      process.stdout.write(content);
-      if (!content.endsWith("\n")) process.stdout.write("\n");
+      if (!options.open) {
+        process.stdout.write(content);
+        if (!content.endsWith("\n")) process.stdout.write("\n");
+      }
       if (options.open) openInDefaultApp(rangeCache);
       return 0;
     } catch {
@@ -672,7 +697,7 @@ export async function runRangeSummary(
     prompt: metaPrompt,
     stdin: metaInput,
     cachePath: rangeCache,
-    streamToStdout: true,
+    streamToStdout: !options.open,
     model: options.model,
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,11 @@ import {
   findContainingProject,
   getProjectsDir,
 } from "./data/sessions.js";
-import { runRangeSummary, runSummary } from "./data/summaryRunner.js";
+import {
+  formatPromptSource,
+  runRangeSummary,
+  runSummary,
+} from "./data/summaryRunner.js";
 import { App } from "./ui/App.js";
 import { enterAltScreen, installAltScreenCleanup } from "./utils/altScreen.js";
 import { isLegacyProjectConfig } from "./utils/legacyConfig.js";
@@ -110,6 +114,13 @@ if (options.mode === "summary") {
       withGit: options.summaryWithGit ?? false,
       model: options.summaryModel,
     })}\n`,
+  );
+  const isRangeMode = !!(options.summaryFrom && options.summaryTo);
+  process.stderr.write(
+    `agenthud: prompt = ${formatPromptSource(
+      isRangeMode ? "range" : "daily",
+      options.summaryPrompt,
+    )}\n`,
   );
   const today = new Date();
   if (options.summaryFrom && options.summaryTo) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,7 +117,7 @@ if (options.mode === "summary") {
   );
   const isRangeMode = !!(options.summaryFrom && options.summaryTo);
   process.stderr.write(
-    `agenthud: prompt = ${formatPromptSource(
+    `prompt = ${formatPromptSource(
       isRangeMode ? "range" : "daily",
       options.summaryPrompt,
     )}\n`,
@@ -178,7 +178,7 @@ if (options.scopeToCwd) {
     process.exit(1);
   }
   scopeToProject = match;
-  process.stderr.write(`agenthud: scope = ${match}\n`);
+  process.stderr.write(`scope = ${match}\n`);
 }
 
 if (options.mode === "watch") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,6 +135,7 @@ if (options.mode === "summary") {
       detailLimit: options.summaryDetailLimit!,
       withGit: options.summaryWithGit!,
       open: options.summaryOpen,
+      openIndex: options.summaryOpenIndex,
     });
     process.exit(exitCode);
   }
@@ -148,6 +149,7 @@ if (options.mode === "summary") {
     detailLimit: options.summaryDetailLimit!,
     withGit: options.summaryWithGit!,
     open: options.summaryOpen,
+    openIndex: options.summaryOpenIndex,
   });
   process.exit(exitCode);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,6 +123,7 @@ if (options.mode === "summary") {
       include: options.summaryInclude!,
       detailLimit: options.summaryDetailLimit!,
       withGit: options.summaryWithGit!,
+      open: options.summaryOpen,
     });
     process.exit(exitCode);
   }
@@ -135,6 +136,7 @@ if (options.mode === "summary") {
     include: options.summaryInclude!,
     detailLimit: options.summaryDetailLimit!,
     withGit: options.summaryWithGit!,
+    open: options.summaryOpen,
   });
   process.exit(exitCode);
 }

--- a/src/utils/openInDefaultApp.ts
+++ b/src/utils/openInDefaultApp.ts
@@ -1,0 +1,63 @@
+import { spawn } from "node:child_process";
+
+export interface OpenCommand {
+  command: string;
+  args: string[];
+}
+
+/**
+ * Build the OS-specific command needed to open a file with the user's
+ * default application. Returns null on platforms we don't recognize so
+ * the caller can fall back to a warning + the printed path.
+ *
+ * Paths are passed through verbatim — `spawn` handles quoting at the
+ * argument boundary, so caller-supplied spaces / unicode are fine.
+ */
+export function buildOpenCommand(
+  platform: NodeJS.Platform | string,
+  path: string,
+): OpenCommand | null {
+  switch (platform) {
+    case "darwin":
+      return { command: "open", args: [path] };
+    case "linux":
+      return { command: "xdg-open", args: [path] };
+    case "win32":
+      // The empty-string after `start` is the window title — Windows
+      // treats the first quoted argument to `start` as the title, so a
+      // path with spaces would otherwise be eaten as the title and the
+      // file would never open.
+      return { command: "cmd", args: ["/c", "start", "", path] };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Launch the OS default app on `path` and return immediately. Failures
+ * (no command, spawn error, missing handler like `xdg-open` on
+ * minimal Linux) are reported on stderr; the agenthud process keeps
+ * going so the path it already printed remains the user's fallback.
+ */
+export function openInDefaultApp(path: string): void {
+  const cmd = buildOpenCommand(process.platform, path);
+  if (!cmd) {
+    process.stderr.write(
+      `agenthud: --open: no known opener for platform "${process.platform}"\n`,
+    );
+    return;
+  }
+  try {
+    const child = spawn(cmd.command, cmd.args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", (err) => {
+      process.stderr.write(`agenthud: --open failed: ${err.message}\n`);
+    });
+    child.unref();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`agenthud: --open failed: ${msg}\n`);
+  }
+}

--- a/src/utils/stderrTicker.ts
+++ b/src/utils/stderrTicker.ts
@@ -1,0 +1,51 @@
+/**
+ * Live "still working" feedback on stderr while a long-running task
+ * (LLM call, big build, etc.) blocks. Renders the same line repeatedly
+ * using a carriage return so the spinner doesn't scroll past the
+ * pre-line content.
+ *
+ * Use case in agenthud: when --open suppresses the streamed claude
+ * output, the user is otherwise staring at a frozen-looking terminal
+ * for 30–60+ seconds. A ticking line tells them the process is alive.
+ */
+
+/** Pure helper used to render the ticker line. Exported for testing. */
+export function formatTickerLine(
+  label: string,
+  elapsedSeconds: number,
+  dots: number,
+): string {
+  // dots ∈ [0..3]; pad to 3 chars so the trailing text doesn't jitter.
+  const tail = ".".repeat(dots % 4).padEnd(3, " ");
+  return `${label}${tail} ${elapsedSeconds}s`;
+}
+
+/**
+ * Start writing a ticker to stderr. Returns a `stop()` function that
+ * clears the line and stops the interval. Safe to call stop() even if
+ * the ticker never wrote anything (e.g. the task finished before the
+ * first tick).
+ */
+export function startStderrTicker(
+  label: string,
+  options: { intervalMs?: number; stream?: NodeJS.WritableStream } = {},
+): () => void {
+  const intervalMs = options.intervalMs ?? 500;
+  const stream = options.stream ?? process.stderr;
+  const start = Date.now();
+  let ticks = 0;
+
+  const id = setInterval(() => {
+    ticks++;
+    const elapsed = Math.floor((Date.now() - start) / 1000);
+    stream.write(`\r${formatTickerLine(label, elapsed, ticks)}`);
+  }, intervalMs);
+
+  return function stop(): void {
+    clearInterval(id);
+    // Wipe whatever the spinner wrote so the next stderr line starts
+    // clean at column 0. \r returns to column start, \x1b[K erases to
+    // end-of-line.
+    if (ticks > 0) stream.write("\r\x1b[K");
+  };
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -439,6 +439,32 @@ describe("parseArgs", () => {
       expect(opts.summaryModel).toBeUndefined();
     });
 
+    describe("--open / -o flag", () => {
+      it("parses --open", () => {
+        const opts = parseArgs(["summary", "--open"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryOpen).toBe(true);
+      });
+
+      it("parses -o", () => {
+        const opts = parseArgs(["summary", "-o"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryOpen).toBe(true);
+      });
+
+      it("works alongside --last", () => {
+        const opts = parseArgs(["summary", "--last", "7d", "--open"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryOpen).toBe(true);
+        expect(opts.summaryFrom).toBeDefined();
+      });
+
+      it("defaults to undefined when neither flag is given", () => {
+        const opts = parseArgs(["summary"]);
+        expect(opts.summaryOpen).toBeUndefined();
+      });
+    });
+
     describe("report-shaped options on summary", () => {
       it("parses --include and threads it through", () => {
         const opts = parseArgs(["summary", "--include", "response,user"]);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -571,7 +571,7 @@ describe("formatEffectiveOptionsLine", () => {
       format: "markdown",
     });
     expect(line).toBe(
-      "agenthud: report → include=[user,response,bash,edit,thinking] detail-limit=120 with-git=off format=markdown",
+      "report → include=[user,response,bash,edit,thinking] detail-limit=120 with-git=off format=markdown",
     );
   });
 
@@ -583,7 +583,7 @@ describe("formatEffectiveOptionsLine", () => {
       model: "sonnet",
     });
     expect(line).toBe(
-      "agenthud: summary → include=[bash] detail-limit=∞ with-git=on model=sonnet",
+      "summary → include=[bash] detail-limit=∞ with-git=on model=sonnet",
     );
   });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -465,6 +465,32 @@ describe("parseArgs", () => {
       });
     });
 
+    describe("--open-index / -I flag", () => {
+      it("parses --open-index", () => {
+        const opts = parseArgs(["summary", "--open-index"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryOpenIndex).toBe(true);
+      });
+
+      it("parses -I", () => {
+        const opts = parseArgs(["summary", "-I"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryOpenIndex).toBe(true);
+      });
+
+      it("defaults to undefined when neither flag is given", () => {
+        const opts = parseArgs(["summary"]);
+        expect(opts.summaryOpenIndex).toBeUndefined();
+      });
+
+      it("can be combined with -o (both flags become true)", () => {
+        const opts = parseArgs(["summary", "-o", "-I"]);
+        expect(opts.summaryError).toBeUndefined();
+        expect(opts.summaryOpen).toBe(true);
+        expect(opts.summaryOpenIndex).toBe(true);
+      });
+    });
+
     describe("report-shaped options on summary", () => {
       it("parses --include and threads it through", () => {
         const opts = parseArgs(["summary", "--include", "response,user"]);

--- a/tests/data/summariesIndex.test.ts
+++ b/tests/data/summariesIndex.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildBacklinkFooter,
   buildIndexMarkdown,
+  extractContextSnippet,
   parseSummaryFilename,
   prependBacklinkFooter,
   stripExistingBacklinkFooter,
@@ -83,19 +84,38 @@ describe("buildIndexMarkdown", () => {
     expect(md).toContain("<!-- agenthud-summaries-index -->");
   });
 
-  it("renders a daily-only single-month list", () => {
+  it("renders a daily-only single-month list with weekday tags", () => {
     const md = buildIndexMarkdown([
       mkDaily("2026-06-07"),
       mkDaily("2026-06-06"),
     ]);
     expect(md).toContain("## 2026");
     expect(md).toContain("### June");
-    expect(md).toContain("- [2026-06-07](./2026-06-07.md)");
-    expect(md).toContain("- [2026-06-06](./2026-06-06.md)");
+    // 2026-06-07 is a Sunday, 2026-06-06 is a Saturday.
+    expect(md).toContain("- [2026-06-07 (Sun)](./2026-06-07.md)");
+    expect(md).toContain("- [2026-06-06 (Sat)](./2026-06-06.md)");
     // newest first
     expect(md.indexOf("2026-06-07.md")).toBeLessThan(
       md.indexOf("2026-06-06.md"),
     );
+  });
+
+  it("appends snippets when provided via the snippets map", () => {
+    const md = buildIndexMarkdown(
+      [mkDaily("2026-06-07")],
+      new Map([
+        ["2026-06-07.md", "Shipped --open / -o for summary."],
+      ]),
+    );
+    expect(md).toContain(
+      "- [2026-06-07 (Sun)](./2026-06-07.md) — Shipped --open / -o for summary.",
+    );
+  });
+
+  it("omits the em-dash when no snippet is available for that file", () => {
+    const md = buildIndexMarkdown([mkDaily("2026-06-07")]);
+    expect(md).toContain("- [2026-06-07 (Sun)](./2026-06-07.md)\n");
+    expect(md).not.toContain("- [2026-06-07 (Sun)](./2026-06-07.md) —");
   });
 
   it("renders a range entry with the range label and links to its file", () => {
@@ -152,21 +172,21 @@ describe("buildBacklinkFooter", () => {
     expect(footer).toContain("[← all summaries](./index.md)");
   });
 
-  it("daily with both prev and next dailies emits all three links", () => {
+  it("daily with both prev and next dailies emits all three links with weekday tags", () => {
     const entries = [
-      mkDaily("2026-06-08"),
-      mkDaily("2026-06-07"),
-      mkDaily("2026-06-06"),
+      mkDaily("2026-06-08"), // Mon
+      mkDaily("2026-06-07"), // Sun
+      mkDaily("2026-06-06"), // Sat
     ];
     const footer = buildBacklinkFooter("2026-06-07.md", entries);
-    expect(footer).toContain("[← 2026-06-06](./2026-06-06.md)");
-    expect(footer).toContain("[2026-06-08 →](./2026-06-08.md)");
+    expect(footer).toContain("[← 2026-06-06 (Sat)](./2026-06-06.md)");
+    expect(footer).toContain("[2026-06-08 (Mon) →](./2026-06-08.md)");
   });
 
   it("daily with only prev does not synthesize a next", () => {
     const entries = [mkDaily("2026-06-07"), mkDaily("2026-06-06")];
     const footer = buildBacklinkFooter("2026-06-07.md", entries);
-    expect(footer).toContain("[← 2026-06-06](./2026-06-06.md)");
+    expect(footer).toContain("[← 2026-06-06 (Sat)](./2026-06-06.md)");
     expect(footer).not.toContain("→");
   });
 
@@ -217,5 +237,50 @@ describe("stripExistingBacklinkFooter / prependBacklinkFooter", () => {
       "<!-- agenthud-backlinks-start -->\norphan\n# title\n";
     // No closing marker → leave alone, don't risk eating real content.
     expect(stripExistingBacklinkFooter(body)).toBe(body);
+  });
+});
+
+describe("extractContextSnippet", () => {
+  it("returns the first prose line after the heading", () => {
+    const content =
+      "## Context\n\nTwo workstreams ran today: built the index feature and reviewed PRs.\n\n## More\n";
+    expect(extractContextSnippet(content)).toBe(
+      "Two workstreams ran today: built the index feature and reviewed PRs.",
+    );
+  });
+
+  it("ignores leading backlink footer when extracting", () => {
+    const content =
+      "<!-- agenthud-backlinks-start -->\n[← all](./index.md)\n<!-- agenthud-backlinks-end -->\n\n## Context\n\nReal content here.\n";
+    expect(extractContextSnippet(content)).toBe("Real content here.");
+  });
+
+  it("truncates with ellipsis at 200 chars by default", () => {
+    const long = "x".repeat(500);
+    const content = `${long}\n`;
+    const snippet = extractContextSnippet(content);
+    expect(snippet).not.toBeNull();
+    expect(snippet!.length).toBeLessThanOrEqual(200);
+    expect(snippet!.endsWith("…")).toBe(true);
+  });
+
+  it("respects a custom max-char cap", () => {
+    const content =
+      "This is a fairly long sentence that should be cut by the cap.\n";
+    expect(extractContextSnippet(content, 20)).toBe("This is a fairly lo…");
+  });
+
+  it("returns null for an empty file", () => {
+    expect(extractContextSnippet("")).toBeNull();
+  });
+
+  it("returns null for a file with only headings and blanks", () => {
+    expect(extractContextSnippet("## Context\n\n## More\n")).toBeNull();
+  });
+
+  it("returns null for a file with only the backlink footer (no body)", () => {
+    const content =
+      "<!-- agenthud-backlinks-start -->\n[← all](./index.md)\n<!-- agenthud-backlinks-end -->\n";
+    expect(extractContextSnippet(content)).toBeNull();
   });
 });

--- a/tests/data/summariesIndex.test.ts
+++ b/tests/data/summariesIndex.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBacklinkFooter,
+  buildIndexMarkdown,
+  parseSummaryFilename,
+  prependBacklinkFooter,
+  stripExistingBacklinkFooter,
+  type SummaryEntry,
+} from "../../src/data/summariesIndex.js";
+
+describe("parseSummaryFilename", () => {
+  it("recognizes a daily summary filename and parses the date as local midnight", () => {
+    const entry = parseSummaryFilename("2026-06-07.md");
+    expect(entry).not.toBeNull();
+    expect(entry?.kind).toBe("daily");
+    if (entry?.kind === "daily") {
+      expect(entry.filename).toBe("2026-06-07.md");
+      expect(entry.date.getFullYear()).toBe(2026);
+      expect(entry.date.getMonth()).toBe(5); // June (0-indexed)
+      expect(entry.date.getDate()).toBe(7);
+      expect(entry.date.getHours()).toBe(0);
+    }
+  });
+
+  it("recognizes a range summary filename and parses both bounds", () => {
+    const entry = parseSummaryFilename(
+      "range-2026-06-01_2026-06-07.md",
+    );
+    expect(entry).not.toBeNull();
+    expect(entry?.kind).toBe("range");
+    if (entry?.kind === "range") {
+      expect(entry.filename).toBe("range-2026-06-01_2026-06-07.md");
+      expect(entry.from.getFullYear()).toBe(2026);
+      expect(entry.from.getDate()).toBe(1);
+      expect(entry.to.getDate()).toBe(7);
+    }
+  });
+
+  it("returns null for a malformed daily (impossible date)", () => {
+    expect(parseSummaryFilename("2026-13-99.md")).toBeNull();
+  });
+
+  it("returns null for the index file itself", () => {
+    expect(parseSummaryFilename("index.md")).toBeNull();
+  });
+
+  it("returns null for a non-markdown file", () => {
+    expect(parseSummaryFilename("notes.txt")).toBeNull();
+  });
+
+  it("returns null for hidden files like .DS_Store", () => {
+    expect(parseSummaryFilename(".DS_Store")).toBeNull();
+  });
+
+  it("returns null for completely arbitrary names", () => {
+    expect(parseSummaryFilename("hello-world.md")).toBeNull();
+  });
+});
+
+describe("buildIndexMarkdown", () => {
+  const mkDaily = (iso: string): SummaryEntry => {
+    const [y, m, d] = iso.split("-").map(Number);
+    return {
+      kind: "daily",
+      date: new Date(y, m - 1, d),
+      filename: `${iso}.md`,
+    };
+  };
+  const mkRange = (fromIso: string, toIso: string): SummaryEntry => {
+    const [fy, fm, fd] = fromIso.split("-").map(Number);
+    const [ty, tm, td] = toIso.split("-").map(Number);
+    return {
+      kind: "range",
+      from: new Date(fy, fm - 1, fd),
+      to: new Date(ty, tm - 1, td),
+      filename: `range-${fromIso}_${toIso}.md`,
+    };
+  };
+
+  it("returns just a header when there are no entries", () => {
+    const md = buildIndexMarkdown([]);
+    expect(md).toContain("# AgentHUD summaries");
+    expect(md).toContain("<!-- agenthud-summaries-index -->");
+  });
+
+  it("renders a daily-only single-month list", () => {
+    const md = buildIndexMarkdown([
+      mkDaily("2026-06-07"),
+      mkDaily("2026-06-06"),
+    ]);
+    expect(md).toContain("## 2026");
+    expect(md).toContain("### June");
+    expect(md).toContain("- [2026-06-07](./2026-06-07.md)");
+    expect(md).toContain("- [2026-06-06](./2026-06-06.md)");
+    // newest first
+    expect(md.indexOf("2026-06-07.md")).toBeLessThan(
+      md.indexOf("2026-06-06.md"),
+    );
+  });
+
+  it("renders a range entry with the range label and links to its file", () => {
+    const md = buildIndexMarkdown([mkRange("2026-06-01", "2026-06-07")]);
+    expect(md).toContain(
+      "- [Range: 2026-06-01 → 2026-06-07](./range-2026-06-01_2026-06-07.md) · weekly",
+    );
+  });
+
+  it("groups across years and months newest-first", () => {
+    const md = buildIndexMarkdown([
+      mkDaily("2026-06-07"),
+      mkDaily("2026-05-31"),
+      mkDaily("2025-12-25"),
+    ]);
+    // year order
+    expect(md.indexOf("## 2026")).toBeLessThan(md.indexOf("## 2025"));
+    // month order within 2026 (June before May)
+    expect(md.indexOf("### June")).toBeLessThan(md.indexOf("### May"));
+  });
+});
+
+describe("buildBacklinkFooter", () => {
+  const mkDaily = (iso: string): SummaryEntry => {
+    const [y, m, d] = iso.split("-").map(Number);
+    return {
+      kind: "daily",
+      date: new Date(y, m - 1, d),
+      filename: `${iso}.md`,
+    };
+  };
+  const mkRange = (fromIso: string, toIso: string): SummaryEntry => {
+    const [fy, fm, fd] = fromIso.split("-").map(Number);
+    const [ty, tm, td] = toIso.split("-").map(Number);
+    return {
+      kind: "range",
+      from: new Date(fy, fm - 1, fd),
+      to: new Date(ty, tm - 1, td),
+      filename: `range-${fromIso}_${toIso}.md`,
+    };
+  };
+
+  it("wraps the line in HTML-comment markers so we can re-prepend idempotently", () => {
+    const entries = [mkDaily("2026-06-07")];
+    const footer = buildBacklinkFooter("2026-06-07.md", entries);
+    expect(footer).toContain("<!-- agenthud-backlinks-start -->");
+    expect(footer).toContain("<!-- agenthud-backlinks-end -->");
+  });
+
+  it("always includes a link back to the index", () => {
+    const footer = buildBacklinkFooter("2026-06-07.md", [
+      mkDaily("2026-06-07"),
+    ]);
+    expect(footer).toContain("[← all summaries](./index.md)");
+  });
+
+  it("daily with both prev and next dailies emits all three links", () => {
+    const entries = [
+      mkDaily("2026-06-08"),
+      mkDaily("2026-06-07"),
+      mkDaily("2026-06-06"),
+    ];
+    const footer = buildBacklinkFooter("2026-06-07.md", entries);
+    expect(footer).toContain("[← 2026-06-06](./2026-06-06.md)");
+    expect(footer).toContain("[2026-06-08 →](./2026-06-08.md)");
+  });
+
+  it("daily with only prev does not synthesize a next", () => {
+    const entries = [mkDaily("2026-06-07"), mkDaily("2026-06-06")];
+    const footer = buildBacklinkFooter("2026-06-07.md", entries);
+    expect(footer).toContain("[← 2026-06-06](./2026-06-06.md)");
+    expect(footer).not.toContain("→");
+  });
+
+  it("range entries get the index link only — no prev/next chain", () => {
+    const entries = [
+      mkRange("2026-06-01", "2026-06-07"),
+      mkDaily("2026-06-07"),
+      mkDaily("2026-06-06"),
+    ];
+    const footer = buildBacklinkFooter(
+      "range-2026-06-01_2026-06-07.md",
+      entries,
+    );
+    expect(footer).toContain("[← all summaries](./index.md)");
+    expect(footer).not.toContain("→");
+    expect(footer).not.toContain("[← 2026");
+  });
+});
+
+describe("stripExistingBacklinkFooter / prependBacklinkFooter", () => {
+  it("prepending onto fresh content yields footer + body", () => {
+    const body = "# title\n\nbody\n";
+    const footer =
+      "<!-- agenthud-backlinks-start -->\n[← all summaries](./index.md)\n<!-- agenthud-backlinks-end -->\n\n";
+    const out = prependBacklinkFooter(body, footer);
+    expect(out).toBe(`${footer}${body}`);
+  });
+
+  it("prepending onto content that already has a footer replaces it cleanly", () => {
+    const body = "# title\n\nbody\n";
+    const oldFooter =
+      "<!-- agenthud-backlinks-start -->\nold\n<!-- agenthud-backlinks-end -->\n\n";
+    const withOld = `${oldFooter}${body}`;
+    const newFooter =
+      "<!-- agenthud-backlinks-start -->\nnew\n<!-- agenthud-backlinks-end -->\n\n";
+    const out = prependBacklinkFooter(withOld, newFooter);
+    expect(out).toBe(`${newFooter}${body}`);
+    expect(out).not.toContain("old");
+  });
+
+  it("strip-only on content with no footer is a no-op", () => {
+    const body = "# title\n\nbody\n";
+    expect(stripExistingBacklinkFooter(body)).toBe(body);
+  });
+
+  it("strip-only on content with only the start marker is a no-op (defensive)", () => {
+    const body =
+      "<!-- agenthud-backlinks-start -->\norphan\n# title\n";
+    // No closing marker → leave alone, don't risk eating real content.
+    expect(stripExistingBacklinkFooter(body)).toBe(body);
+  });
+});

--- a/tests/data/summariesIndex.test.ts
+++ b/tests/data/summariesIndex.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildBacklinkFooter,
+  buildHeaderBlock,
   buildIndexMarkdown,
+  buildTitleLine,
   extractContextSnippet,
   parseSummaryFilename,
-  prependBacklinkFooter,
-  stripExistingBacklinkFooter,
+  prependHeaderBlock,
+  stripExistingHeaderBlock,
   type SummaryEntry,
 } from "../../src/data/summariesIndex.js";
 
@@ -138,7 +139,7 @@ describe("buildIndexMarkdown", () => {
   });
 });
 
-describe("buildBacklinkFooter", () => {
+describe("buildTitleLine", () => {
   const mkDaily = (iso: string): SummaryEntry => {
     const [y, m, d] = iso.split("-").map(Number);
     return {
@@ -158,18 +159,57 @@ describe("buildBacklinkFooter", () => {
     };
   };
 
-  it("wraps the line in HTML-comment markers so we can re-prepend idempotently", () => {
-    const entries = [mkDaily("2026-06-07")];
-    const footer = buildBacklinkFooter("2026-06-07.md", entries);
-    expect(footer).toContain("<!-- agenthud-backlinks-start -->");
-    expect(footer).toContain("<!-- agenthud-backlinks-end -->");
+  it("renders a daily title with the long weekday for readability", () => {
+    // 2026-06-07 is a Sunday.
+    expect(buildTitleLine(mkDaily("2026-06-07"))).toBe(
+      "# 2026-06-07 (Sunday)",
+    );
   });
 
-  it("always includes a link back to the index", () => {
-    const footer = buildBacklinkFooter("2026-06-07.md", [
-      mkDaily("2026-06-07"),
-    ]);
-    expect(footer).toContain("[← all summaries](./index.md)");
+  it("renders a Friday daily as 'Friday'", () => {
+    expect(buildTitleLine(mkDaily("2026-05-15"))).toBe(
+      "# 2026-05-15 (Friday)",
+    );
+  });
+
+  it("renders a range title without the weekday (the span carries the meaning)", () => {
+    expect(buildTitleLine(mkRange("2026-05-11", "2026-05-17"))).toBe(
+      "# Range: 2026-05-11 → 2026-05-17",
+    );
+  });
+});
+
+describe("buildHeaderBlock", () => {
+  const mkDaily = (iso: string): SummaryEntry => {
+    const [y, m, d] = iso.split("-").map(Number);
+    return {
+      kind: "daily",
+      date: new Date(y, m - 1, d),
+      filename: `${iso}.md`,
+    };
+  };
+  const mkRange = (fromIso: string, toIso: string): SummaryEntry => {
+    const [fy, fm, fd] = fromIso.split("-").map(Number);
+    const [ty, tm, td] = toIso.split("-").map(Number);
+    return {
+      kind: "range",
+      from: new Date(fy, fm - 1, fd),
+      to: new Date(ty, tm - 1, td),
+      filename: `range-${fromIso}_${toIso}.md`,
+    };
+  };
+
+  it("wraps the block in HTML-comment markers so we can re-prepend idempotently", () => {
+    const entries = [mkDaily("2026-06-07")];
+    const block = buildHeaderBlock("2026-06-07.md", entries);
+    expect(block).toContain("<!-- agenthud-backlinks-start -->");
+    expect(block).toContain("<!-- agenthud-backlinks-end -->");
+  });
+
+  it("always includes a link back to the index and the H1 title", () => {
+    const block = buildHeaderBlock("2026-06-07.md", [mkDaily("2026-06-07")]);
+    expect(block).toContain("[← all summaries](./index.md)");
+    expect(block).toContain("# 2026-06-07 (Sunday)");
   });
 
   it("daily with both prev and next dailies emits all three links with weekday tags", () => {
@@ -178,40 +218,41 @@ describe("buildBacklinkFooter", () => {
       mkDaily("2026-06-07"), // Sun
       mkDaily("2026-06-06"), // Sat
     ];
-    const footer = buildBacklinkFooter("2026-06-07.md", entries);
-    expect(footer).toContain("[← 2026-06-06 (Sat)](./2026-06-06.md)");
-    expect(footer).toContain("[2026-06-08 (Mon) →](./2026-06-08.md)");
+    const block = buildHeaderBlock("2026-06-07.md", entries);
+    expect(block).toContain("[← 2026-06-06 (Sat)](./2026-06-06.md)");
+    expect(block).toContain("[2026-06-08 (Mon) →](./2026-06-08.md)");
   });
 
   it("daily with only prev does not synthesize a next", () => {
     const entries = [mkDaily("2026-06-07"), mkDaily("2026-06-06")];
-    const footer = buildBacklinkFooter("2026-06-07.md", entries);
-    expect(footer).toContain("[← 2026-06-06 (Sat)](./2026-06-06.md)");
-    expect(footer).not.toContain("→");
+    const block = buildHeaderBlock("2026-06-07.md", entries);
+    expect(block).toContain("[← 2026-06-06 (Sat)](./2026-06-06.md)");
+    expect(block).not.toContain("→");
   });
 
-  it("range entries get the index link only — no prev/next chain", () => {
+  it("range entries get the index link + range title — no prev/next chain", () => {
     const entries = [
       mkRange("2026-06-01", "2026-06-07"),
       mkDaily("2026-06-07"),
       mkDaily("2026-06-06"),
     ];
-    const footer = buildBacklinkFooter(
+    const block = buildHeaderBlock(
       "range-2026-06-01_2026-06-07.md",
       entries,
     );
-    expect(footer).toContain("[← all summaries](./index.md)");
-    expect(footer).not.toContain("→");
-    expect(footer).not.toContain("[← 2026");
+    expect(block).toContain("[← all summaries](./index.md)");
+    expect(block).toContain("# Range: 2026-06-01 → 2026-06-07");
+    expect(block).not.toContain("→](./");
+    expect(block).not.toContain("[← 2026");
   });
 });
 
-describe("stripExistingBacklinkFooter / prependBacklinkFooter", () => {
+describe("stripExistingHeaderBlock / prependHeaderBlock", () => {
   it("prepending onto fresh content yields footer + body", () => {
     const body = "# title\n\nbody\n";
     const footer =
       "<!-- agenthud-backlinks-start -->\n[← all summaries](./index.md)\n<!-- agenthud-backlinks-end -->\n\n";
-    const out = prependBacklinkFooter(body, footer);
+    const out = prependHeaderBlock(body, footer);
     expect(out).toBe(`${footer}${body}`);
   });
 
@@ -222,21 +263,21 @@ describe("stripExistingBacklinkFooter / prependBacklinkFooter", () => {
     const withOld = `${oldFooter}${body}`;
     const newFooter =
       "<!-- agenthud-backlinks-start -->\nnew\n<!-- agenthud-backlinks-end -->\n\n";
-    const out = prependBacklinkFooter(withOld, newFooter);
+    const out = prependHeaderBlock(withOld, newFooter);
     expect(out).toBe(`${newFooter}${body}`);
     expect(out).not.toContain("old");
   });
 
   it("strip-only on content with no footer is a no-op", () => {
     const body = "# title\n\nbody\n";
-    expect(stripExistingBacklinkFooter(body)).toBe(body);
+    expect(stripExistingHeaderBlock(body)).toBe(body);
   });
 
   it("strip-only on content with only the start marker is a no-op (defensive)", () => {
     const body =
       "<!-- agenthud-backlinks-start -->\norphan\n# title\n";
     // No closing marker → leave alone, don't risk eating real content.
-    expect(stripExistingBacklinkFooter(body)).toBe(body);
+    expect(stripExistingHeaderBlock(body)).toBe(body);
   });
 });
 

--- a/tests/data/summaryRunner.formatPromptSource.test.ts
+++ b/tests/data/summaryRunner.formatPromptSource.test.ts
@@ -1,0 +1,37 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { formatPromptSource } from "../../src/data/summaryRunner.js";
+
+describe("formatPromptSource", () => {
+  it("returns the daily prompt path with ~ abbreviation when no override", () => {
+    expect(formatPromptSource("daily")).toBe("~/.agenthud/summary-prompt.md");
+  });
+
+  it("returns the range prompt path with ~ abbreviation when no override", () => {
+    expect(formatPromptSource("range")).toBe(
+      "~/.agenthud/summary-range-prompt.md",
+    );
+  });
+
+  it("returns an inline marker when the user passed --prompt on daily", () => {
+    expect(formatPromptSource("daily", "Only commits")).toBe(
+      "<inline> (from --prompt)",
+    );
+  });
+
+  it("ignores inline override on range (range does not accept --prompt)", () => {
+    expect(formatPromptSource("range", "ignored")).toBe(
+      "~/.agenthud/summary-range-prompt.md",
+    );
+  });
+
+  it("falls back to the absolute path when homedir is not a prefix", () => {
+    // Sanity: the helper still produces a usable label even if the user's
+    // homedir somehow doesn't match the path (rare in practice, e.g.
+    // sandboxed test runners with a custom XDG layout).
+    const path = formatPromptSource("daily");
+    if (!path.startsWith("~")) {
+      expect(path).toContain(homedir());
+    }
+  });
+});

--- a/tests/utils/openInDefaultApp.test.ts
+++ b/tests/utils/openInDefaultApp.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildOpenCommand } from "../../src/utils/openInDefaultApp.js";
+
+describe("buildOpenCommand", () => {
+  it("uses `open <path>` on macOS", () => {
+    expect(buildOpenCommand("darwin", "/tmp/foo.md")).toEqual({
+      command: "open",
+      args: ["/tmp/foo.md"],
+    });
+  });
+
+  it("uses `xdg-open <path>` on Linux", () => {
+    expect(buildOpenCommand("linux", "/tmp/foo.md")).toEqual({
+      command: "xdg-open",
+      args: ["/tmp/foo.md"],
+    });
+  });
+
+  it("uses `cmd /c start \"\" <path>` on Windows", () => {
+    // The empty-string first arg to `start` is the window title — required
+    // because Windows treats the first quoted argument as the title.
+    expect(buildOpenCommand("win32", "C:/tmp/foo.md")).toEqual({
+      command: "cmd",
+      args: ["/c", "start", "", "C:/tmp/foo.md"],
+    });
+  });
+
+  it("returns null for an unsupported platform so the caller can warn", () => {
+    expect(buildOpenCommand("aix", "/tmp/foo.md")).toBeNull();
+  });
+
+  it("preserves paths containing spaces verbatim (spawn handles quoting)", () => {
+    const result = buildOpenCommand(
+      "darwin",
+      "/Users/me/Library/Application Support/agenthud/summary.md",
+    );
+    expect(result).toEqual({
+      command: "open",
+      args: ["/Users/me/Library/Application Support/agenthud/summary.md"],
+    });
+  });
+});

--- a/tests/utils/stderrTicker.test.ts
+++ b/tests/utils/stderrTicker.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatTickerLine } from "../../src/utils/stderrTicker.js";
+
+describe("formatTickerLine", () => {
+  it("renders zero dots padded to 3 chars so the suffix doesn't jitter", () => {
+    // No dots → 3 spaces of padding so "0s" sits in the same column
+    // whether dots is 0, 1, 2, or 3.
+    expect(formatTickerLine("sending to claude", 0, 0)).toBe(
+      "sending to claude    0s",
+    );
+  });
+
+  it("renders one dot and pads with two spaces", () => {
+    expect(formatTickerLine("sending to claude", 1, 1)).toBe(
+      "sending to claude.   1s",
+    );
+  });
+
+  it("renders three dots with no padding", () => {
+    expect(formatTickerLine("sending to claude", 3, 3)).toBe(
+      "sending to claude... 3s",
+    );
+  });
+
+  it("wraps the dot count at 4 so the cycle is 0,1,2,3,0,1,...", () => {
+    expect(formatTickerLine("x", 4, 4)).toBe("x    4s"); // 4 % 4 === 0 dots
+    expect(formatTickerLine("x", 5, 5)).toBe("x.   5s"); // 5 % 4 === 1 dot
+  });
+
+  it("accepts arbitrary labels and elapsed values", () => {
+    expect(formatTickerLine("waiting", 47, 9)).toBe("waiting.   47s");
+  });
+});


### PR DESCRIPTION
Closes #110

Branched off \`feat/108-summary-open\` to inherit the \`--open\`
infrastructure I'm mirroring here. Will rebase onto \`main\` cleanly
once PR #109 lands.

## Summary
Turn \`~/.agenthud/summaries/\` from a flat directory of dated files
into a navigable knowledge base.

1. **\`index.md\` hub** — auto-regenerated on every successful summary
   write. Lists every daily and range summary grouped year → month →
   entry, newest first. Range entries float to the head of their month
   with a \`· weekly\` tag.

2. **Backlink footer** prepended at the top of each summary file:
   \`\`\`
   [← all summaries](./index.md) · [← 2026-06-06](./2026-06-06.md) · [2026-06-08 →](./2026-06-08.md)
   \`\`\`
   Wrapped in HTML-comment markers so successive runs replace it
   idempotently. Range entries are skipped in the prev/next walk so
   the day-to-day sequence stays clean.

3. **\`--open-index\` / \`-I\`** mirrors \`--open\` / \`-o\`. Both can
   fire from the same invocation: \`summary -oI\` opens today's
   summary and the index at once.

Markdown viewers (VS Code preview, browser markdown extensions) render
the relative links inline, so the \`.md\` file is the navigation — no
HTML, no extra dependency.

## Files
- \`src/data/summariesIndex.ts\` (new) — every pure helper plus the
  \`regenerateIndex\` orchestrator.
- \`src/data/summaryRunner.ts\` — imports \`regenerateIndex\`; calls it
  at the three success points already touched by \`--open\`. Failures
  swallowed — index/backlink work never blocks the LLM-success path.
- \`src/cli.ts\` — \`-I\` / \`--open-index\` parsing,
  \`summaryOpenIndex\` on \`CliOptions\`, help text.
- \`src/main.ts\` — flag threading.
- \`README.md\` — example block + brief paragraph.

## Tests
- \`summariesIndex\`: 20 cases — \`parseSummaryFilename\` (7),
  \`buildIndexMarkdown\` (4), \`buildBacklinkFooter\` (5),
  \`stripExistingBacklinkFooter\` / \`prependBacklinkFooter\` (4).
- \`cli\`: 4 cases for \`-I\`/\`--open-index\` (long, short, default,
  combined with \`-o\`).

## Test plan
- [x] \`npx vitest run\` — 500/500 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [ ] Manual smoke:
      \`node dist/index.js summary -I\` opens \`index.md\`,
      \`summary -oI\` opens both, fresh summaries get backlinks at top.

## Out of scope
Persisting LLM usage info (token/cost columns in the index). The
survey confirmed it's stderr-only today — adding it would either need
frontmatter (changes the file contract) or a sidecar
\`.metadata.json\`. Deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI flags (`--open`, `--open-index`) to open generated summaries and index in your OS default application.
  * Implemented automatic summaries index with navigation between entries.

* **Documentation**
  * Updated README with instructions on opening summaries and summaries index.
  * Documented index auto-regeneration behavior and backlink footer details.

* **Style**
  * Improved output message formatting for cleaner terminal display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->