### PR TITLE
fix(summary): wrap each daily in <day date="..."> for range input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Changed
+- **Range summary input format: XML-tag delimited.** Each daily summary
+  is now wrapped in `<day date="YYYY-MM-DD">…</day>` instead of a
+  `# YYYY-MM-DD` heading + `---` separator. Two reasons: (1) the date
+  travels as a structured attribute so the LLM can't conflate it with
+  date headings *inside* a summary; (2) the `---` separator collided
+  with markdown horizontal rules and yaml frontmatter that a daily
+  summary might legitimately contain. The bundled
+  `src/templates/summary-range-prompt.md` was updated to match. **If
+  you have a customized `~/.agenthud/summary-range-prompt.md`,
+  agenthud will keep using yours unchanged** — sync your edits against
+  the new template if you want the XML-aware instructions, or delete
+  the file and agenthud will regenerate it on next run.
+
 ## [0.12.4] - 2026-06-08
 
 ### Fixed

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -159,6 +159,38 @@ function resolvePrompt(kind: PromptKind, override?: string): string {
 }
 
 /**
+ * Build the LLM input for a range summary by wrapping each daily
+ * summary in a `<day date="YYYY-MM-DD">…</day>` tag and joining with
+ * blank lines.
+ *
+ * The tag form (over the previous `# YYYY-MM-DD` heading + `---`
+ * separator) buys two things:
+ *
+ *   1. The date is an XML attribute, not free text the model has to
+ *      tokenize out of a header line — eliminates conflation with
+ *      date headings *inside* a daily summary (e.g. a section that
+ *      quotes a past date).
+ *   2. No separator collision. The old `---` delimiter clashed with
+ *      markdown horizontal rules and yaml frontmatter that a daily
+ *      summary might legitimately contain; tag boundaries can't be
+ *      faked by content.
+ *
+ * Anthropic's prompting guidance recommends XML-style tags for
+ * delimited inputs, which this format matches.
+ */
+export function buildRangeMetaInput(
+  dailyMarkdowns: { date: Date; markdown: string }[],
+): string {
+  if (dailyMarkdowns.length === 0) return "";
+  return dailyMarkdowns
+    .map(
+      ({ date, markdown }) =>
+        `<day date="${dateKey(date)}">\n\n${markdown}\n\n</day>`,
+    )
+    .join("\n\n");
+}
+
+/**
  * Range cache is only valid when today is NOT in the range. Today's activity
  * grows throughout the day, so any cached range that includes today is stale
  * the moment the day continues.
@@ -771,10 +803,7 @@ export async function runRangeSummary(
     return 0;
   }
 
-  // Build meta input: each daily summary prefixed with its date, separated by ---.
-  const metaInput = dailyMarkdowns
-    .map(({ date, markdown }) => `# ${dateKey(date)}\n\n${markdown}`)
-    .join("\n\n---\n\n");
+  const metaInput = buildRangeMetaInput(dailyMarkdowns);
 
   process.stderr.write(
     `\ncombining ${dailyMarkdowns.length} daily summaries into range summary...\n`,

--- a/src/templates/summary-range-prompt.md
+++ b/src/templates/summary-range-prompt.md
@@ -1,5 +1,18 @@
-The following are daily engineering summaries from a date range, separated by `---` lines.
-Each daily summary uses the structure: Context / Key Accomplishments / Technical Insights / Major Code Changes / Open Questions.
+The input contains daily engineering summaries from a date range.
+
+Each day is wrapped in an XML tag with its date as an attribute:
+
+<day date="YYYY-MM-DD">
+(that day's summary — markdown using sections like
+Context / Key Accomplishments / Technical Insights /
+Major Code Changes / Open Questions)
+</day>
+
+Multiple `<day>` blocks follow in chronological order. Use the
+`date` attribute as the authoritative date for that block — do not
+infer dates from headings or text inside the block. Any `# YYYY-MM-DD`
+heading or `---` line you see inside a `<day>` block is part of the
+day's content, not a structural divider.
 
 Write a range-level synthesis in English.
 Aim for roughly 400-700 words total — the value of a range summary is cross-day pattern extraction, not re-summarization.
@@ -14,6 +27,8 @@ The point of a range summary is to surface what only becomes visible by looking 
 - recurring debugging patterns or repeated tradeoffs
 - outcomes that matter at the range level, not at any single day
 - work that started in one day and continued, completed, or was abandoned later
+
+When you reference a specific day, use its `date` attribute value verbatim (`2026-06-07`), not a relative term like "Monday" or "yesterday".
 
 Use the following format:
 
@@ -32,4 +47,4 @@ Themes that surfaced on more than one day: repeated debugging classes, recurring
 ## Carried-Over / Unfinished Work
 Work still in progress at the end of the range, or open questions that persisted across multiple days.
 
-Daily summaries:
+Daily summaries follow:

--- a/tests/data/summaryRunner.buildRangeMetaInput.test.ts
+++ b/tests/data/summaryRunner.buildRangeMetaInput.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { buildRangeMetaInput } from "../../src/data/summaryRunner.js";
+
+describe("buildRangeMetaInput", () => {
+  it("wraps each daily summary in a <day date=YYYY-MM-DD> tag", () => {
+    const out = buildRangeMetaInput([
+      { date: new Date(2026, 5, 1), markdown: "## Context\n\nDay 1.\n" },
+      { date: new Date(2026, 5, 2), markdown: "## Context\n\nDay 2.\n" },
+    ]);
+    expect(out).toContain('<day date="2026-06-01">');
+    expect(out).toContain('<day date="2026-06-02">');
+    expect(out).toContain("</day>");
+  });
+
+  it("places the daily markdown body inside the tag", () => {
+    const out = buildRangeMetaInput([
+      { date: new Date(2026, 5, 1), markdown: "## Context\n\nFirst day.\n" },
+    ]);
+    expect(out).toMatch(
+      /<day date="2026-06-01">\s*## Context\s*First day\.\s*<\/day>/,
+    );
+  });
+
+  it("separates entries with blank lines (not the markdown horizontal rule `---`)", () => {
+    // The old format used `---` as the separator, which collided
+    // with horizontal rules and yaml frontmatter inside summaries.
+    // The new format relies on the tag boundaries, no `---` needed.
+    const out = buildRangeMetaInput([
+      { date: new Date(2026, 5, 1), markdown: "Day 1.\n" },
+      { date: new Date(2026, 5, 2), markdown: "Day 2.\n" },
+    ]);
+    expect(out).not.toContain("\n---\n");
+  });
+
+  it("does not break when a daily summary itself contains `---` or `# YYYY-MM-DD`", () => {
+    // A daily summary might quote `---` (horizontal rule) or a date
+    // heading from its source content; the tag-based format must not
+    // confuse those with section boundaries.
+    const out = buildRangeMetaInput([
+      {
+        date: new Date(2026, 5, 1),
+        markdown:
+          "Some text\n\n---\n\n# 2026-05-15\n\nQuoted older date heading.\n",
+      },
+      { date: new Date(2026, 5, 2), markdown: "Day 2.\n" },
+    ]);
+    // Two opening tags, two closing tags — neither the embedded `---`
+    // nor the embedded `# 2026-05-15` should produce an extra day.
+    const openTags = out.match(/<day date="\d{4}-\d{2}-\d{2}">/g) ?? [];
+    const closeTags = out.match(/<\/day>/g) ?? [];
+    expect(openTags).toHaveLength(2);
+    expect(closeTags).toHaveLength(2);
+  });
+
+  it("returns an empty string when no dailies are supplied", () => {
+    expect(buildRangeMetaInput([])).toBe("");
+  });
+
+  it("preserves order — newest input is the last <day> block", () => {
+    const out = buildRangeMetaInput([
+      { date: new Date(2026, 5, 1), markdown: "first" },
+      { date: new Date(2026, 5, 2), markdown: "second" },
+    ]);
+    const firstIdx = out.indexOf('date="2026-06-01"');
+    const secondIdx = out.indexOf('date="2026-06-02"');
+    expect(firstIdx).toBeLessThan(secondIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Two weaknesses in the range summary meta-input format:

1. **Date conflation.** The previous format prefixed each daily with `# YYYY-MM-DD`. The LLM had to extract the authoritative date from a markdown heading — easy to confuse with a date heading *inside* a daily (e.g. a section quoting an older date).
2. **Separator collision.** `---` was used to join blocks, but a daily summary can legitimately contain `---` as a markdown horizontal rule or yaml frontmatter, making block boundaries ambiguous.

Switch to XML-style tag delimiters (per Anthropic's prompting guidance):

```
<day date="2026-06-07">

(daily markdown)

</day>

<day date="2026-06-08">
...
</day>
```

The date now rides as a structured attribute and tag boundaries can't be forged by content. `src/templates/summary-range-prompt.md` is rewritten to describe the new input shape and instruct the model to treat the `date` attribute as authoritative.

## Behavior for existing users

Users who customized `~/.agenthud/summary-range-prompt.md` keep their override unchanged — agenthud won't overwrite home-dir prompts. CHANGELOG documents the manual sync path: edit your file or delete it to regenerate from the new template.

## Test plan
- [x] New unit tests cover tag wrapping, date attribute, embedded `---` / `# YYYY-MM-DD` not breaking parsing, empty array, order preservation.
- [x] `npx vitest run` — 554/554 passing.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual smoke: `agenthud summary --from 2026-06-01 --to 2026-06-07` and confirm the range output references days by their `date` attribute values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Range daily summaries now use XML-style tags instead of markdown headers and separators for improved structure and consistency.
  * Users with customized summary templates should manually update them or delete to regenerate with the new format.

* **Tests**
  * Added test coverage for range summary formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->