### PR TITLE
fix: don't propose deleting Windows-side config from WSL (or any user home)

### DIFF
--- a/src/utils/legacyConfig.ts
+++ b/src/utils/legacyConfig.ts
@@ -1,13 +1,41 @@
 import { join, resolve } from "node:path";
+import { isWSL as detectWSL } from "./platform.js";
+
+// `/mnt/<drive>/Users/<name>` — the WSL mount of a Windows-side user
+// home. Only meaningful when we know we're inside WSL.
+const WSL_WINDOWS_USER_HOME = /^\/mnt\/[a-z]\/Users\/[^/]+\/?$/i;
 
 /**
- * Returns true if a `.agenthud/config.yaml` under `cwd` should be treated as a
- * legacy project-level config (and offered for migration). Returns false when
- * the path collides with the global `~/.agenthud/config.yaml`, which happens
- * if the user runs agenthud from their home directory.
+ * Returns true if a `.agenthud/config.yaml` under `cwd` should be
+ * treated as a legacy project-level config (and offered for
+ * migration). Returns false when the path is in fact a global config
+ * we shouldn't touch — currently two cases:
+ *
+ *   1. `cwd` is literally the user's home directory (the existing
+ *      guard — covers every native platform). `homedir()` is the
+ *      source of truth here.
+ *
+ *   2. We're running inside WSL and `cwd` looks like a
+ *      `/mnt/<drive>/Users/<name>` mount of the Windows-side user
+ *      home. In that case `homedir()` lies — it reports the Linux
+ *      home (`/home/<name>`) — but the `.agenthud/config.yaml`
+ *      sitting in the Windows user dir is the Windows-native global
+ *      config and deleting it would wipe real settings.
+ *
+ * `opts.isWSL` is injectable for tests; in real use the default
+ * runtime detector fires.
  */
