### PR TITLE
fix: --open surfaces WSL failures + summary skips claude on empty input

### DIFF
--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   unlinkSync,
+  writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -478,19 +479,52 @@ async function generateDailySummary(
   const reportBytes = Buffer.byteLength(reportMarkdown, "utf-8");
   const estimatedTokens = Math.ceil(reportBytes / 4);
 
+  const reportLines = reportMarkdown.split("\n");
+  const sessionCount = reportLines.filter((l) => l.startsWith("## ")).length;
+  const activityCount = reportLines.filter((l) =>
+    /^\[\d{2}:\d{2}\]/.test(l),
+  ).length;
+  const commitCount = reportLines.filter((l) =>
+    /^\[\d{2}:\d{2}\] ◆/.test(l),
+  ).length;
+
   if (opts.announce) {
-    const reportLines = reportMarkdown.split("\n");
-    const sessionCount = reportLines.filter((l) => l.startsWith("## ")).length;
-    const activityCount = reportLines.filter((l) =>
-      /^\[\d{2}:\d{2}\]/.test(l),
-    ).length;
-    const commitCount = reportLines.filter((l) =>
-      /^\[\d{2}:\d{2}\] ◆/.test(l),
-    ).length;
     const sizeKb = (reportBytes / 1024).toFixed(1);
     process.stderr.write(
       `input: ${sessionCount} sessions, ${activityCount} activities, ${commitCount} commits (${reportLines.length} lines, ${sizeKb}KB ≈ ${estimatedTokens.toLocaleString()} tokens)\n`,
     );
+  }
+
+  // Skip the LLM call entirely when there's nothing to summarize. Without
+  // this, `summary --date today` against an empty day still pays for a
+  // claude call that produces nothing useful (and on `-o` it would open
+  // an empty page). Write a small stub so the cache exists for the
+  // index and future calls return instantly.
+  if (sessionCount === 0 && activityCount === 0 && commitCount === 0) {
+    const stub =
+      `## Context\n\nNo activity recorded for ${dateLabel}.\n` +
+      "No claude call was issued — the report was empty.\n";
+    try {
+      writeFileSync(cached, stub, "utf-8");
+    } catch {
+      // Best-effort: stub still lets us return a useful result even if
+      // the cache write fails (downstream reads will just regenerate).
+    }
+    if (opts.announce) {
+      process.stderr.write(
+        `${dateLabel} has no activity — wrote stub to ${cached}, skipped claude\n`,
+      );
+    }
+    if (opts.streamToStdout) {
+      process.stdout.write(stub);
+    }
+    return {
+      code: 0,
+      markdown: stub,
+      fromCache: false,
+      skipped: false,
+      usage: null,
+    };
   }
 
   if (opts.confirmBeforeSpawn) {
@@ -595,10 +629,10 @@ export async function runSummary(options: SummaryOptions): Promise<number> {
     }
   }
   if (options.open && res.code === 0 && !res.skipped) {
-    openInDefaultApp(dailyCachePath(options.date));
+    await openInDefaultApp(dailyCachePath(options.date));
   }
   if (options.openIndex && res.code === 0 && !res.skipped) {
-    openInDefaultApp(join(summariesDir(), "index.md"));
+    await openInDefaultApp(join(summariesDir(), "index.md"));
   }
   return res.code;
 }
@@ -636,9 +670,9 @@ export async function runRangeSummary(
       } catch {
         /* best-effort */
       }
-      if (options.open) openInDefaultApp(rangeCache);
+      if (options.open) await openInDefaultApp(rangeCache);
       if (options.openIndex) {
-        openInDefaultApp(join(summariesDir(), "index.md"));
+        await openInDefaultApp(join(summariesDir(), "index.md"));
       }
       return 0;
     } catch {
@@ -765,9 +799,9 @@ export async function runRangeSummary(
   } catch {
     /* best-effort */
   }
-  if (options.open) openInDefaultApp(rangeCache);
+  if (options.open) await openInDefaultApp(rangeCache);
   if (options.openIndex) {
-    openInDefaultApp(join(summariesDir(), "index.md"));
+    await openInDefaultApp(join(summariesDir(), "index.md"));
   }
   return 0;
 }

