### PR TITLE
docs: add file headers to report + summary subsystem (PR 3/5)

### DIFF
--- a/src/data/reportGenerator.ts
+++ b/src/data/reportGenerator.ts
@@ -1,3 +1,33 @@
+/**
+ * Build a chronological activity report for one date, scoped to a
+ * given set of sessions. Two output formats: Markdown (human-/
+ * LLM-readable) and JSON (script-readable). Drives both `agenthud
+ * report` and the LLM payload that feeds `agenthud summary`.
+ *
+ * Design decisions:
+ * - JSON nests sub-agent activities under their parent session;
+ *   Markdown does *not*. Reason: sub-agent activity is high-volume
+ *   exploratory output. JSON consumers can filter, but a markdown
+ *   report aimed at human reading would balloon by 10× per day.
+ *   Subagent results still reach the LLM via the parent's Task row
+ *   (see `formatTaskBody`).
+ * - `activityMatchesInclude` is a hand-written switch on label,
+ *   not a label→type map. The fan-in is small (~10 labels) and
+ *   the explicit branches double as documentation of what each
+ *   include type captures.
+ * - Markdown deliberately omits `detailBody` for every tool
+ *   *except* Task. Edit/Write/Read bodies stay TUI-only to keep
+ *   the LLM payload bounded; Task's body is the subagent's
+ *   returned text, which is the entire point of including Task.
+ *
+ * Gotcha:
+ * - `sessionIsOnDate` checks BOTH file mtime AND activity
+ *   timestamps. mtime alone misclassifies cases where today's
+ *   only activity was a small tool result that didn't bump mtime
+ *   visibly, and timestamps alone misclassify sessions that
+ *   touched today but whose tail entries are still parsing.
+ */
+
 import { statSync } from "node:fs";
 import type { ActivityEntry, SessionNode } from "../types/index.js";
 import { parseGitCommits } from "./gitCommits.js";

