### PR TITLE
docs: add file headers to UI panels (PR 4/5)

### DIFF
--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -1,3 +1,33 @@
+/**
+ * Bottom panel: render the activity feed for the selected session
+ * as a tail-feed (newest at the bottom). Scrollable, filterable
+ * via filter presets, with a "live" highlight band that sweeps
+ * across the newest row while the session is mid-update.
+ *
+ * Design decisions:
+ * - Tail-feed layout (v0.9.3 reversal). Newest entry sits at the
+ *   bottom like `tail -f`, terminal logs, chat apps. Empty
+ *   padding moved to the top. `g` jumps to the oldest (top), `G`
+ *   to the live edge (bottom) — vim convention. PgUp/PgDn
+ *   directions swap accordingly.
+ * - "Live" row gets a spinner icon + flashlight highlight band
+ *   that sweeps left → right across its label. Replaces the
+ *   v0.9.3 standalone sliding-arrow row — the alive cue now
+ *   lives on the actual row, freeing the breathing slot back as
+ *   real activity space.
+ * - Filter application is memoized on `(sessionId + visible
+ *   activities window)` only, NOT on the spinner tick. Including
+ *   the tick in the key trashes the memo every 100ms and recomputes
+ *   the filter on every render — measurable scroll-position
+ *   regression on long histories.
+ *
+ * Gotcha:
+ * - Status-bar PAUSED indicator distinguishes `↑N` (scrolled up
+ *   from live) from `+N↓` (new entries below current view) so the
+ *   user always knows their position relative to live. A single
+ *   "PAUSED" with no counter loses that signal.
+ */
+
 import { Box, Text } from "ink";
 import type React from "react";
 import { memo } from "react";

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,3 +1,41 @@
+/**
+ * Top-level Ink component. Owns the global state — sessions, selected
+ * id, expand-state set, viewer scroll, focus, tracking — and wires the
+ * background refresh: a ~2s poll plus a supplementary `fs.watch` on
+ * the projects directory. Dispatches keystrokes to the right
+ * sub-panel via `useHotkeys`.
+ *
+ * Design decisions:
+ * - Inverse expansion. Hot/warm sessions and projects default to
+ *   *expanded*; cold ones default to *collapsed*. Reason: on boot,
+ *   the user almost always cares about today's hot work, not last
+ *   month's cold tree. Enter toggles in either direction.
+ * - Polling is primary; `fs.watch` is supplemental. macOS
+ *   recursive `fs.watch` silently drops cross-project events, so
+ *   the ~2s poll guarantees the tree converges within one
+ *   interval even when the OS watcher missed an event.
+ * - Tracking mode jumps only on *new* sub-agent ids (or when the
+ *   current one cools). A naive "newest mtime" implementation
+ *   loses every race to the already-busy sub-agent — the user
+ *   selected it, it keeps writing fastest, tracking never
+ *   advances. Snapshot the known-id set when tracking turns on,
+ *   then chase additions to it.
+ * - `appendSubAgentRows` is exported solely so the same expansion
+ *   rule the renderer applies is pinned by unit test. Keeping the
+ *   rule one-place-only (in the render code) makes drift between
+ *   App's flattened nav list and SessionTreePanel's rendered list
+ *   inevitable — and that drift is exactly what breaks j/k
+ *   navigation silently.
+ *
+ * Gotcha:
+ * - Cold-session sub-agent expansion uses its own flag
+ *   (`__expanded-session-<id>`), separate from the global
+ *   `expandedIds`. Both `appendSubAgentRows` here AND
+ *   `SessionTreePanel:subAgentsFullyExpanded` must consult it or
+ *   the renderer shows every sub-agent while App's nav list
+ *   misses them (selectedIndex = -1, j/k go silent).
+ */
+
 // src/ui/App.tsx
 
 import type { FSWatcher } from "node:fs";

