### PR TITLE
docs: add file headers to UI hooks + utils (PR 5/5, final)

### DIFF
--- a/src/ui/hooks/useHotkeys.ts
+++ b/src/ui/hooks/useHotkeys.ts
@@ -1,3 +1,26 @@
+/**
+ * Single-source-of-truth Ink keyboard dispatcher. Receives a giant
+ * options bag of `onXxx` callbacks from `App.tsx` and routes the
+ * current keystroke to the right callback based on focus (`tree`
+ * vs `viewer`) and mode (help overlay open, detail overlay open).
+ *
+ * Design decisions:
+ * - Modes are exclusive and short-circuit: help > detail > main.
+ *   The input handler returns early after the first mode handles
+ *   the key. Otherwise typing `j` in the help overlay would also
+ *   scroll the tree underneath.
+ * - Vim keys (`j/k/g/G/Ctrl+B/F/U/D`) and arrow keys are both
+ *   accepted in parallel — users come from both terminal cultures
+ *   and having either work removes friction.
+ *
+ * Gotcha:
+ * - The plain `f` (filter cycle) handler MUST guard `!key.ctrl`.
+ *   Otherwise Ctrl+F (page-down) ALSO fires the filter cycle on
+ *   the same keystroke. Same for `b`/`u`/`d` vs their Ctrl
+ *   variants — vim's leader-style keys overlap with control
+ *   codes if the modifier isn't excluded.
+ */
+
 interface UseHotkeysOptions {
   focus: "tree" | "viewer";
   detailMode: boolean;

--- a/src/ui/hooks/useSpinner.ts
+++ b/src/ui/hooks/useSpinner.ts
@@ -1,3 +1,16 @@
+/**
+ * Cycle through braille spinner frames at a fixed interval while
+ * `active` is true. Returns the current frame glyph, or an empty
+ * string when inactive.
+ *
+ * Design decision:
+ * - Inactive returns `""` (not `null`/`undefined` or a static
+ *   glyph) so the consumer can splice it into JSX without
+ *   conditional rendering: `<Text>{spinner}{label}</Text>` reads
+ *   the same active or inactive, and the layout doesn't reflow
+ *   when the spinner stops.
+ */
+
 import { useEffect, useState } from "react";
 
 const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];

--- a/src/ui/hooks/useTick.ts
+++ b/src/ui/hooks/useTick.ts
@@ -1,15 +1,17 @@
+/**
+ * Monotonic frame counter that increments every `intervalMs` while
+ * `active` is true; freezes the value when `active` flips to false.
+ *
+ * Design decision:
+ * - Distinct from `useSpinner` (which returns a glyph) because
+ *   some animations — a flashlight sweep, a sliding cursor — have
+ *   a modulus that depends on per-row content (e.g. the row's
+ *   character width). Returning a raw integer lets callers do
+ *   `% N` where `N` varies per render.
+ */
+
 import { useEffect, useState } from "react";
 
