### PR TITLE
docs: add file headers to data parsing layer (PR 2/5)

### DIFF
--- a/src/data/activityParser.ts
+++ b/src/data/activityParser.ts
@@ -1,3 +1,31 @@
+/**
+ * Parse Claude Code session JSONL lines into typed `ActivityEntry[]`:
+ * user prompts, assistant responses, thinking blocks, tool calls
+ * (with their results), and token usage.
+ *
+ * Design decisions:
+ * - Two-pass parser. The first pass walks every line to build a
+ *   `tool_use_id → tool_result` map; the second pass walks again
+ *   to build the activity timeline. A tool_result lands in a
+ *   *later* JSONL entry than its tool_use, so the lookahead has
+ *   to happen up front — otherwise we'd attach the result to the
+ *   next tool call, not the current one.
+ * - Adjacent identical activities (same `label + detail`) are
+ *   collapsed into a single entry with a `count` field rather
+ *   than rendered as separate rows. Keeps `"Edit foo.ts ×3"`
+ *   instead of three Edit lines for a rapid back-to-back retry.
+ * - `TodoWrite` is silently dropped — surfaced only via task
+ *   status changes (`TaskUpdate`), not as a row of its own.
+ *
+ * Gotchas:
+ * - `entry.toolUseResult` lives on the *user* entry that contains
+ *   the tool_result content block; the entry's `message.content`
+ *   array is what we match `tool_use_id` against.
+ * - Model name parsing keys off hard-coded patterns
+ *   (`claude-opus-X-Y`, `claude-sonnet-X`, `claude-X-Y-haiku`).
+ *   New model families need new patterns added here.
+ */
+
 import type { ActivityEntry } from "../types/index.js";
 import { ICONS } from "../types/index.js";
 import type { ToolInput, ToolUseResult } from "./toolDetails.js";

--- a/src/data/gitCommits.ts
+++ b/src/data/gitCommits.ts
@@ -1,3 +1,27 @@
+/**
+ * Shell out to `git log` to merge commit entries into the activity
+ * timeline (`--with-git` flag on `report` / `summary`), and to
+ * `git show --stat --patch` for the commit detail view (`↵` on a
+ * commit row).
+ *
+ * Design decisions:
+ * - `git -C <projectPath>` instead of `cwd`. Callers don't have
+ *   to `chdir`, and the project path can point anywhere — useful
+ *   when agenthud is invoked from outside the project tree.
+ * - `--format="%ct|%h|%s"` (unix-timestamp | short-hash | subject)
+ *   chosen over `--format=json` because shipped `git` versions
+ *   don't all support `--format=json`. Subject lines with embedded
+ *   pipes are joined back from the trailing parts.
+ *
+ * Gotcha:
+ * - stderr is suppressed (`stdio: ["ignore", "pipe", "ignore"]`).
+ *   `git log` on a non-repo path prints "fatal: not a git
+ *   repository" — without the redirect, that leaks into the TUI
+ *   and corrupts the Ink render. The trade-off is that real git
+ *   errors also go silent; callers detect failure via the
+ *   try/catch returning `[]` or `null`.
+ */
+
 import { execSync } from "node:child_process";
 import type { ActivityEntry } from "../types/index.js";
 import { ICONS } from "../types/index.js";

--- a/src/data/sessionHistory.ts
+++ b/src/data/sessionHistory.ts
@@ -1,3 +1,14 @@
+/**
+ * Filesystem wrapper: read a session JSONL file from disk and
+ * return the complete activity history in chronological order.
+ *
+ * Design decision:
+ * - Pure I/O. All parsing logic stays in `activityParser.ts`. This
+ *   split lets the parser be unit-tested with synthetic lines
+ *   without touching the filesystem, while callers that already
+ *   have a path can stay one-liner.
+ */
+
 import { existsSync, readFileSync } from "node:fs";
 import type { ActivityEntry } from "../types/index.js";
 import { parseActivitiesFromLines } from "./activityParser.js";