--- a/src/ui/DetailViewPanel.tsx
+++ b/src/ui/DetailViewPanel.tsx
@@ -1,3 +1,30 @@
+/**
+ * Full-screen detail overlay for one activity entry. Renders the
+ * multi-line body — diff for Edit, written content for Write,
+ * line-numbered content for Read, subagent response for Task, full
+ * `git show --stat --patch` for commits — with syntax-aware
+ * coloring (green/red/cyan for diffs, cyan for fenced code blocks,
+ * plain for prose).
+ *
+ * Design decisions:
+ * - Coloring routes through `lineColoring.classifyDiffLines` and
+ *   `classifyCodeFences`, not language-specific syntax
+ *   highlighters. Goal is structural cues (added vs removed,
+ *   prose vs code), not real syntax highlighting — keeps the
+ *   dependency surface tiny and the renderer fast.
+ * - Scroll-only overlay: `↑/↓/j/k` to scroll, `Esc/q/↵` to close.
+ *   No find/search/copy — Ink's text rendering would have to
+ *   reimplement them and they're easily available outside the
+ *   TUI.
+ *
+ * Gotcha:
+ * - Indentation and whitespace inside code and diff bodies must
+ *   be preserved verbatim. Ink's `<Text>` is rendered with no
+ *   `wrap` so the trailing spaces on patch hunk context lines
+ *   stay intact (v0.11.0 fix — earlier versions flattened lines
+ *   and broke hunk alignment in the renderer).
+ */
+
 import { Box, Text } from "ink";
 import type React from "react";
 import type { ActivityEntry } from "../types/index.js";

--- a/src/ui/HelpPanel.tsx
+++ b/src/ui/HelpPanel.tsx
@@ -1,3 +1,30 @@
+/**
+ * Full-screen `?` help overlay listing every keybinding by panel,
+ * session-status badges with their colors, CLI commands, and file
+ * paths agenthud reads/writes. The canonical "what does X key do"
+ * reference inside the app.
+ *
+ * Design decisions:
+ * - The `SECTIONS` constant is hand-curated, not generated from
+ *   `useHotkeys` callbacks. Reason: hotkeys are runtime
+ *   dispatchers, the help table is documentation — they want
+ *   different groupings ("Project tree", "Activity viewer",
+ *   "Always available") that don't map 1:1 to call sites. Drift
+ *   is caught in code review; the value of human-readable
+ *   section grouping outweighs deduplication.
+ * - Scrollable (`j/k`, `↑/↓`, `PgUp/PgDn`, `Ctrl+B/F`, `Space`,
+ *   `g/G`) with a bottom indicator (`-- current/total --`) so
+ *   users on terminals shorter than the help content know there's
+ *   more to scroll to. v0.9.3 added this after the help silently
+ *   truncated on smaller windows.
+ *
+ * Gotcha:
+ * - The key-column width is auto-computed but capped at 30 cells.
+ *   Without the cap, a single long keybind label
+ *   (e.g. `PgUp / PgDn / Ctrl+B / Ctrl+F`) crushes the
+ *   description column on narrow terminals.
+ */
+
 import { Box, Text } from "ink";
 import type React from "react";
 import { getDisplayWidth } from "./constants.js";

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -1,3 +1,30 @@
+/**
+ * Top panel: renders the project tree — projects → sessions →
+ * sub-agents — with status badges, elapsed time, model name, and
+ * the active selection highlight.
+ *
+ * Design decisions:
+ * - Cold projects collapse into a single
+ *   `... N cold projects` sentinel at the bottom of the tree, not
+ *   per-project. Enter on that sentinel expands the entire cold
+ *   group at once. Reason: a single user usually has 10–30 cold
+ *   projects scattered over time; per-row expansion turns the
+ *   tree into mostly grayed noise.
+ * - Sub-agents under cold sessions group under a
+ *   `__sub-parent__` sentinel; Enter on the cold session expands
+ *   them all (must agree with App's `appendSubAgentRows` rule —
+ *   see App.tsx's gotcha).
+ * - Right-edge column reserves 3 cells of padding so the
+ *   project/session title doesn't run flush against the
+ *   elapsed/model column. Improves readability at every width.
+ *
+ * Gotcha:
+ * - Width-aware title truncation uses display *cells* (CJK-aware
+ *   via `getDisplayWidth`), not JavaScript character count. A
+ *   `.length`-based truncation would chop CJK strings at the
+ *   wrong width and leave bare half-width remnants.
+ */
+
 import { homedir } from "node:os";
 import { Box, Text } from "ink";
 import type React from "react";

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -1,3 +1,27 @@
+/**
+ * Shared UI constants — time thresholds, panel widths, terminal
+ * limits, box-drawing characters — plus the display-width helpers
+ * (`getDisplayWidth`, `getInnerWidth`, `createTitleLine`,
+ * `createBottomLine`) used by every panel for borders and
+ * truncation.
+ *
+ * Design decision:
+ * - `getDisplayWidth` is memoized across calls. Without
+ *   memoization, repeated `stringWidth` invocations on the same
+ *   string across renders cost ~17% CPU on a 60-row tree
+ *   (measured in v0.9.0). The cache survives renders and is
+ *   stable across the process lifetime — no invalidation needed
+ *   since string display width is a pure function.
+ *
+ * Gotcha:
+ * - `THIRTY_MINUTES_MS` and `ONE_HOUR_MS` are imported by
+ *   `src/data/sessions.ts` and `src/data/sessionLiveness.ts` —
+ *   a data → ui layer violation flagged in those files. The
+ *   constants should move to `src/utils/timeConstants.ts` (or
+ *   live on `types/index.ts`) on a future refactor; keeping them
+ *   here for now to avoid mixing the move with unrelated work.
+ */
+
 // Time constants (in milliseconds)
 export const THIRTY_SECONDS_MS = 30 * 1000;
 export const THIRTY_MINUTES_MS = 30 * 60 * 1000;

