### PR TITLE
docs: add file headers to entry + config layer (PR 1/5)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,30 @@
+/**
+ * Parse `process.argv` into a typed `CliOptions` for each subcommand
+ * (`watch` / `once` / `report` / `summary` / `help` / `version`).
+ * Also owns help text (`getHelp()`), version string (`getVersion()`),
+ * and the effective-options summarizer (`formatEffectiveOptionsLine`).
+ *
+ * Design decisions:
+ * - POSIX short-flag clusters (`-oI` → `-o -I`, `-yo` → `-y -o`)
+ *   are expanded once at the top via `expandCombinedShortFlags`
+ *   so each per-subcommand parser sees individual flags only. The
+ *   expander triggers only on `-` + two-or-more letters so the
+ *   `-Nd` date short-form (`--date -1d`) stays intact.
+ * - Options resolution is shared across surfaces: CLI flag wins,
+ *   then `summary.<key>`, then `report.<key>`, then built-in
+ *   default. `formatEffectiveOptionsLine` formats the resolved
+ *   set for the stderr breadcrumb.
+ * - Unknown subcommands / flags / include types are *errors* at
+ *   parse time, not silently dropped. The validation gates live
+ *   in `KNOWN_*_FLAGS` sets and `ALL_TYPES`.
+ *
+ * Gotcha:
+ * - `--include` validation must reject typos: a real v0.9.x bug
+ *   was `--include response,bas` being silently accepted (no
+ *   match, no error). Unknown values now error with the full list
+ *   of valid types.
+ */
+
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/src/config/globalConfig.ts
+++ b/src/config/globalConfig.ts
@@ -1,3 +1,35 @@
+/**
+ * Read/write the global config at `~/.agenthud/config.yaml` and the
+ * sibling app-managed state at `~/.agenthud/state.yaml`. Owns the
+ * canonical default sets (`DEFAULT_INCLUDE_TYPES`,
+ * `ALLOWED_INCLUDE_TYPES`, `DEFAULT_GLOBAL_CONFIG`) — every other
+ * module reads from these instead of redefining defaults locally.
+ *
+ * Design decisions:
+ * - Config / state are SPLIT into two files. `config.yaml` holds
+ *   user-edited preferences (filter presets, defaults, refresh
+ *   interval). `state.yaml` holds app-managed UI state (hidden
+ *   sessions / sub-agents / projects toggled by the `h` key).
+ *   Reason: with one combined file, `git diff` on dotfiles churns
+ *   constantly as the user hides/unhides items at runtime. Split
+ *   in v0.9.0 with one-time auto-migration of the merged shape.
+ * - `summary.*` keys INHERIT from `report.*` at the call site
+ *   (not at parse time). An empty `summary:` block in the user's
+ *   config means "use everything from report"; explicit summary
+ *   keys override per-field. This lets users pin one defaults
+ *   block under `report:` and have summary follow.
+ * - `ALLOWED_INCLUDE_TYPES` is the validation gate (what's a
+ *   *legal* type); `DEFAULT_INCLUDE_TYPES` is the default subset
+ *   (what's ON by default). The two are not the same — `read`,
+ *   `glob`, `commit` are allowed but not default-on.
+ *
+ * Gotcha:
+ * - Auto-migration runs once on first load; the migrated file is
+ *   then re-saved with the new schema. Editing the old schema
+ *   after migration won't take effect — read the current shape
+ *   from the actual file, not from old docs.
+ */
+
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,26 @@
 #!/usr/bin/env node
+/**
+ * CLI binary entry. Performs Node-version gate and forces
+ * `NODE_ENV=production` *before* dynamically importing the main
+ * application bundle.
+ *
+ * Design decisions:
+ * - Pre-import work lives here as plain top-level code (no imports
+ *   of project modules) because some transitive deps require Node
+ *   20+. If we let those load on Node 18 the error message is an
+ *   incomprehensible stack from inside a dep — the guard here
+ *   replaces it with a one-line "upgrade Node" message.
+ * - The main app is loaded via `await import("./main.js")` so the
+ *   bundler keeps it as a deferred chunk and the guard above
+ *   actually runs first.
+ *
+ * Gotcha:
+ * - `process.env.NODE_ENV = "production"` MUST happen before
+ *   importing anything that pulls in React/Ink, or the dev-mode
+ *   profiler accumulates `PerformanceMeasure` objects (~600KB/s)
+ *   and watch mode OOMs after ~88 min. Confirmed regression
+ *   pattern — do not move this assignment after the import.
+ */
 
 // Check Node.js version before importing any dependencies
 // This prevents ugly crashes from libraries that require Node 20+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,29 @@