--- a/src/data/sessionLiveness.ts
+++ b/src/data/sessionLiveness.ts
@@ -1,3 +1,27 @@
+/**
+ * Classify a recently-active session as `working` or `waiting`
+ * from the structure of its JSONL tail.
+ *
+ * Design decision:
+ * - The signal is the *tail structure*, not file mtime. A
+ *   long-running tool (multi-minute `Bash`) leaves the JSONL
+ *   silent — mtime goes stale — even though the session is
+ *   `working`: there's a pending `tool_use` at the tail with no
+ *   matching `tool_result` yet. mtime alone would misclassify
+ *   this as `waiting` and the user would assume Claude is idle.
+ *
+ * Gotchas:
+ * - `AskUserQuestion` is treated as `waiting`. Even though it's
+ *   technically a pending tool_use, the ball is in the user's
+ *   court — they need to answer before Claude can continue.
+ * - Returns `null` outside the 30-minute recency window;
+ *   upstream falls back to the time-based `[hot/warm/cool/cold]`
+ *   ladder.
+ * - Imports `THIRTY_MINUTES_MS` from `ui/constants.ts` — a known
+ *   data → ui layer violation. Should move to `utils/` or a
+ *   shared time-constants module on a future refactor.
+ */
+
 import type { LiveState } from "../types/index.js";
 import { THIRTY_MINUTES_MS } from "../ui/constants.js";
 

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -1,3 +1,37 @@
+/**
+ * Walk `~/.claude/projects/` to discover every session and sub-agent,
+ * build the typed `SessionTree` (active projects + cold-only projects
+ * × their sessions × their sub-agents). Also exposes
+ * `findContainingProject` for the `--cwd` scoping feature and
+ * `decodeProjectPath` for reversing Claude's directory-name encoding.
+ *
+ * Design decisions:
+ * - Project paths are encoded in directory names with hyphens
+ *   replacing `/` (e.g., `/Users/neo/myproject` →
+ *   `-Users-neochoon-WestbrookAI-agenthud`). `decodeProjectPath`
+ *   reverses this. Windows drives use a different encoding
+ *   (`C--Users-neo` → `C:\Users\neo`) and are detected by a
+ *   leading-letter pattern.
+ * - Sub-agents live under `<projectDir>/<sessionId>/subagents/*.jsonl`.
+ *   `buildSubAgents` is intentionally per-session so the parent
+ *   carries its own sub-agent list as a tree branch — never a
+ *   flat global list.
+ * - `findContainingProject` does longest-prefix match for cwd →
+ *   project resolution (used by `--cwd`). A `realpath` injection
+ *   point exists for callers that want symlink-aware resolution.
+ *
+ * Gotchas:
+ * - `findContainingProject` matches by string by default. Callers
+ *   on systems with symlinks should pass `{ realpath: realpathSync }`
+ *   or pre-resolve before calling.
+ * - `CLAUDE_PROJECTS_DIR` env var overrides the default
+ *   `~/.claude/projects` location — useful for backups or mounted
+ *   volumes. Read once at module load via `getProjectsDir()`.
+ * - Imports `ONE_HOUR_MS` / `THIRTY_MINUTES_MS` from
+ *   `ui/constants.ts` — same layer-violation note as
+ *   `sessionLiveness.ts`.
+ */
+
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";


### PR DESCRIPTION
## Summary

PR 2/5 of the file-headers retrofit ([convention](https://github.com/neochoon/agenthud/pull/121)). Covers the 5 files that ingest raw Claude Code JSONL + git data and turn it into typed activity streams.

## Files

- **\`src/data/activityParser.ts\`** — JSONL line → \`ActivityEntry[]\`; two-pass tool_use_id resolution; adjacent-dedup with ×N count
- **\`src/data/sessionHistory.ts\`** — filesystem wrapper (pure I/O around the parser)
- **\`src/data/sessionLiveness.ts\`** — \`working\` / \`waiting\` classification from tail structure
- **\`src/data/sessions.ts\`** — directory walk → \`SessionTree\`; project path encoding/decoding incl. Windows drive form
- **\`src/data/gitCommits.ts\`** — \`git log\` shellout with stderr suppression

## Notable findings flagged in the headers

- **\`activityParser.ts\`**: Two-pass parse because \`tool_result\` lands in a *later* JSONL entry than its \`tool_use\` — needs lookahead before main pass.
- **\`sessionLiveness.ts\`**: Tail structure, not mtime, is the signal — a long-running \`Bash\` leaves mtime stale even though the session is \`working\`.
- **\`gitCommits.ts\`**: stderr suppressed so "fatal: not a git repository" doesn't leak into the Ink TUI render.
- **Cross-cutting smell**: both \`sessions.ts\` and \`sessionLiveness.ts\` import \`THIRTY_MINUTES_MS\` / \`ONE_HOUR_MS\` from \`src/ui/constants.ts\` — a known data → ui layer violation. Flagged as a known issue in each header; the actual fix (move to \`utils/timeConstants.ts\`) belongs in a separate PR.

## Test plan
- [x] \`npx vitest run\` — 561/561 passing
- [x] \`npx tsc --noEmit\` — clean
- [x] No code changes; doc-only

## Remaining series

| PR | Area | Files |
|---|---|---|
| 3 | Data report+summary | reportGenerator, toolDetails, summaryRunner, summariesIndex |
| 4 | UI panels | App, SessionTreePanel, ActivityViewerPanel, DetailViewPanel, HelpPanel, constants, lineColoring |
| 5 | UI hooks + utils | useHotkeys, useSpinner, useTick, altScreen, legacyConfig, nodeVersion, openInDefaultApp, performance, platform, stderrTicker |

🤖 Generated with [Claude Code](https://claude.com/claude-code)