--- a/src/utils/openInDefaultApp.ts
+++ b/src/utils/openInDefaultApp.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 export interface OpenCommand {
   command: string;
@@ -7,20 +9,25 @@ export interface OpenCommand {
 
 /**
  * Build the OS-specific command needed to open a file with the user's
- * default application. Returns null on platforms we don't recognize so
+ * default application. Returns null on platforms we don't recognise so
  * the caller can fall back to a warning + the printed path.
  *
- * Paths are passed through verbatim — `spawn` handles quoting at the
- * argument boundary, so caller-supplied spaces / unicode are fine.
+ * For WSL we prefer `wslview` (from the wslu package) — it knows how
+ * to route through to the Windows host's default app. `xdg-open` is
+ * the linux fallback when wslview isn't installed; on a headless WSL
+ * without a display that will fail but at least the caller sees the
+ * non-zero exit and can warn.
  */
 export function buildOpenCommand(
   platform: NodeJS.Platform | string,
   path: string,
+  opts: { wslView?: boolean } = {},
 ): OpenCommand | null {
   switch (platform) {
     case "darwin":
       return { command: "open", args: [path] };
     case "linux":
+      if (opts.wslView) return { command: "wslview", args: [path] };
       return { command: "xdg-open", args: [path] };
     case "win32":
       // The empty-string after `start` is the window title — Windows
@@ -34,30 +41,129 @@ export function buildOpenCommand(
 }
 
 /**
- * Launch the OS default app on `path` and return immediately. Failures
- * (no command, spawn error, missing handler like `xdg-open` on
- * minimal Linux) are reported on stderr; the agenthud process keeps
- * going so the path it already printed remains the user's fallback.
+ * True when this Node process is running inside WSL. Detected by the
+ * `WSL_DISTRO_NAME` env var (set by Microsoft's launcher) or by the
+ * `microsoft`/`wsl` markers in `/proc/version`.
  */
-export function openInDefaultApp(path: string): void {
-  const cmd = buildOpenCommand(process.platform, path);
+export function isWSL(): boolean {
+  if (process.env.WSL_DISTRO_NAME) return true;
+  try {
+    const ver = readFileSync("/proc/version", "utf-8");
+    return /microsoft|wsl/i.test(ver);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Synchronously check whether `command` is on PATH. Used before spawn
+ * so we can fail loud when the platform-specific opener isn't
+ * installed (e.g. WSL without `xdg-utils` or `wslu`).
+ */
+export function commandExists(command: string): boolean {
+  const PATH = process.env.PATH ?? "";
+  const sep = process.platform === "win32" ? ";" : ":";
+  const exts =
+    process.platform === "win32"
+      ? (process.env.PATHEXT?.split(";") ?? [".EXE", ".CMD", ".BAT"]).map(
+          (e) => e.toLowerCase(),
+        )
+      : [""];
+  for (const dir of PATH.split(sep)) {
+    if (!dir) continue;
+    const full = join(dir, command);
+    for (const ext of exts) {
+      try {
+        if (existsSync(full + ext)) return true;
+      } catch {
+        // ignore — keep walking
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Launch the OS default app on `path`. Returns a promise that resolves
+ * once we know whether the spawn succeeded — either after a brief
+ * grace period (the typical happy path) or as soon as the child errors
+ * / exits with a non-zero code. Failures (no command, fast error, bad
+ * exit) are reported on stderr so the caller's printed path remains a
+ * sensible fallback.
+ */
+export async function openInDefaultApp(path: string): Promise<void> {
+  // Prefer wslview on WSL when it's available (it routes through to
+  // the Windows host); otherwise fall back to xdg-open and let the
+  // command-exists / exit-code check below surface the failure.
+  const wslView = isWSL() && commandExists("wslview");
+  const cmd = buildOpenCommand(process.platform, path, { wslView });
+
   if (!cmd) {
     process.stderr.write(
       `agenthud: --open: no known opener for platform "${process.platform}"\n`,
     );
     return;
   }
-  try {
-    const child = spawn(cmd.command, cmd.args, {
-      detached: true,
-      stdio: "ignore",
-    });
+
+  if (!commandExists(cmd.command)) {
+    process.stderr.write(
+      `agenthud: --open: '${cmd.command}' is not on PATH; cannot open ${path}\n`,
+    );
+    if (isWSL()) {
+      process.stderr.write(
+        "agenthud: hint: on WSL install `wslu` (provides wslview) so files open with the Windows host's default app — e.g. `sudo apt install wslu`\n",
+      );
+    }
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
+    let child;
+    try {
+      child = spawn(cmd.command, cmd.args, {
+        detached: true,
+        stdio: "ignore",
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`agenthud: --open failed: ${msg}\n`);
+      finish();
+      return;
+    }
+
     child.on("error", (err) => {
       process.stderr.write(`agenthud: --open failed: ${err.message}\n`);
+      finish();
     });
-    child.unref();
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`agenthud: --open failed: ${msg}\n`);
-  }
+
+    // Most openers (open/xdg-open/wslview/cmd start) hand off to the
+    // OS and exit within tens of milliseconds; a non-zero exit code
+    // here means the dispatch failed (no display, unknown handler,
+    // …) and we want to surface that.
+    child.on("exit", (code) => {
+      if (code !== null && code !== 0) {
+        process.stderr.write(
+          `agenthud: --open: '${cmd.command}' exited with code ${code}\n`,
+        );
+      }
+      finish();
+    });
+
+    // Give the child up to 200ms to fail fast. If it's still running
+    // by then it almost certainly succeeded (the launched viewer
+    // takes over), so we detach and let agenthud return.
+    setTimeout(() => {
+      if (!settled) {
+        child.unref();
+        finish();
+      }
+    }, 200).unref();
+  });
 }

--- a/tests/utils/openInDefaultApp.test.ts
+++ b/tests/utils/openInDefaultApp.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildOpenCommand } from "../../src/utils/openInDefaultApp.js";
+import {
+  buildOpenCommand,
+  commandExists,
+} from "../../src/utils/openInDefaultApp.js";
 
 describe("buildOpenCommand", () => {
   it("uses `open <path>` on macOS", () => {
@@ -9,11 +12,20 @@ describe("buildOpenCommand", () => {
     });
   });
 
-  it("uses `xdg-open <path>` on Linux", () => {
+  it("uses `xdg-open <path>` on Linux by default", () => {
     expect(buildOpenCommand("linux", "/tmp/foo.md")).toEqual({
       command: "xdg-open",
       args: ["/tmp/foo.md"],
     });
+  });
+
+  it("prefers `wslview` on Linux when the wslView opt is set", () => {
+    // On WSL, openInDefaultApp passes wslView=true after a sync
+    // check that wslview is on PATH; this lets the host's default app
+    // handle the file (browser, VS Code, …) instead of an X server.
+    expect(
+      buildOpenCommand("linux", "/mnt/c/Users/me/foo.md", { wslView: true }),
+    ).toEqual({ command: "wslview", args: ["/mnt/c/Users/me/foo.md"] });
   });
 
   it("uses `cmd /c start \"\" <path>` on Windows", () => {
@@ -38,5 +50,19 @@ describe("buildOpenCommand", () => {
       command: "open",
       args: ["/Users/me/Library/Application Support/agenthud/summary.md"],
     });
+  });
+});
+
+describe("commandExists", () => {
+  it("returns true for a command on the test runner's PATH", () => {
+    // `node` runs vitest, so it's guaranteed to be on PATH everywhere
+    // this test could plausibly execute (CI, dev machines, WSL).
+    expect(commandExists("node")).toBe(true);
+  });
+
+  it("returns false for a command that does not exist", () => {
+    expect(commandExists("definitely-not-a-real-command-xyz-12345")).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
Two bugs the user surfaced while smoke-testing on Windows / WSL.

## #1 — `--open` silently failed in WSL
\`process.platform\` is \`"linux"\` in WSL, so we shipped \`xdg-open\`
— which on a headless WSL exits non-zero, or isn't installed at all.
Detached + \`stdio: "ignore"\` + immediate \`process.exit()\` meant
the spawn-error event never fired before parent died, so the user saw
nothing.

Fixes:
- Sync \`commandExists\` check before spawn → if the opener isn't on
  PATH, clear stderr line and bail (with a hint about \`wslu\` on
  WSL).
- WSL detection + prefer \`wslview\` when present (routes through to
  the Windows host's default app).
- \`openInDefaultApp\` is now async; resolves after a 200ms fail-fast
  window or as soon as the child errors / exits non-zero. Call sites
  await.

## #2 — \`summary\` was sending empty days to claude
With \`report --date today\` yielding "No activity found", agenthud
still piped the empty payload to \`claude -p\`, paying for tokens to
produce nothing. \`range\` mode had per-day "no activity → skipping"
logic; daily didn't.

Fix: in \`generateDailySummary\`, when sessionCount / activityCount /
commitCount are all zero:
- write a small stub to the daily cache
- print "<date> has no activity — wrote stub, skipped claude"
- return success without spawning claude

The stub also reads sensibly in the index snippet column.

## Tests
- \`buildOpenCommand\`: new \`wslView: true\` case asserts \`wslview\`
  is used on linux when the hint is set.
- \`commandExists\`: smoke on \`node\` + nonsense string.
- 515/515 total tests pass.
- Manual smoke against \`CLAUDE_PROJECTS_DIR=$(mktemp -d) node
  dist/index.js summary --date today\` confirms the stub path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved support for opening files in default applications with enhanced Windows Subsystem for Linux detection and command validation.

* **Performance**
  * Optimized daily summary processing to skip unnecessary work when no activity is detected.

* **Bug Fixes**
  * Enhanced error messaging when file opener commands are unavailable on the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->