--- a/src/data/summariesIndex.ts
+++ b/src/data/summariesIndex.ts
@@ -1,18 +1,37 @@
 /**
- * Maintenance for ~/.agenthud/summaries/ as a navigable knowledge base:
+ * Maintain `~/.agenthud/summaries/` as a navigable knowledge base.
+ * Two artifacts: `index.md` (auto-regenerated hub listing every
+ * daily and range summary, grouped year → month → entry,
+ * newest-first), and a one-line backlink footer prepended to each
+ * summary file so a reader can hop to the index or to neighboring
+ * dates without leaving their markdown viewer.
  *
- * - `index.md` is an auto-regenerated hub listing every daily and range
- *   summary, grouped year → month → entry (newest first).
- * - Each summary file gets a one-line backlink footer prepended at the
- *   top so a reader can hop back to the index or to neighboring dates
- *   without leaving their markdown viewer.
+ * Design decisions:
+ * - Markdown only — no HTML, no extra dependency. VS Code preview
+ *   and browser markdown extensions render relative links inline,
+ *   so a plain `.md` file is enough to be a navigable hub.
+ * - Pure helpers (`parseSummaryFilename`, `listSummaries`,
+ *   `buildIndexMarkdown`, `buildBacklinkFooter`,
+ *   `stripExistingBacklinkFooter`, `prependBacklinkFooter`) are
+ *   exported individually so each is unit-testable in isolation.
+ *   The side-effect orchestrator `regenerateIndex` sits at the
+ *   bottom and is covered by manual smoke + integration tests.
+ * - Backlink footer wrapped in HTML comment markers
+ *   (`<!-- agenthud-backlinks-start -->` /
+ *   `<!-- agenthud-backlinks-end -->`) so re-runs strip-and-prepend
+ *   cleanly. Without the markers, a re-run would either duplicate
+ *   the footer or corrupt the file.
+ * - Backlink prev/next walks only over daily entries, not range
+ *   entries. The day-to-day chain stays a clean sequence; a range
+ *   entry in the middle would break the "next day" navigation
+ *   intent.
  *
- * Markdown only — VS Code preview and browser markdown extensions
- * render relative links inline, so we never need to ship HTML.
- *
- * The pure helpers in this module are exported individually so each
- * one is unit-testable; the side-effect orchestrator `regenerateIndex`
- * sits at the bottom and is exercised end-to-end via manual smoke.
+ * Gotcha:
+ * - Index regen is *best-effort*. Errors are logged to stderr but
+ *   never thrown — the LLM call's success is what matters, and a
+ *   stale index file shouldn't block the summary write path or
+ *   the user's exit code. Callers should not rely on
+ *   `regenerateIndex` always succeeding.
  */
 
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -1,3 +1,49 @@
+/**
+ * Daily and range summary orchestrators. Activity report →
+ * `claude -p` → cache write → index regeneration.
+ *
+ * Design decisions:
+ * - Daily and range share state intentionally — `runRangeSummary`
+ *   calls `runSummary` per day to reuse the cache-write path.
+ *   One code path means cache lookups, prompt resolution, ticker
+ *   handling, and index regen all happen the same way regardless
+ *   of how the user invoked summary.
+ * - Past-day caches are immutable; today is always regenerated.
+ *   Today's activity grows during the day, so any cached output
+ *   that includes today is stale the moment the day continues.
+ *   Same logic for range caches that contain today.
+ * - Meta-input format for range summaries is XML-tag delimited
+ *   (`<day date="YYYY-MM-DD">…</day>`, see `buildRangeMetaInput`).
+ *   The date rides as a structured attribute (no LLM conflation
+ *   with date headings inside a daily) and tag boundaries can't
+ *   be forged by content (avoids `---` collision with markdown
+ *   horizontal rules / yaml frontmatter inside summaries). Lands
+ *   in v0.13.0; older user-customized
+ *   `~/.agenthud/summary-range-prompt.md` files keep their old
+ *   format until manually synced.
+ * - The stderr ticker (`startStderrTicker`) is unconditionally
+ *   started during the claude call; the `onFirstChunk` callback
+ *   stops it the moment output begins streaming. Required for
+ *   `-o` (silent stdout) mode — otherwise the call looks frozen.
+ *
+ * Gotchas:
+ * - `claude -p` is invoked with `--no-session-persistence`.
+ *   Without it, every summary call creates a JSONL session under
+ *   `~/.claude/projects/` and pollutes agenthud's own session
+ *   tree (v0.9.3 fix).
+ * - The empty-day check counts 3 string-parsed metrics from the
+ *   built report markdown (`sessionCount` / `activityCount` /
+ *   `commitCount`). Fragile — deriving from `flatSessions`
+ *   upstream would be cleaner, but the count needs to reflect
+ *   what the LLM will actually see, which means parsing the
+ *   final markdown.
+ * - User home-dir prompt files (`~/.agenthud/summary-prompt.md`,
+ *   `~/.agenthud/summary-range-prompt.md`) are auto-created from
+ *   the bundled template on first run. Subsequent template
+ *   updates are NOT propagated — users who customized are left
+ *   alone. CHANGELOG documents the manual sync path.
+ */
+
 import { spawn } from "node:child_process";
 import {
   copyFileSync,

--- a/src/data/toolDetails.ts
+++ b/src/data/toolDetails.ts
@@ -1,3 +1,34 @@
+/**
+ * Per-tool summarizers for activity rows: `summarizeToolDetail`
+ * returns the one-line detail string (the part after the colon in
+ * `[HH:MM] ⚙ Edit: foo.ts L10-12 +3 -1`), and `buildToolDetailBody`
+ * returns the optional multi-line body shown in the TUI detail view
+ * (and, for Task only, included in the markdown report).
+ *
+ * Design decisions:
+ * - All tool kinds live in this one file as switch-style branches.
+ *   Splitting per-tool would over-fragment for ~10 tools; the
+ *   centralized switch doubles as a checklist of "what tools do
+ *   we render specially?"
+ * - `detailBody` is opt-in per tool: Edit gives a unified diff,
+ *   Write gives the written content, Read gives line-numbered
+ *   content, Task gives the subagent's returned text. Bash and
+ *   everything else return null so the TUI just shows the
+ *   one-liner.
+ * - Task's body is intentionally exposed to the markdown report
+ *   (see `reportGenerator.ts:formatTaskBody`). Other tools'
+ *   bodies stay TUI-only to keep LLM payload size bounded.
+ *
+ * Gotcha:
+ * - Claude Code's JSONL stores tool results in a `toolUseResult`
+ *   field with shape-per-tool. `Write` puts content on
+ *   `result.content`, `Read` on `result.file.content`, `Task`
+ *   also on `result.content`, `Edit` puts a structured patch on
+ *   `result.structuredPatch`. Defensive null checks throughout
+ *   because Claude Code's schema isn't versioned and this code
+ *   runs against logs going back months.
+ */
+
 import { basename } from "node:path";
 
 export interface ToolInput {


### PR DESCRIPTION
## Summary

PR 3/5 of the file-headers retrofit. Covers the 4 files that turn raw activity into reports and LLM summaries.

## Files

- **\`src/data/reportGenerator.ts\`** — chronological report builder; Markdown for humans/LLM, JSON for scripts
- **\`src/data/toolDetails.ts\`** — per-tool one-liner summarizer + opt-in multi-line body
- **\`src/data/summaryRunner.ts\`** — daily/range orchestration via \`claude -p\`
- **\`src/data/summariesIndex.ts\`** — existing prose header reshaped into the new Purpose/Decisions/Gotcha layout

## Findings flagged in the headers

- **\`reportGenerator.ts\`**: JSON nests sub-agent activities under parents; Markdown deliberately does not (LLM payload size bound). Task's \`detailBody\` is the only tool body that reaches the markdown payload — that's the whole point of including Task.
- **\`toolDetails.ts\`**: Claude Code's JSONL \`toolUseResult\` schema isn't versioned; every shape access is defensive because the code runs against logs months old.
- **\`summaryRunner.ts\`**: Daily and range share state on purpose (one cache-write path). Empty-day check uses string-parsed metrics on the built report markdown — fragile but reflects what the LLM actually sees. \`claude -p\` invoked with \`--no-session-persistence\` to avoid polluting agenthud's own session tree (v0.9.3 regression guard).
- **\`summariesIndex.ts\`**: Index regen is best-effort — errors logged to stderr, never thrown. The LLM call's success is what matters; a stale index shouldn't block the user's exit code.

## Note on existing header

\`summariesIndex.ts\` already had a prose-style doc block. Per the new convention rule — "update or delete the wrong bullet, never leave a stale one" — reshaped to the standard layout. Substantively the same content, just structured for searchability.

## Test plan
- [x] \`npx vitest run\` — 561/561 passing
- [x] \`npx tsc --noEmit\` — clean
- [x] No code changes; doc-only

## Remaining series

| PR | Area | Files |
|---|---|---|
| 4 | UI panels | App, SessionTreePanel, ActivityViewerPanel, DetailViewPanel, HelpPanel, constants, lineColoring |
| 5 | UI hooks + utils | useHotkeys, useSpinner, useTick, altScreen, legacyConfig, nodeVersion, openInDefaultApp, performance, platform, stderrTicker |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal code documentation across data processing modules with comprehensive comments detailing report generation, summaries indexing, summary orchestration, and tool detail handling. Improved developer clarity on design decisions and system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->