-export function isLegacyProjectConfig(cwd: string, home: string): boolean {
+export function isLegacyProjectConfig(
+  cwd: string,
+  home: string,
+  opts: { isWSL?: boolean } = {},
+): boolean {
   const legacy = resolve(join(cwd, ".agenthud", "config.yaml"));
   const global = resolve(join(home, ".agenthud", "config.yaml"));
-  return legacy !== global;
+  if (legacy === global) return false;
+
+  const wsl = opts.isWSL ?? detectWSL();
+  if (wsl && WSL_WINDOWS_USER_HOME.test(cwd)) return false;
+
+  return true;
 }

--- a/src/utils/openInDefaultApp.ts
+++ b/src/utils/openInDefaultApp.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { isWSL } from "./platform.js";
 
 export interface OpenCommand {
   command: string;
@@ -37,21 +38,6 @@ export function buildOpenCommand(
       return { command: "cmd", args: ["/c", "start", "", path] };
     default:
       return null;
-  }
-}
-
-/**
- * True when this Node process is running inside WSL. Detected by the
- * `WSL_DISTRO_NAME` env var (set by Microsoft's launcher) or by the
- * `microsoft`/`wsl` markers in `/proc/version`.
- */
-export function isWSL(): boolean {
-  if (process.env.WSL_DISTRO_NAME) return true;
-  try {
-    const ver = readFileSync("/proc/version", "utf-8");
-    return /microsoft|wsl/i.test(ver);
-  } catch {
-    return false;
   }
 }
 

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * True when this Node process is running inside WSL. Detected by the
+ * `WSL_DISTRO_NAME` env var (set by Microsoft's launcher) or the
+ * `microsoft`/`wsl` markers in `/proc/version`. Result is cached for
+ * the lifetime of the process — neither signal changes mid-run.
+ */
+let cached: boolean | null = null;
+export function isWSL(): boolean {
+  if (cached !== null) return cached;
+  if (process.env.WSL_DISTRO_NAME) {
+    cached = true;
+    return cached;
+  }
+  try {
+    const ver = readFileSync("/proc/version", "utf-8");
+    cached = /microsoft|wsl/i.test(ver);
+  } catch {
+    cached = false;
+  }
+  return cached;
+}

--- a/tests/utils/legacyConfig.test.ts
+++ b/tests/utils/legacyConfig.test.ts
@@ -1,24 +1,87 @@
 import { describe, expect, it } from "vitest";
 import { isLegacyProjectConfig } from "../../src/utils/legacyConfig.js";
 
-describe("isLegacyProjectConfig", () => {
+describe("isLegacyProjectConfig — native (non-WSL)", () => {
+  // The runtime is the macOS dev box; isWSL detector returns false
+  // for these tests automatically. Explicitly injecting `isWSL: false`
+  // keeps the intent in the test names.
+  const opts = { isWSL: false };
+
   it("returns true when cwd is a real project directory (cwd != home)", () => {
-    expect(isLegacyProjectConfig("/Users/me/work/myproject", "/Users/me")).toBe(
-      true,
-    );
+    expect(
+      isLegacyProjectConfig("/Users/me/work/myproject", "/Users/me", opts),
+    ).toBe(true);
   });
 
   it("returns false when cwd is the user's home directory", () => {
-    // This is the bug fix: ~/.agenthud/config.yaml is the GLOBAL config, not a
-    // legacy project file. Offering to delete it would wipe user settings.
-    expect(isLegacyProjectConfig("/Users/me", "/Users/me")).toBe(false);
+    expect(isLegacyProjectConfig("/Users/me", "/Users/me", opts)).toBe(false);
   });
 
   it("returns false when cwd resolves to home with trailing slash", () => {
-    expect(isLegacyProjectConfig("/Users/me/", "/Users/me")).toBe(false);
+    expect(isLegacyProjectConfig("/Users/me/", "/Users/me", opts)).toBe(false);
   });
 
   it("treats relative-to-same-target paths as equal", () => {
-    expect(isLegacyProjectConfig("/Users/me/./", "/Users/me")).toBe(false);
+    expect(isLegacyProjectConfig("/Users/me/./", "/Users/me", opts)).toBe(
+      false,
+    );
+  });
+
+  it("does NOT special-case Windows-mount paths when not on WSL", () => {
+    // `/mnt/c/Users/X` on a real Linux box is a normal path; nothing
+    // about it implies "Windows global config". The cross-OS heuristic
+    // only kicks in inside WSL.
+    expect(
+      isLegacyProjectConfig("/mnt/c/Users/someone", "/home/me", opts),
+    ).toBe(true);
+  });
+});
+
+describe("isLegacyProjectConfig — inside WSL", () => {
+  // WSL is the only environment where `homedir()` lies about the
+  // user's effective home for the .agenthud/config.yaml lookup.
+  const opts = { isWSL: true };
+
+  it("returns false for /mnt/<drive>/Users/<name> (Windows-side user home)", () => {
+    expect(
+      isLegacyProjectConfig("/mnt/c/Users/neoch", "/home/neochoon", opts),
+    ).toBe(false);
+  });
+
+  it("handles uppercase mount drive letters", () => {
+    expect(
+      isLegacyProjectConfig("/mnt/D/Users/neoch", "/home/neochoon", opts),
+    ).toBe(false);
+  });
+
+  it("trailing slash still matches", () => {
+    expect(
+      isLegacyProjectConfig("/mnt/c/Users/neoch/", "/home/neochoon", opts),
+    ).toBe(false);
+  });
+
+  it("still returns true for a nested project under a Windows user home", () => {
+    // `/mnt/c/Users/neoch/projects/foo` is a real working dir, not a
+    // home — the prompt should fire for any `.agenthud/config.yaml`
+    // there.
+    expect(
+      isLegacyProjectConfig(
+        "/mnt/c/Users/neoch/projects/foo",
+        "/home/neochoon",
+        opts,
+      ),
+    ).toBe(true);
+  });
+
+  it("still returns false when cwd is the Linux home (same as native)", () => {
+    expect(
+      isLegacyProjectConfig("/home/neochoon", "/home/neochoon", opts),
+    ).toBe(false);
+  });
+
+  it("returns true for an unrelated dir that's neither home nor a Windows mount", () => {
+    expect(
+      isLegacyProjectConfig("/etc/something", "/home/neochoon", opts),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
Real-world report: running \`npx agenthud summary …\` from WSL
inside \`/mnt/c/Users/<X>\` triggered the migration prompt that
offers to delete \`.agenthud/config.yaml\` in the cwd. That file is
the **Windows-native global config**, not a legacy project config —
agreeing to the prompt wipes the Windows agenthud user's real
settings.

## Root cause
\`isLegacyProjectConfig\` only bailed when \`resolve(cwd) ===
resolve(home)\`. From WSL the two differ (\`homedir()\` reports the
Linux home, e.g. \`/home/<X>\`), while the user's effective cwd may
be \`/mnt/c/Users/<Y>\` — the Windows-side home.

## Fix
Narrow the new guard to exactly where \`homedir()\` lies: inside
WSL, when cwd matches \`/mnt/<drive>/Users/<name>\`. Non-WSL
platforms keep the existing \`cwd === home\` check and nothing else
— no cross-OS path-shape heuristics they don't need.

- New \`src/utils/platform.ts\` with a cached \`isWSL()\` (detects
  via \`WSL_DISTRO_NAME\` env or \`microsoft\`/\`wsl\` in
  \`/proc/version\`). The duplicate in \`openInDefaultApp.ts\` is
  removed and that module now imports from \`platform.ts\`.
- \`isLegacyProjectConfig(cwd, home, opts?)\` — new \`opts.isWSL\`
  is injectable for tests, defaults to the runtime detector.
  main.ts call site keeps its existing two-arg form.

## Tests
- "non-WSL" block (5 cases): existing home-detection behavior, plus
  an assertion that \`/mnt/c/Users/X\` is NOT treated specially
  off-WSL.
- "inside WSL" block (6 cases): the Windows-mount user home is
  flagged false (lowercase + uppercase drive letters + trailing
  slash); a nested project dir under it still returns true; the
  Linux home still bails; an unrelated path still flags as legacy.

548/548 overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)