--- a/src/ui/lineColoring.ts
+++ b/src/ui/lineColoring.ts
@@ -1,3 +1,23 @@
+/**
+ * Tag each line of a unified-diff– or markdown-fenced–shaped block
+ * with a `LineCategory` so the renderer (`DetailViewPanel`) can
+ * color them: `diff-add` green, `diff-remove` red, `diff-hunk`
+ * cyan, `diff-meta` dimmed, `code-fence` cyan, `code` plain, etc.
+ *
+ * Design decision:
+ * - Heuristic-only — no language parser, no AST. Goal is
+ *   "structural cues a reader uses to skim a diff or a code
+ *   block", not real syntax highlighting. Keeps the file under
+ *   100 lines and the dep surface zero.
+ *
+ * Gotcha:
+ * - Order matters in `classifyDiffLines`: `+++ /path` and
+ *   `--- /path` are unified-diff *file headers* and must be
+ *   matched BEFORE the generic `+`/`-` prefix check. Without the
+ *   ordering, file headers get colored green/red and look like
+ *   added/removed code lines.
+ */
+
 export type LineCategory =
   | "diff-add"
   | "diff-remove"


### PR DESCRIPTION
## Summary

PR 4/5 of the file-headers retrofit. Covers the 7 files that make up the interactive TUI surface.

## Files

- **\`src/ui/App.tsx\`** — top-level Ink component; global state owner; polling + fs.watch wiring
- **\`src/ui/SessionTreePanel.tsx\`** — project/session/sub-agent tree renderer
- **\`src/ui/ActivityViewerPanel.tsx\`** — tail-feed activity panel
- **\`src/ui/DetailViewPanel.tsx\`** — full-screen detail overlay
- **\`src/ui/HelpPanel.tsx\`** — \`?\` help overlay
- **\`src/ui/constants.ts\`** — UI constants + display-width helpers
- **\`src/ui/lineColoring.ts\`** — diff/code line classification

## Highlighted findings

- **\`App.tsx\` ↔ \`SessionTreePanel.tsx\`**: the cold-session sub-agent expansion rule lives in both files. Both headers cross-reference the other — agreement between them is what keeps j/k navigation working on cold trees (else the renderer shows rows that App's nav list misses, \`selectedIndex = -1\`, silent failure).
- **\`App.tsx\`**: tracking jumps on *new* sub-agent ids, not "newest mtime". A naive mtime impl loses every race to the already-busy sub-agent, so tracking would never advance. Snapshot the known-id set when tracking turns on, then chase additions.
- **\`ActivityViewerPanel.tsx\`**: filter memo key intentionally excludes the spinner tick. Including it trashes the memo every 100ms and recomputes the filter on every render — measurable scroll-position regression.
- **\`HelpPanel.tsx\`**: \`SECTIONS\` is hand-curated, not derived from \`useHotkeys\`. Different groupings serve different purposes; drift caught in code review.
- **\`constants.ts\`**: \`getDisplayWidth\` memoization saves ~17% CPU on tall trees (v0.9.0 measurement). Also reflagged the \`THIRTY_MINUTES_MS\` data → ui import layer violation from the receiving side; the actual move belongs in a separate refactor.
- **\`lineColoring.ts\`**: ordering gotcha — \`+++ /path\` and \`--- /path\` are unified-diff *file headers*, must match before the generic \`+\`/\`-\` prefix check or they get colored as added/removed code.

## Test plan
- [x] \`npx vitest run\` — 561/561 passing
- [x] \`npx tsc --noEmit\` — clean
- [x] No code changes; doc-only

## Remaining series

| PR | Area | Files |
|---|---|---|
| 5 | UI hooks + utils | useHotkeys, useSpinner, useTick, altScreen, legacyConfig, nodeVersion, openInDefaultApp, performance, platform, stderrTicker |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added line coloring and classification system for code and diff views with automatic style assignment.

* **Documentation**
  * Enhanced internal documentation for UI components, state management, and rendering design decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->