+/**
+ * Application bootstrap. Loads `~/.agenthud/config.yaml`, parses
+ * argv, runs the legacy-config migration check, and dispatches
+ * to one of: watch (interactive TUI), once (snapshot), report,
+ * or summary.
+ *
+ * Design decisions:
+ * - Global config is loaded *before* `parseArgs` so the CLI parser
+ *   can layer flags over `report.*` / `summary.*` user defaults
+ *   (resolution order: CLI flag → summary key → report key →
+ *   built-in default). Done eagerly here, not lazily downstream,
+ *   so the effective-options stderr line at run start reflects the
+ *   real values before any work begins.
+ * - The legacy-config migration prompt fires from this entry
+ *   point, not from inside the App component, so non-interactive
+ *   modes (`--once`, `report`, `summary`) get the same prompt.
+ *
+ * Gotcha:
+ * - The "is this a project-level config?" check honors WSL: from
+ *   inside WSL, `homedir()` returns the Linux home but cwd often
+ *   sits under `/mnt/c/Users/<X>` — the Windows-side home. Without
+ *   the WSL guard, we'd offer to delete the Windows-native
+ *   `.agenthud/config.yaml`. See `isLegacyProjectConfig()` for the
+ *   actual detection.
+ */
+
 import { existsSync, readdirSync, realpathSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,17 @@
+/**
+ * Shared TypeScript types and constants: session tree
+ * (`SessionNode`, `ProjectNode`, `SessionTree`), activity entries
+ * (`ActivityEntry`), config (`GlobalConfig`, `ReportConfig`,
+ * `SummaryConfig`), and the `ICONS` table.
+ *
+ * Design decision:
+ * - `ICONS` lives here, not under `src/ui/`, so the data layer
+ *   (`activityParser`, `reportGenerator`) can use it without
+ *   importing UI. Icons are an attribute of the activity, not of
+ *   the renderer. Keeps the dep graph clean (data → types →
+ *   nothing).
+ */
+
 // Session status
 export type SessionStatus = "hot" | "warm" | "cool" | "cold";
 


### PR DESCRIPTION
## Summary

First in a series of 5 PRs retrofitting the new **File Headers** convention (added to global \`~/.claude/CLAUDE.md\`) across the agenthud source tree.

This PR covers the CLI / config entry layer — 5 files:

- \`src/index.ts\` — binary entry, Node-version gate, \`NODE_ENV\` pin
- \`src/main.ts\` — bootstrap, config load, legacy-migration prompt dispatch
- \`src/cli.ts\` — argv parsing, POSIX short-flag clustering, options resolution chain
- \`src/config/globalConfig.ts\` — config/state file split, \`summary\` inherits from \`report\`
- \`src/types/index.ts\` — shared types + \`ICONS\` table (intentionally outside \`src/ui/\`)

## Convention recap

Each header has up to three fields, in this order:

1. **Purpose** (mandatory): one sentence. What the file is *for*.
2. **Design decisions** (optional, 2–5 bullets): the *why* behind non-obvious structure.
3. **Gotcha(s)** (optional, 2–5 bullets): non-obvious behaviors.

Skipped: API enumeration, caller lists, LOC, dependency lists, version/changelog notes — all rot fast.

## Sample (from \`src/cli.ts\`)

Headers capture only things the filename + first export *can't* tell you:

> POSIX short-flag clusters (\`-oI\` → \`-o -I\`) expanded once at the top so per-subcommand parsers stay simple; \`-Nd\` date short-form is intentionally exempt.

> \`--include\` validation must reject typos: a real v0.9.x bug was \`--include response,bas\` being silently accepted.

## Plan: remaining 4 PRs

| PR | Area | Files |
|---|---|---|
| 2 | Data parsing | activityParser, sessionHistory, sessionLiveness, sessions, gitCommits |
| 3 | Data report+summary | reportGenerator, toolDetails, summaryRunner, summariesIndex |
| 4 | UI panels | App, SessionTreePanel, ActivityViewerPanel, DetailViewPanel, HelpPanel, constants, lineColoring |
| 5 | UI hooks + utils | useHotkeys, useSpinner, useTick, altScreen, legacyConfig, nodeVersion, openInDefaultApp, performance, platform, stderrTicker |

## Test plan
- [x] \`npx vitest run\` — 561/561 passing
- [x] \`npx tsc --noEmit\` — clean
- [x] No code changes; doc-only retrofit

🤖 Generated with [Claude Code](https://claude.com/claude-code)