### PR TITLE
feat(report): surface Task subagent results to the LLM payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+- **`task` activity type, default-on.** Task tool delegations to
+  subagents are now visible in `report` and `summary` output. The
+  subagent's returned text is surfaced as a `<task-result>…</task-result>`
+  XML block below the row, so the LLM summary pipeline can see what the
+  subagent actually did instead of only the parent's task description.
+  Previously Task activities were filtered out of every report — work
+  delegated to subagents was invisible to the daily summary. Use
+  `--include` (e.g. `--include user,response,bash,edit`) to opt out
+  per-invocation, or omit `task` from `report.include` in
+  `~/.agenthud/config.yaml` to opt out by default. The XML tag form
+  matches the range meta-input change below — content can't forge
+  the delimiter.
+
 ### Changed
 - **Range summary input format: XML-tag delimited.** Each daily summary
   is now wrapped in `<day date="YYYY-MM-DD">…</day>` instead of a

--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ Output:
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--date` | today | `YYYY-MM-DD`, `today`, `yesterday`, or `-Nd` (N days ago, local date) |
-| `--include` | `user,response,bash,edit,thinking` | Comma-separated types or `all` |
+| `--include` | `user,response,bash,edit,thinking,task` | Comma-separated types or `all` |
 | `--format` | `markdown` | `markdown` or `json` |
 | `--detail-limit` | `120` | Max chars per detail field; `0` = unlimited |
 | `--with-git` | off | Merge git commits from each session's project into the timeline |
 
-`--include` types: `response`, `bash`, `edit`, `thinking`, `read`, `glob`, `user`
+`--include` types: `response`, `bash`, `edit`, `thinking`, `read`, `glob`, `user`, `task` (Task tool delegations to subagents — surfaces the subagent's returned text so the LLM summary can see what the subagent actually did)
 
 ## Summary
 
@@ -262,7 +262,7 @@ refreshInterval: 2s
 
 # Activity filter presets (cycle with 'f' key in viewer)
 # Each list is one preset. Use "all" (or "*") to show everything.
-# Types: response, user, bash, edit, thinking, read, glob, commit
+# Types: response, user, bash, edit, thinking, read, glob, commit, task
 filterPresets:
   - ["all"]
   - ["response", "user"]
@@ -270,7 +270,7 @@ filterPresets:
 
 # Defaults for `agenthud report` (CLI flags still win per-invocation).
 report:
-  include: [user, response, bash, edit, thinking]
+  include: [user, response, bash, edit, thinking, task]
   detailLimit: 120
   withGit: false
   format: markdown

--- a/src/config/globalConfig.ts
+++ b/src/config/globalConfig.ts
@@ -15,6 +15,7 @@ export const DEFAULT_INCLUDE_TYPES = [
   "bash",
   "edit",
   "thinking",
+  "task",
 ];
 
 const ALLOWED_INCLUDE_TYPES = new Set([
@@ -26,6 +27,7 @@ const ALLOWED_INCLUDE_TYPES = new Set([
   "read",
   "glob",
   "commit",
+  "task",
 ]);
 
 export const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {

--- a/src/data/reportGenerator.ts
+++ b/src/data/reportGenerator.ts
@@ -33,6 +33,7 @@ function activityMatchesInclude(
     return true;
   if (include.includes("glob") && (label === "glob" || label === "grep"))
     return true;
+  if (include.includes("task") && label === "task") return true;
   return false;
 }
 
@@ -53,6 +54,27 @@ function formatActivity(activity: ActivityEntry, limit: number): string {
   const detail = truncateDetail(activity.detail, limit);
   const suffix = detail ? `: ${detail}` : "";
   return `[${time}] ${activity.icon} ${activity.label}${suffix}`;
+}
+
+/**
+ * For Task activities, expose the subagent's returned text on its own
+ * lines as an XML-tagged block. XML tags (over fenced code blocks or
+ * `---` separators) survive the kind of content subagent results
+ * typically contain — code fences, horizontal rules, yaml frontmatter
+ * — without ambiguity.
+ *
+ * Returns null for any other tool. The markdown report deliberately
+ * keeps `detailBody` out of the LLM payload elsewhere: a full Edit
+ * diff or Read body would balloon the input without adding
+ * proportional signal. Task is the exception because its row summary
+ * is otherwise just the task description — the actual result is the
+ * only signal.
+ */
+function formatTaskBody(activity: ActivityEntry, limit: number): string | null {
+  if (activity.label !== "Task") return null;
+  if (!activity.detailBody) return null;
+  const body = truncateRaw(activity.detailBody, limit);
+  return `<task-result>\n${body}\n</task-result>`;
 }
 
 function formatDateString(date: Date): string {
@@ -191,6 +213,8 @@ export function generateReport(
     lines.push("");
     for (const activity of activities) {
       lines.push(formatActivity(activity, detailLimit));
+      const taskBody = formatTaskBody(activity, detailLimit);
+      if (taskBody) lines.push(taskBody);
     }
     lines.push("");
   }

--- a/src/data/toolDetails.ts
+++ b/src/data/toolDetails.ts
@@ -152,6 +152,13 @@ export function buildToolDetailBody(
     const content = result?.content ?? input?.content;
     if (content) return { text: content, kind: "code" };
   }
+  // Task surfaces the subagent's returned text — without this, the LLM
+  // summary pipeline sees only the task description and is blind to
+  // whatever the subagent actually did or concluded.
+  if (name === "Task") {
+    const content = result?.content;
+    if (content) return { text: content, kind: "code" };
+  }
   if (name === "Read") {
     const content = result?.file?.content;
     if (content) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -138,6 +138,7 @@ describe("parseArgs", () => {
         "bash",
         "edit",
         "thinking",
+        "task",
       ]);
     });
 

--- a/tests/config/globalConfig.test.ts
+++ b/tests/config/globalConfig.test.ts
@@ -335,6 +335,7 @@ describe("report/summary config", () => {
       "bash",
       "edit",
       "thinking",
+      "task",
     ]);
     expect(cfg.report.detailLimit).toBe(120);
     expect(cfg.report.withGit).toBe(false);
@@ -370,6 +371,7 @@ describe("report/summary config", () => {
       "bash",
       "edit",
       "thinking",
+      "task",
     ]);
     expect(cfg.report.detailLimit).toBe(120);
     expect(cfg.report.format).toBe("markdown");
@@ -413,6 +415,7 @@ describe("report/summary config", () => {
       "bash",
       "edit",
       "thinking",
+      "task",
     ]);
     expect(cfg.report.detailLimit).toBe(120);
     expect(cfg.report.withGit).toBe(false);

--- a/tests/data/reportGenerator.test.ts
+++ b/tests/data/reportGenerator.test.ts
@@ -551,4 +551,95 @@ describe("generateReport", () => {
     generateReport([makeSession()], { date: DAY, include: ["response"] });
     expect(vi.mocked(parseGitCommits)).not.toHaveBeenCalled();
   });
+
+  it("includes Task detailBody as an XML-tagged block in markdown format", () => {
+    vi.mocked(statSync).mockReturnValue({
+      mtimeMs: new Date("2026-05-14T10:00:00Z").getTime(),
+    } as ReturnType<typeof statSync>);
+    vi.mocked(parseSessionHistory).mockReturnValue([
+      makeActivity({
+        type: "tool",
+        icon: "⚙",
+        label: "Task",
+        detail: "find auth code",
+        detailBody: "Found auth in src/auth.ts:42.\nUses passport strategy.",
+        detailKind: "code",
+      }),
+    ]);
+    const result = generateReport([makeSession()], {
+      date: DAY,
+      include: ["bash", "edit", "thinking", "response", "user", "task"],
+    });
+    expect(result).toContain("⚙ Task: find auth code");
+    expect(result).toContain("<task-result>");
+    expect(result).toContain("Found auth in src/auth.ts:42.");
+    expect(result).toContain("Uses passport strategy.");
+    expect(result).toContain("</task-result>");
+  });
+
+  it("does not include detailBody for non-Task activities in markdown format", () => {
+    vi.mocked(statSync).mockReturnValue({
+      mtimeMs: new Date("2026-05-14T10:00:00Z").getTime(),
+    } as ReturnType<typeof statSync>);
+    vi.mocked(parseSessionHistory).mockReturnValue([
+      makeActivity({
+        type: "tool",
+        icon: "✎",
+        label: "Edit",
+        detail: "auth.ts L10-12 (+2/-1)",
+        detailBody: "@@ -10,3 +10,2 @@\n ctx\n-old\n+new",
+        detailKind: "diff",
+      }),
+    ]);
+    const result = generateReport([makeSession()], {
+      date: DAY,
+      include: ["edit"],
+    });
+    expect(result).toContain("✎ Edit: auth.ts L10-12 (+2/-1)");
+    expect(result).not.toContain("<task-result>");
+    expect(result).not.toContain("@@ -10,3");
+  });
+
+  it("Task without detailBody renders as a normal one-line activity", () => {
+    vi.mocked(statSync).mockReturnValue({
+      mtimeMs: new Date("2026-05-14T10:00:00Z").getTime(),
+    } as ReturnType<typeof statSync>);
+    vi.mocked(parseSessionHistory).mockReturnValue([
+      makeActivity({
+        type: "tool",
+        icon: "⚙",
+        label: "Task",
+        detail: "explore",
+      }),
+    ]);
+    const result = generateReport([makeSession()], {
+      date: DAY,
+      include: ["bash", "edit", "thinking", "response", "user", "task"],
+    });
+    expect(result).toContain("⚙ Task: explore");
+    expect(result).not.toContain("<task-result>");
+  });
+
+  it("Task detailBody is truncated by detailLimit (preserving newlines)", () => {
+    vi.mocked(statSync).mockReturnValue({
+      mtimeMs: new Date("2026-05-14T10:00:00Z").getTime(),
+    } as ReturnType<typeof statSync>);
+    vi.mocked(parseSessionHistory).mockReturnValue([
+      makeActivity({
+        type: "tool",
+        icon: "⚙",
+        label: "Task",
+        detail: "do thing",
+        detailBody: "line one\nline two\nline three",
+        detailKind: "code",
+      }),
+    ]);
+    const result = generateReport([makeSession()], {
+      date: DAY,
+      include: ["bash", "edit", "thinking", "response", "user", "task"],
+      detailLimit: 12,
+    });
+    expect(result).toContain("line one\nlin");
+    expect(result).not.toContain("line three");
+  });
 });

--- a/tests/data/toolDetails.test.ts
+++ b/tests/data/toolDetails.test.ts
@@ -275,7 +275,7 @@ describe("buildToolDetailBody", () => {
     ).toEqual({ text: "10: only", kind: "code", numbered: true });
   });
 
-  it("Read without file content, and Task/Bash tools, have no body", () => {
+  it("Read without file content, and TaskUpdate/Bash tools, have no body", () => {
     expect(
       buildToolDetailBody(
         "Read",
@@ -289,5 +289,28 @@ describe("buildToolDetailBody", () => {
     expect(
       buildToolDetailBody("Bash", { command: "ls" }, undefined),
     ).toBeNull();
+  });
+
+  it("Task: returns the subagent result content as kind 'code'", () => {
+    expect(
+      buildToolDetailBody(
+        "Task",
+        { description: "find auth code" },
+        { content: "Found auth in src/auth.ts:42 — uses passport.\n" },
+      ),
+    ).toEqual({
+      text: "Found auth in src/auth.ts:42 — uses passport.\n",
+      kind: "code",
+    });
+  });
+
+  it("Task: null when result is missing", () => {
+    expect(
+      buildToolDetailBody("Task", { description: "x" }, undefined),
+    ).toBeNull();
+  });
+
+  it("Task: null when result has no content", () => {
+    expect(buildToolDetailBody("Task", { description: "x" }, {})).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Daily and range summaries had a blind spot: Task tool delegations to subagents were filtered out of every report.

- `activityMatchesInclude` had no `task` case, so even the parent's "spawned Task: <description>" row never reached the markdown payload — to say nothing of what the subagent actually did or returned.
- Heavy users of subagent delegation saw their LLM summaries describe a near-empty day.

## Changes

1. **New `task` activity type, default-on.** Added to `ALLOWED_INCLUDE_TYPES`, `DEFAULT_INCLUDE_TYPES`, and `activityMatchesInclude`. Users can opt out per-invocation via `--include` or persistently via `report.include` in `~/.agenthud/config.yaml`.

2. **`buildToolDetailBody` Task branch.** Exposes the subagent's returned text (stored as `result.content` on the tool_result by Claude Code). Mirrors the existing Write pattern.

3. **`generateReport` markdown loop — Task body unrolled.** For Task activities only, the body is appended under the one-line activity wrapped in a `<task-result>…</task-result>` XML tag. XML over fences or `---` for the same reason PR #117 picked XML for the range meta-input: subagent output frequently contains code fences, horizontal rules, and yaml frontmatter, and tag boundaries can't be forged by content. Truncation still honors `detailLimit`.

Non-Task activities (Edit, Write, Read) are unaffected — their `detailBody` deliberately stays out of the markdown report to keep payload size bounded. The TUI rendering is unchanged for all tools.

## Sample output

```
[10:23] ⚙ Task: investigate auth flow
<task-result>
Found auth in src/auth.ts:42. Uses passport with a custom strategy
defined in src/auth/strategy.ts. The init chain is:
index.ts → app.ts:bootstrap() → passport.use(...).
</task-result>
```

## Test plan
- [x] 7 new unit tests (3 in `toolDetails.test.ts`, 4 in `reportGenerator.test.ts`).
- [x] `npx vitest run` — 555/555 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean.
- [ ] Manual smoke: run `agenthud summary --date today` on a session that dispatched at least one Task call and confirm the subagent result appears in the produced summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task activity type is now default-enabled in report output
  * Subagent task results are displayed in dedicated XML blocks for processing

* **Documentation**
  * Updated CLI and configuration documentation to include task activity support
  * Added changelog entry documenting task activity behavior and opt-out options via flags or configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->