-/**
- * Monotonic counter that increments every `intervalMs` while `active` is
- * true. Stops (freezes the value) when `active` flips to false. Use the
- * returned integer with `% N` to drive any sliding / sweeping animation
- * whose period depends on per-frame content.
- *
- * Distinct from `useSpinner` (which returns a glyph) so we can drive an
- * animation whose modulus changes per row (e.g. a flashlight sweep
- * scaled to the row's character width).
- */
 export function useTick(active: boolean, intervalMs = 100): number {
   const [n, setN] = useState(0);
   useEffect(() => {

--- a/src/utils/altScreen.ts
+++ b/src/utils/altScreen.ts
@@ -1,12 +1,29 @@
 /**
- * Alternate screen buffer helper. Mirrors what htop/vim/btop/lazygit do:
- * on entry the terminal switches to a fresh buffer, on exit it restores
- * the user's pre-launch shell with no TUI residue. Without this, agenthud's
- * rendered tree stays on screen after `q` and viewers can't tell whether
- * the process is still running.
+ * Alternate screen buffer (`\x1b[?1049h` / `l`) entry, exit, and
+ * signal-handler installation. Mirrors what htop, vim, btop, and
+ * lazygit do: on entry the terminal switches to a fresh buffer; on
+ * exit the user's pre-launch shell is restored with no TUI residue.
  *
- * Idempotent: enter() / leave() each only fire once even if called multiple
- * times. leave() is auto-registered on the common exit paths.
+ * Design decisions:
+ * - Idempotent. `enterAltScreen()` / `leaveAltScreen()` each only
+ *   write once regardless of how many times they're called.
+ *   Otherwise duplicate handler registration (every Ink re-render
+ *   on hot module reload during dev) would write the escape
+ *   sequence repeatedly.
+ * - `installAltScreenCleanup` registers leave on every common
+ *   exit path: normal exit, SIGINT (Ctrl+C, exit 130), SIGTERM
+ *   (exit 143), and `uncaughtException`.
+ * - The uncaught-exception handler re-throws via `setImmediate`
+ *   after restoring the terminal. The async re-throw ensures node
+ *   still exits non-zero AND prints the trace itself — without
+ *   `setImmediate`, the trace would race the alt-screen restore
+ *   and land on the buried TUI underneath.
+ *
+ * Gotcha:
+ * - `process.on("exit")` handlers MUST be synchronous. A direct
+ *   `process.stdout.write` is fine; anything async (e.g. an
+ *   `await` or a `setTimeout`) silently no-ops because node is
+ *   already tearing down.
  */
 
 const ENTER = "\x1b[?1049h";

--- a/src/utils/legacyConfig.ts
+++ b/src/utils/legacyConfig.ts
@@ -1,3 +1,27 @@
+/**
+ * Decide whether a `.agenthud/config.yaml` under `cwd` should be
+ * treated as a *legacy project-level* config that the user should
+ * be prompted to migrate, or as the *global* config that must
+ * never be touched. Used by the migration prompt at boot.
+ *
+ * Design decisions:
+ * - Returns false (= "this IS the global config, leave alone") in
+ *   two cases: cwd literally equals home (covers every native
+ *   platform), AND cwd is a `/mnt/<drive>/Users/<name>` Windows
+ *   user-home mount when running inside WSL.
+ * - `opts.isWSL` is dependency-injectable so tests don't have to
+ *   either stub `/proc/version` or skip on non-WSL runners.
+ *
+ * Gotcha:
+ * - Inside WSL, `homedir()` returns the Linux home
+ *   (`/home/<name>`) but the user often runs from
+ *   `/mnt/c/Users/<name>` — the Windows-side home. Without the
+ *   WSL guard, agenthud's "is this a project-level config?" check
+ *   wrongly returns true and the migration prompt offers to
+ *   delete the Windows-native global config. v0.12.4 added this
+ *   as a data-loss guard.
+ */
+
 import { join, resolve } from "node:path";
 import { isWSL as detectWSL } from "./platform.js";
 
@@ -5,26 +29,6 @@ import { isWSL as detectWSL } from "./platform.js";
 // home. Only meaningful when we know we're inside WSL.
 const WSL_WINDOWS_USER_HOME = /^\/mnt\/[a-z]\/Users\/[^/]+\/?$/i;
 
-/**
- * Returns true if a `.agenthud/config.yaml` under `cwd` should be
- * treated as a legacy project-level config (and offered for
- * migration). Returns false when the path is in fact a global config
- * we shouldn't touch — currently two cases:
- *
- *   1. `cwd` is literally the user's home directory (the existing
- *      guard — covers every native platform). `homedir()` is the
- *      source of truth here.
- *
- *   2. We're running inside WSL and `cwd` looks like a
- *      `/mnt/<drive>/Users/<name>` mount of the Windows-side user
- *      home. In that case `homedir()` lies — it reports the Linux
- *      home (`/home/<name>`) — but the `.agenthud/config.yaml`
- *      sitting in the Windows user dir is the Windows-native global
- *      config and deleting it would wipe real settings.
- *
- * `opts.isWSL` is injectable for tests; in real use the default
- * runtime detector fires.
- */
 export function isLegacyProjectConfig(
   cwd: string,
   home: string,

--- a/src/utils/nodeVersion.ts
+++ b/src/utils/nodeVersion.ts
@@ -1,3 +1,18 @@
+/**
+ * Parse and validate the running Node major version; abort with a
+ * friendly upgrade message if below `MIN_NODE_VERSION`.
+ *
+ * Design decision:
+ * - This file exposes unit-testable helpers
+ *   (`parseNodeMajorVersion`, `isNodeVersionSupported`) that
+ *   don't fire `process.exit`. The bin entry (`src/index.ts`)
+ *   deliberately duplicates the version-gate logic inline rather
+ *   than importing this module, so the boot path doesn't load
+ *   any project code before the Node-version check passes — which
+ *   is the whole point of the gate (older Node may fail on
+ *   transitive dep parse).
+ */
+
 export const MIN_NODE_VERSION = 20;
 
 export function parseNodeMajorVersion(version: string): number {

--- a/src/utils/openInDefaultApp.ts
+++ b/src/utils/openInDefaultApp.ts
@@ -1,3 +1,33 @@
+/**
+ * Launch the OS default app on a file path (drives `summary --open`
+ * and `--open-index`). Builds per-platform commands, sync-checks
+ * that the launcher exists on PATH, spawns it, waits a brief grace
+ * period, and bubbles failures to stderr so the caller's printed
+ * path remains a sensible fallback.
+ *
+ * Design decisions:
+ * - Per-platform command builders return `null` (not a default
+ *   fallback) on unrecognized platforms, so the caller decides
+ *   how to warn — silent fallback would mean the user wonders
+ *   why nothing opened.
+ * - On WSL prefer `wslview` (from the `wslu` package) — it routes
+ *   through to the Windows host's default app. `xdg-open` is the
+ *   linux fallback; on a headless WSL without a display it'll
+ *   fail, and the command-exists check below catches that before
+ *   the spawn even runs.
+ * - Failure detection waits a brief grace period after spawn,
+ *   then resolves. Fast-failing errors (no command, immediate
+ *   non-zero exit) get surfaced; long-running launches (the app
+ *   is starting up) succeed. The grace is intentionally short
+ *   (~200ms) so the parent process doesn't hang on the call.
+ *
+ * Gotcha:
+ * - Windows `start` quoting: the FIRST quoted argument to `start`
+ *   is the window title. A path with spaces would otherwise be
+ *   eaten as the title and the file would never open. The leading
+ *   empty-string title `""` in `start "" "path"` is intentional.
+ */
+
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -1,3 +1,24 @@
+/**
+ * Periodic cleanup of `performance.mark` / `performance.measure`
+ * entries. Dodges the "Possible perf_hooks memory leak detected"
+ * Node warning that fires when the buffer exceeds its default
+ * limit (10k entries).
+ *
+ * Design decision:
+ * - Run as an opt-in background interval owned by the App; safe
+ *   to call `stopPerformanceCleanup` more than once (clears the
+ *   handle and re-nulls it). Default 60s interval is tuned to
+ *   stay well under the buffer limit even on hot Ink renders.
+ *
+ * Gotcha:
+ * - `src/index.ts` pins `NODE_ENV=production` precisely to stop
+ *   React from emitting per-render perf marks (the v0.9.0
+ *   ~600KB/s leak). Even with that, some deps still emit marks
+ *   at runtime — the buffer fills more slowly but eventually
+ *   trips the warning if uncleared. This cleanup is the
+ *   belt-and-braces for the env pin.
+ */
+
 import { performance } from "node:perf_hooks";
 
 const DEFAULT_CLEANUP_INTERVAL = 60000; // 60 seconds

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,11 +1,24 @@
+/**
+ * Detect whether this Node process is running inside WSL — via the
+ * `WSL_DISTRO_NAME` env var (set by Microsoft's launcher) or the
+ * `microsoft`/`wsl` markers in `/proc/version`.
+ *
+ * Design decision:
+ * - Result cached for the lifetime of the process. Neither signal
+ *   changes mid-run, and `--open` calls (which check WSL) can
+ *   fire repeatedly — re-reading `/proc/version` every time would
+ *   be wasted syscalls.
+ *
+ * Gotcha:
+ * - Only used as an environment detector — don't read it before
+ *   `process.env` is populated (i.e. don't call from a module
+ *   top-level that runs at import time on Node where env stripping
+ *   could matter). All current call sites are inside functions, so
+ *   this is fine in practice.
+ */
+
 import { readFileSync } from "node:fs";
 
-/**
- * True when this Node process is running inside WSL. Detected by the
- * `WSL_DISTRO_NAME` env var (set by Microsoft's launcher) or the
- * `microsoft`/`wsl` markers in `/proc/version`. Result is cached for
- * the lifetime of the process — neither signal changes mid-run.
- */
 let cached: boolean | null = null;
 export function isWSL(): boolean {
   if (cached !== null) return cached;

--- a/src/utils/stderrTicker.ts
+++ b/src/utils/stderrTicker.ts
@@ -1,12 +1,27 @@
 /**
  * Live "still working" feedback on stderr while a long-running task
- * (LLM call, big build, etc.) blocks. Renders the same line repeatedly
- * using a carriage return so the spinner doesn't scroll past the
- * pre-line content.
+ * blocks. Used during `claude -p` summary calls, especially when
+ * `--open` suppresses the streamed LLM output and the user would
+ * otherwise stare at a frozen-looking terminal for 30–60+ seconds.
  *
- * Use case in agenthud: when --open suppresses the streamed claude
- * output, the user is otherwise staring at a frozen-looking terminal
- * for 30–60+ seconds. A ticking line tells them the process is alive.
+ * Design decisions:
+ * - Uses `\r` (carriage return) instead of newlines so the ticker
+ *   updates in place — doesn't scroll the pre-spinner content out
+ *   of view, doesn't fill the terminal with redraw lines.
+ * - Dot count is padded to 3 cells (`. `, `..`, `...`, `   `) so
+ *   the trailing elapsed-seconds text stays at the same column
+ *   regardless of which dot frame is current. Without the pad the
+ *   `12s` jitters left and right as dots cycle.
+ * - `stop()` only erases the line if the ticker actually wrote
+ *   anything. Safe to call `stop()` even when the task finished
+ *   before the first tick — no spurious blank line in stderr.
+ *
+ * Gotcha:
+ * - The erase sequence is `\r\x1b[K` (return to col 0, erase to
+ *   end-of-line). Without the `\x1b[K`, a long ticker line
+ *   (`"sending to claude... 47s"`) could leave trailing chars
+ *   behind the next stderr write if it's shorter than the
+ *   ticker's last frame.
  */
 
 /** Pure helper used to render the ticker line. Exported for testing. */


### PR DESCRIPTION
## Summary

**Final PR (5/5)** of the file-headers retrofit. Covers the 10 remaining UI-hook and utility files.

After this lands, **all 31 source files carry a header** following the convention from \`~/.claude/CLAUDE.md\`.

## Files

**UI hooks (3):**
- \`src/ui/hooks/useHotkeys.ts\` — single-source Ink input dispatcher
- \`src/ui/hooks/useSpinner.ts\` — braille frame spinner
- \`src/ui/hooks/useTick.ts\` — monotonic frame counter

**Utils (7):**
- \`src/utils/altScreen.ts\` — alt-screen buffer + signal handlers
- \`src/utils/legacyConfig.ts\` — WSL home-detection guard
- \`src/utils/nodeVersion.ts\` — testable Node version helpers
- \`src/utils/openInDefaultApp.ts\` — OS default-app launcher
- \`src/utils/performance.ts\` — \`perf_hooks\` buffer cleanup
- \`src/utils/platform.ts\` — WSL detection
- \`src/utils/stderrTicker.ts\` — in-place \"still working\" feedback

## Notable findings

- **\`useHotkeys.ts\`**: \`f\` (filter cycle) MUST guard \`!key.ctrl\` — without it Ctrl+F (page-down) fires the filter cycle too on the same keystroke. Same for \`b/u/d\` vs their Ctrl variants.
- **\`altScreen.ts\`**: \`uncaughtException\` handler re-throws via \`setImmediate\` after restoring the terminal. Without the async, the trace races the alt-screen restore and lands on the buried TUI.
- **\`legacyConfig.ts\`**: re-documents the v0.12.4 WSL data-loss guard — \`homedir()\` returns the Linux home, but cwd often sits under \`/mnt/c/Users/<X>\`. Without the WSL check the migration prompt offers to delete the Windows-native config.
- **\`nodeVersion.ts\`**: bin entry deliberately duplicates the version-gate inline so the boot path doesn't import this module before the Node check passes — which is the whole point of the gate.
- **\`openInDefaultApp.ts\`**: Windows \`start \"\" \"path\"\` empty-title quoting documented (a path with spaces would otherwise be swallowed as the window title).
- **\`stderrTicker.ts\`**: \`\\r\\x1b[K\` erase sequence so the next stderr line starts clean — without \`\\x1b[K\`, the prior ticker line bleeds through if the next message is shorter.

## Reshape note

\`altScreen.ts\`, \`legacyConfig.ts\`, \`platform.ts\`, and \`stderrTicker.ts\` already had prose-style header comments. Per the convention rule (\"update or delete the wrong bullet — never leave a stale one\"), reshaped each into the Purpose / Design decisions / Gotcha layout. Substance preserved.

## Test plan
- [x] \`npx vitest run\` — 561/561 passing
- [x] \`npx tsc --noEmit\` — clean
- [x] No code changes; doc-only

## Series summary

| PR | Area | Files | Status |
|---|---|---|---|
| #121 | Entry + config | 5 | ✓ merged |
| #122 | Data parsing | 5 | ✓ merged |
| #123 | Report + summary | 4 | ✓ merged |
| #124 | UI panels | 7 | ✓ merged |
| **#125** | **UI hooks + utils** | **10** | **this PR** |
| **Total** | | **31 / 31 files** | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)