### PR TITLE
fix: anchor activity-viewer cursor to its activity on new entries

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -503,18 +503,25 @@ export function App({
     const fileChanged = lastLoadedFileRef.current !== newFile;
     lastLoadedFileRef.current = newFile;
 
+    // Only react when the loaded FILE changes (selection moved or
+    // hottest-session-of-project changed). Activity updates for the
+    // already-selected file flow through `refresh` (polling /
+    // fs.watch), which has the delta-aware PAUSED bump for
+    // scrollOffset + newCount. A second `setActivities` from this
+    // effect on every sessionTree change would bypass that bump —
+    // view would scroll forward while the badge sat frozen.
+    if (!fileChanged) return;
+
     if (node?.filePath) {
       setActivities(parseSessionHistory(node.filePath));
-      if (fileChanged) {
-        setScrollOffset(0);
-        setIsLive(true);
-        setNewCount(0);
-        setViewerCursorLine(0);
-        setGitActivities([]);
-      }
+      setScrollOffset(0);
+      setIsLive(true);
+      setNewCount(0);
+      setViewerCursorLine(0);
+      setGitActivities([]);
     } else {
       setActivities([]);
-      if (fileChanged) setGitActivities([]);
+      setGitActivities([]);
     }
   }, [selectedId, sessionTree]);
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -503,25 +503,18 @@ export function App({
     const fileChanged = lastLoadedFileRef.current !== newFile;
     lastLoadedFileRef.current = newFile;
 
-    // Only react when the loaded FILE changes (selection moved or
-    // hottest-session-of-project changed). Activity updates for the
-    // already-selected file flow through `refresh` (polling /
-    // fs.watch), which has the delta-aware PAUSED bump for
-    // scrollOffset + newCount. A second `setActivities` from this
-    // effect on every sessionTree change would bypass that bump —
-    // view would scroll forward while the badge sat frozen.
-    if (!fileChanged) return;
-
     if (node?.filePath) {
       setActivities(parseSessionHistory(node.filePath));
-      setScrollOffset(0);
-      setIsLive(true);
-      setNewCount(0);
-      setViewerCursorLine(0);
-      setGitActivities([]);
+      if (fileChanged) {
+        setScrollOffset(0);
+        setIsLive(true);
+        setNewCount(0);
+        setViewerCursorLine(0);
+        setGitActivities([]);
+      }
     } else {
       setActivities([]);
-      setGitActivities([]);
+      if (fileChanged) setGitActivities([]);
     }
   }, [selectedId, sessionTree]);
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -697,25 +697,30 @@ export function App({
   // view freezes on the same snapshot and the cursor's activity stays
   // put. Math is in viewerCursor.ts; this effect just feeds it the
   // current snapshot and applies the resulting state changes.
+  //
+  // State updates intentionally live at the top of the effect body
+  // (not inside `setViewerCursorLine`'s functional updater) — mixing
+  // side-effect setStates inside an updater can fire twice in Strict
+  // Mode and double-count the auto-pause scroll/badge delta.
   useEffect(() => {
     const prev = prevMergedCountRef.current;
     prevMergedCountRef.current = mergedActivities.length;
-    setViewerCursorLine((current) => {
-      const result = adjustViewerCursorOnNewActivities({
-        prevCursorLine: current,
-        prevActivityCount: prev,
-        newActivityCount: mergedActivities.length,
-        isLive,
-        viewerRows,
-      });
-      if (result.autoPause) {
-        setIsLive(false);
-        setScrollOffset((o) => o + result.scrollDelta);
-        setNewCount((n) => n + result.scrollDelta);
-      }
-      return result.cursorLine;
+    const result = adjustViewerCursorOnNewActivities({
+      prevCursorLine: viewerCursorLine,
+      prevActivityCount: prev,
+      newActivityCount: mergedActivities.length,
+      isLive,
+      viewerRows,
     });
-  }, [mergedActivities.length, isLive, viewerRows]);
+    if (result.cursorLine !== viewerCursorLine) {
+      setViewerCursorLine(result.cursorLine);
+    }
+    if (result.autoPause) {
+      setIsLive(false);
+      setScrollOffset((o) => o + result.scrollDelta);
+      setNewCount((n) => n + result.scrollDelta);
+    }
+  }, [mergedActivities.length, isLive, viewerRows, viewerCursorLine]);
 
   // Spinner and flashlight tick on the same cadence (150ms) so the entire
   // App re-renders ~6.7 times per second instead of 10 — measurably less

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -464,6 +464,17 @@ export function App({
   // changes per render but never needs to trigger one.
   const prevMergedCountRef = useRef(0);
 
+  // Live mirror of `isLive` so the polling refresh callback below can
+  // read the current value rather than the stale one captured at the
+  // time `refresh` was last memoized by useCallback. Without this,
+  // the very first refresh fire after an auto-PAUSE transition keeps
+  // running the LIVE branch (skipping the scrollOffset/newCount bump)
+  // because the closure still has isLive=true.
+  const isLiveRef = useRef(isLive);
+  useEffect(() => {
+    isLiveRef.current = isLive;
+  }, [isLive]);
+
   // Load activities whenever selected session changes.
   // Only resets cursor/scroll when the loaded FILE changes (selection moved or
   // hottest-session-of-project changed), not on every sessionTree refresh.
@@ -597,11 +608,15 @@ export function App({
     const newActivities = parseSessionHistory(node.filePath);
     const delta = newActivities.length - activitiesLengthRef.current;
     setActivities(newActivities);
-    if (!isLive && delta > 0) {
+    // Read isLive through the ref to avoid the stale-closure race that
+    // skips the PAUSED-mode delta bump on the first poll right after
+    // an auto-PAUSE transition (when the useCallback closure still has
+    // isLive=true even though state has flipped to false).
+    if (!isLiveRef.current && delta > 0) {
       setScrollOffset((o) => o + delta);
       setNewCount((n) => n + delta);
     }
-  }, [selectedId, isLive, expandedIds, tracking, discoverOptions]);
+  }, [selectedId, expandedIds, tracking, discoverOptions]);
 
   // Keep a stable ref so the watcher callback always calls the latest refresh
   const refreshRef = useRef(refresh);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -452,10 +452,8 @@ export function App({
     allFlatRef.current = allFlat;
   }, [allFlat]);
 
-  const activitiesLengthRef = useRef(0);
   const activitiesRef = useRef<ActivityEntry[]>(activities);
   useEffect(() => {
-    activitiesLengthRef.current = activities.length;
     activitiesRef.current = activities;
   }, [activities]);
 
@@ -464,16 +462,13 @@ export function App({
   // changes per render but never needs to trigger one.
   const prevMergedCountRef = useRef(0);
 
-  // Live mirror of `isLive` so the polling refresh callback below can
-  // read the current value rather than the stale one captured at the
-  // time `refresh` was last memoized by useCallback. Without this,
-  // the very first refresh fire after an auto-PAUSE transition keeps
-  // running the LIVE branch (skipping the scrollOffset/newCount bump)
-  // because the closure still has isLive=true.
-  const isLiveRef = useRef(isLive);
-  useEffect(() => {
-    isLiveRef.current = isLive;
-  }, [isLive]);
+  // Snapshot of the previous merged-activity count specifically for
+  // the PAUSED-mode scrollOffset/newCount bump. Separate from
+  // `prevMergedCountRef` because the cursor-anchor effect and the
+  // paused-bump effect process the same delta from different angles
+  // and at different times — sharing one ref creates a missed-update
+  // race when both fire in the same render cycle.
+  const prevPausedCountRef = useRef(0);
 
   // Load activities whenever selected session changes.
   // Only resets cursor/scroll when the loaded FILE changes (selection moved or
@@ -606,16 +601,12 @@ export function App({
     setSessionTree(tree);
     if (!node || !node.filePath) return;
     const newActivities = parseSessionHistory(node.filePath);
-    const delta = newActivities.length - activitiesLengthRef.current;
     setActivities(newActivities);
-    // Read isLive through the ref to avoid the stale-closure race that
-    // skips the PAUSED-mode delta bump on the first poll right after
-    // an auto-PAUSE transition (when the useCallback closure still has
-    // isLive=true even though state has flipped to false).
-    if (!isLiveRef.current && delta > 0) {
-      setScrollOffset((o) => o + delta);
-      setNewCount((n) => n + delta);
-    }
+    // The PAUSED-mode delta bump for scrollOffset / newCount lives
+    // in a centralized useEffect below — see `prevPausedCountRef`.
+    // Keeping it out of here ensures the bump fires regardless of
+    // which path updates activities (refresh or the redundant
+    // useEffect 488 reparse on every sessionTree change).
   }, [selectedId, expandedIds, tracking, discoverOptions]);
 
   // Keep a stable ref so the watcher callback always calls the latest refresh
@@ -736,6 +727,37 @@ export function App({
       setNewCount((n) => n + result.scrollDelta);
     }
   }, [mergedActivities.length, isLive, viewerRows, viewerCursorLine]);
+
+  // While PAUSED, keep the view frozen on its current snapshot as new
+  // entries arrive — bump `scrollOffset` and `newCount` by the delta
+  // so (a) `activities.slice(end - rows, end)` keeps showing the same
+  // window, and (b) the `+N↓` badge reflects how many new entries the
+  // user has yet to catch up to.
+  //
+  // This used to live inline in `refresh` as the
+  // `if (!isLive && delta > 0)` block, but that missed updates from
+  // useEffect 488's "redundant" re-parse of the JSONL on every
+  // sessionTree change. Hoisting it here means any source that grows
+  // mergedActivities triggers the bump correctly.
+  //
+  // Coordination with the auto-PAUSE useEffect above:
+  // - On the LIVE→PAUSED transition, auto-PAUSE bumps by the overflow
+  //   amount and `prevPausedCountRef` was 0 (or the merged count
+  //   before the transition). This effect runs in the SAME render
+  //   with isLive still true (state hasn't propagated yet), so the
+  //   `!isLive` guard skips the duplicate bump.
+  // - On the next render with isLive=false, prev === current →
+  //   delta=0, no bump. Auto-PAUSE noOps (cursor already at max).
+  // - From then on, only this effect bumps as new entries arrive.
+  useEffect(() => {
+    const prev = prevPausedCountRef.current;
+    prevPausedCountRef.current = mergedActivities.length;
+    if (!isLive && mergedActivities.length > prev) {
+      const delta = mergedActivities.length - prev;
+      setScrollOffset((o) => o + delta);
+      setNewCount((n) => n + delta);
+    }
+  }, [mergedActivities.length, isLive]);
 
   // Spinner and flashlight tick on the same cadence (150ms) so the entire
   // App re-renders ~6.7 times per second instead of 10 — measurably less

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -69,6 +69,7 @@ import { useHotkeys } from "./hooks/useHotkeys.js";
 import { useSpinner } from "./hooks/useSpinner.js";
 import { useTick } from "./hooks/useTick.js";
 import { SessionTreePanel } from "./SessionTreePanel.js";
+import { adjustViewerCursorOnNewActivities } from "./viewerCursor.js";
 
 const VIEWER_HEIGHT_FRACTION = 0.55;
 
@@ -458,6 +459,11 @@ export function App({
     activitiesRef.current = activities;
   }, [activities]);
 
+  // Snapshot of the previous merged-activity count, used by the
+  // cursor-anchor effect below. Refs (not state) because the value
+  // changes per render but never needs to trigger one.
+  const prevMergedCountRef = useRef(0);
+
   // Load activities whenever selected session changes.
   // Only resets cursor/scroll when the loaded FILE changes (selection moved or
   // hottest-session-of-project changed), not on every sessionTree refresh.
@@ -682,6 +688,25 @@ export function App({
   const treeRows = Math.max(1, Math.min(naturalTreeRows, maxTreeRows));
   // statusBar(1) + margin(1) + tree(treeRows+2) + margin(1) + viewer(viewerRows+2) = height
   const viewerRows = Math.max(5, height - 7 - treeRows);
+
+  // Keep the viewer cursor anchored to its activity when new entries
+  // arrive in LIVE mode. Without this, the visible window auto-scrolls
+  // to show new content but cursorLine stays at the same screen row —
+  // the highlighted activity silently slides forward. Math is in
+  // viewerCursor.ts; this effect just feeds it the current snapshot.
+  useEffect(() => {
+    const prev = prevMergedCountRef.current;
+    prevMergedCountRef.current = mergedActivities.length;
+    setViewerCursorLine((current) =>
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: current,
+        prevActivityCount: prev,
+        newActivityCount: mergedActivities.length,
+        isLive,
+        viewerRows,
+      }),
+    );
+  }, [mergedActivities.length, isLive, viewerRows]);
 
   // Spinner and flashlight tick on the same cadence (150ms) so the entire
   // App re-renders ~6.7 times per second instead of 10 — measurably less

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -692,20 +692,29 @@ export function App({
   // Keep the viewer cursor anchored to its activity when new entries
   // arrive in LIVE mode. Without this, the visible window auto-scrolls
   // to show new content but cursorLine stays at the same screen row —
-  // the highlighted activity silently slides forward. Math is in
-  // viewerCursor.ts; this effect just feeds it the current snapshot.
+  // the highlighted activity silently slides forward. When the cursor
+  // would scroll off the top, the helper switches to PAUSED so the
+  // view freezes on the same snapshot and the cursor's activity stays
+  // put. Math is in viewerCursor.ts; this effect just feeds it the
+  // current snapshot and applies the resulting state changes.
   useEffect(() => {
     const prev = prevMergedCountRef.current;
     prevMergedCountRef.current = mergedActivities.length;
-    setViewerCursorLine((current) =>
-      adjustViewerCursorOnNewActivities({
+    setViewerCursorLine((current) => {
+      const result = adjustViewerCursorOnNewActivities({
         prevCursorLine: current,
         prevActivityCount: prev,
         newActivityCount: mergedActivities.length,
         isLive,
         viewerRows,
-      }),
-    );
+      });
+      if (result.autoPause) {
+        setIsLive(false);
+        setScrollOffset((o) => o + result.scrollDelta);
+        setNewCount((n) => n + result.scrollDelta);
+      }
+      return result.cursorLine;
+    });
   }, [mergedActivities.length, isLive, viewerRows]);
 
   // Spinner and flashlight tick on the same cadence (150ms) so the entire

--- a/src/ui/viewerCursor.ts
+++ b/src/ui/viewerCursor.ts
@@ -1,7 +1,8 @@
 /**
- * Adjust the activity-viewer cursor when new activities arrive so
- * the cursor stays anchored to its activity instead of sliding to a
- * different one as the visible window auto-scrolls in LIVE mode.
+ * Decide how the activity-viewer cursor should move when new
+ * activities arrive in LIVE mode, so the cursor stays anchored to
+ * its activity rather than sliding to a different one as the
+ * visible window auto-scrolls.
  *
  * Design decisions:
  * - `viewerCursorLine` counts rows from the LIVE EDGE (the bottom
@@ -12,17 +13,18 @@
  * - cursorLine === 0 is treated as "user wants to track live" —
  *   not as a content anchor. The user hasn't moved off the live
  *   row, so leave it on the live row.
- * - Pure function — App.tsx wires it into a `useEffect` keyed off
- *   the merged activity count, but the math has no React
- *   dependencies and tests run as plain unit tests.
- *
- * Gotcha:
  * - When the cursor's anchored activity would scroll off the top
- *   of the viewport (cursor + delta > viewerRows - 1), we clamp
- *   to `viewerRows - 1` and accept losing content-anchoring for
- *   that activity. The alternative — switching the viewer to
- *   PAUSED automatically — is a bigger behavior change and
- *   belongs in a follow-up if it turns out to be needed.
+ *   of the viewport, the result switches the viewer to PAUSED.
+ *   This freezes the view at its current snapshot (cursor stays
+ *   on the top row showing the same activity, no further auto-
+ *   scrolling, new entries accumulate as the `+N↓` badge). The
+ *   alternative (clamp cursor + stay LIVE) makes the cursor's
+ *   activity silently slide forward each new entry — exactly the
+ *   bug we're fixing.
+ * - Pure function returning a result shape. App.tsx wires it into
+ *   a `useEffect` and applies the result to setViewerCursorLine /
+ *   setIsLive / setScrollOffset / setNewCount. Tests run as plain
+ *   unit tests with no React surface.
  */
 
 export interface AdjustViewerCursorArgs {
@@ -33,9 +35,23 @@ export interface AdjustViewerCursorArgs {
   viewerRows: number;
 }
 
+export interface AdjustViewerCursorResult {
+  /** New cursor row (counted from the live edge). */
+  cursorLine: number;
+  /** True when the result transitions LIVE → PAUSED. */
+  autoPause: boolean;
+  /**
+   * On auto-pause, the number of new entries that became
+   * "scrolled past" the viewport — caller should add this to both
+   * `scrollOffset` and `newCount` so the badge reflects them.
+   * Always 0 when `autoPause` is false.
+   */
+  scrollDelta: number;
+}
+
 export function adjustViewerCursorOnNewActivities(
   args: AdjustViewerCursorArgs,
-): number {
+): AdjustViewerCursorResult {
   const {
     prevCursorLine,
     prevActivityCount,
@@ -44,18 +60,44 @@ export function adjustViewerCursorOnNewActivities(
     viewerRows,
   } = args;
 
+  const noOp: AdjustViewerCursorResult = {
+    cursorLine: prevCursorLine,
+    autoPause: false,
+    scrollDelta: 0,
+  };
+
   // Paused: visible window doesn't auto-scroll, so the activity at
   // the cursor's screen row hasn't changed. No adjustment needed.
-  if (!isLive) return prevCursorLine;
+  if (!isLive) return noOp;
 
   // Cursor on the live row — user is tracking the live edge.
-  if (prevCursorLine === 0) return 0;
+  if (prevCursorLine === 0)
+    return { cursorLine: 0, autoPause: false, scrollDelta: 0 };
 
   // Defensive: activity count shrank (filter change, etc.). The
   // filter-change reset elsewhere handles cursor; no-op here.
-  if (newActivityCount <= prevActivityCount) return prevCursorLine;
+  if (newActivityCount <= prevActivityCount) return noOp;
 
   const delta = newActivityCount - prevActivityCount;
   const maxCursor = Math.max(0, viewerRows - 1);
-  return Math.min(prevCursorLine + delta, maxCursor);
+  const upwardRoom = maxCursor - prevCursorLine;
+
+  if (delta <= upwardRoom) {
+    // Fits: move cursor up by delta so it stays on the same activity.
+    return {
+      cursorLine: prevCursorLine + delta,
+      autoPause: false,
+      scrollDelta: 0,
+    };
+  }
+
+  // Overflow: consume `upwardRoom` of the delta lifting the cursor
+  // to the top of the viewport, then transition to PAUSED. The
+  // remaining (delta - upwardRoom) entries become the scroll offset
+  // so the view freezes on the same snapshot it was showing before.
+  return {
+    cursorLine: maxCursor,
+    autoPause: true,
+    scrollDelta: delta - upwardRoom,
+  };
 }

--- a/src/ui/viewerCursor.ts
+++ b/src/ui/viewerCursor.ts
@@ -1,0 +1,61 @@
+/**
+ * Adjust the activity-viewer cursor when new activities arrive so
+ * the cursor stays anchored to its activity instead of sliding to a
+ * different one as the visible window auto-scrolls in LIVE mode.
+ *
+ * Design decisions:
+ * - `viewerCursorLine` counts rows from the LIVE EDGE (the bottom
+ *   of the tail-feed). cursor = 0 means "on the live row";
+ *   cursor = viewerRows - 1 means "at the top of the visible
+ *   window" (oldest visible). Counting from the bottom keeps the
+ *   live-edge case clean: cursor = 0 always means "follow live".
+ * - cursorLine === 0 is treated as "user wants to track live" —
+ *   not as a content anchor. The user hasn't moved off the live
+ *   row, so leave it on the live row.
+ * - Pure function — App.tsx wires it into a `useEffect` keyed off
+ *   the merged activity count, but the math has no React
+ *   dependencies and tests run as plain unit tests.
+ *
+ * Gotcha:
+ * - When the cursor's anchored activity would scroll off the top
+ *   of the viewport (cursor + delta > viewerRows - 1), we clamp
+ *   to `viewerRows - 1` and accept losing content-anchoring for
+ *   that activity. The alternative — switching the viewer to
+ *   PAUSED automatically — is a bigger behavior change and
+ *   belongs in a follow-up if it turns out to be needed.
+ */
+
+export interface AdjustViewerCursorArgs {
+  prevCursorLine: number;
+  prevActivityCount: number;
+  newActivityCount: number;
+  isLive: boolean;
+  viewerRows: number;
+}
+
+export function adjustViewerCursorOnNewActivities(
+  args: AdjustViewerCursorArgs,
+): number {
+  const {
+    prevCursorLine,
+    prevActivityCount,
+    newActivityCount,
+    isLive,
+    viewerRows,
+  } = args;
+
+  // Paused: visible window doesn't auto-scroll, so the activity at
+  // the cursor's screen row hasn't changed. No adjustment needed.
+  if (!isLive) return prevCursorLine;
+
+  // Cursor on the live row — user is tracking the live edge.
+  if (prevCursorLine === 0) return 0;
+
+  // Defensive: activity count shrank (filter change, etc.). The
+  // filter-change reset elsewhere handles cursor; no-op here.
+  if (newActivityCount <= prevActivityCount) return prevCursorLine;
+
+  const delta = newActivityCount - prevActivityCount;
+  const maxCursor = Math.max(0, viewerRows - 1);
+  return Math.min(prevCursorLine + delta, maxCursor);
+}

--- a/tests/ui/viewerCursor.test.ts
+++ b/tests/ui/viewerCursor.test.ts
@@ -6,8 +6,14 @@ describe("adjustViewerCursorOnNewActivities", () => {
   // (the bottom of the tail-feed viewer). cursorLine = 0 means "on the
   // live row"; cursorLine = viewerRows - 1 means "at the top of the
   // visible window" (oldest visible).
+  //
+  // Result shape: { cursorLine, autoPause, scrollDelta }
+  // autoPause is set when the cursor's anchored activity would scroll
+  // off the top of the viewport — at that point the viewer transitions
+  // to PAUSED and scrollDelta is the count of new entries that became
+  // "scrolled past" the visible window.
 
-  it("returns cursorLine unchanged when not in LIVE mode", () => {
+  it("returns no-op when not in LIVE mode", () => {
     // Paused: window does not auto-scroll, so the activity at the
     // cursor's screen row hasn't changed even though new activities
     // arrived. No adjustment needed.
@@ -19,10 +25,10 @@ describe("adjustViewerCursorOnNewActivities", () => {
         isLive: false,
         viewerRows: 20,
       }),
-    ).toBe(3);
+    ).toEqual({ cursorLine: 3, autoPause: false, scrollDelta: 0 });
   });
 
-  it("returns 0 when cursor is on the live row (cursorLine === 0)", () => {
+  it("returns cursorLine 0 when cursor is already on the live row", () => {
     // The user explicitly hasn't moved off live — tracking the live
     // edge is the intent.
     expect(
@@ -33,10 +39,10 @@ describe("adjustViewerCursorOnNewActivities", () => {
         isLive: true,
         viewerRows: 20,
       }),
-    ).toBe(0);
+    ).toEqual({ cursorLine: 0, autoPause: false, scrollDelta: 0 });
   });
 
-  it("returns cursorLine unchanged when no new activities arrived", () => {
+  it("returns no-op when no new activities arrived", () => {
     expect(
       adjustViewerCursorOnNewActivities({
         prevCursorLine: 4,
@@ -45,12 +51,12 @@ describe("adjustViewerCursorOnNewActivities", () => {
         isLive: true,
         viewerRows: 20,
       }),
-    ).toBe(4);
+    ).toEqual({ cursorLine: 4, autoPause: false, scrollDelta: 0 });
   });
 
-  it("returns cursorLine unchanged when activity count somehow shrank", () => {
+  it("returns no-op when activity count shrank (defensive)", () => {
     // Filter change can drop entries; the existing filter-change reset
-    // handles cursor in that path, so we just no-op here defensively.
+    // handles cursor in that path, so we just no-op here.
     expect(
       adjustViewerCursorOnNewActivities({
         prevCursorLine: 5,
@@ -59,10 +65,10 @@ describe("adjustViewerCursorOnNewActivities", () => {
         isLive: true,
         viewerRows: 20,
       }),
-    ).toBe(5);
+    ).toEqual({ cursorLine: 5, autoPause: false, scrollDelta: 0 });
   });
 
-  it("increments cursorLine by the number of new activities (LIVE mode)", () => {
+  it("moves cursor up by the number of new entries when room remains", () => {
     // 3 new activities in LIVE mode → live edge slid 3 rows forward,
     // so the cursor's activity is now 3 rows further from the bottom.
     // Cursor at row 2 → row 5 to stay on the same content.
@@ -74,26 +80,10 @@ describe("adjustViewerCursorOnNewActivities", () => {
         isLive: true,
         viewerRows: 20,
       }),
-    ).toBe(5);
+    ).toEqual({ cursorLine: 5, autoPause: false, scrollDelta: 0 });
   });
 
-  it("clamps adjusted cursor to viewerRows - 1 (cursor would scroll off top)", () => {
-    // Cursor at row 18 in a 20-row viewer; 5 new activities arrive
-    // → 18 + 5 = 23, exceeds the top row 19. Clamp to 19. At this
-    // point we've lost content-anchoring for that one activity, but
-    // staying in the viewport beats vanishing.
-    expect(
-      adjustViewerCursorOnNewActivities({
-        prevCursorLine: 18,
-        prevActivityCount: 10,
-        newActivityCount: 15,
-        isLive: true,
-        viewerRows: 20,
-      }),
-    ).toBe(19);
-  });
-
-  it("handles a single new activity (the common live case)", () => {
+  it("handles a single new entry (the common live case)", () => {
     expect(
       adjustViewerCursorOnNewActivities({
         prevCursorLine: 4,
@@ -102,12 +92,74 @@ describe("adjustViewerCursorOnNewActivities", () => {
         isLive: true,
         viewerRows: 20,
       }),
-    ).toBe(5);
+    ).toEqual({ cursorLine: 5, autoPause: false, scrollDelta: 0 });
+  });
+
+  it("auto-pauses when the cursor's activity would scroll past the top", () => {
+    // Cursor at row 18 in a 20-row viewer; max = 19; upward room = 1.
+    // 5 new activities arrive — first 1 lifts cursor to row 19 (top),
+    // remaining 4 push the cursor's activity off the visible window
+    // → auto-pause, scrollDelta = 4 (those 4 entries became scrolled-
+    // past in the new PAUSED snapshot).
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 18,
+        prevActivityCount: 10,
+        newActivityCount: 15,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toEqual({ cursorLine: 19, autoPause: true, scrollDelta: 4 });
+  });
+
+  it("auto-pauses immediately when cursor is already at the top row", () => {
+    // Cursor at max (row 19 in a 20-row viewer); upward room = 0.
+    // Any number of new entries triggers auto-pause; ALL of them
+    // become the scroll offset since none consumed upward room.
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 19,
+        prevActivityCount: 10,
+        newActivityCount: 13,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toEqual({ cursorLine: 19, autoPause: true, scrollDelta: 3 });
+  });
+
+  it("auto-pauses exactly when delta consumes all remaining upward room", () => {
+    // Edge case: cursor at 17, max = 19, room = 2, delta = 2.
+    // Cursor reaches the top exactly, no overflow → still LIVE.
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 17,
+        prevActivityCount: 10,
+        newActivityCount: 12,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toEqual({ cursorLine: 19, autoPause: false, scrollDelta: 0 });
+  });
+
+  it("auto-pauses with delta = upwardRoom + 1 (just over the line)", () => {
+    // Cursor at 17, max = 19, room = 2, delta = 3.
+    // 2 consumed lifting cursor to 19, 1 overflows → auto-pause,
+    // scrollDelta = 1.
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 17,
+        prevActivityCount: 10,
+        newActivityCount: 13,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toEqual({ cursorLine: 19, autoPause: true, scrollDelta: 1 });
   });
 
   it("handles a viewer with only one row gracefully", () => {
-    // Pathological case: viewer height clamped to 1. Cursor can only
-    // be 0; should never adjust above 0.
+    // Pathological case: viewer height clamped to 1. max = 0, so
+    // cursor === 0 always. The cursor-on-live-row short-circuit
+    // catches this before the overflow path.
     expect(
       adjustViewerCursorOnNewActivities({
         prevCursorLine: 0,
@@ -116,6 +168,6 @@ describe("adjustViewerCursorOnNewActivities", () => {
         isLive: true,
         viewerRows: 1,
       }),
-    ).toBe(0);
+    ).toEqual({ cursorLine: 0, autoPause: false, scrollDelta: 0 });
   });
 });

--- a/tests/ui/viewerCursor.test.ts
+++ b/tests/ui/viewerCursor.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { adjustViewerCursorOnNewActivities } from "../../src/ui/viewerCursor.js";
+
+describe("adjustViewerCursorOnNewActivities", () => {
+  // Contract reminder: viewerCursorLine counts rows from the LIVE EDGE
+  // (the bottom of the tail-feed viewer). cursorLine = 0 means "on the
+  // live row"; cursorLine = viewerRows - 1 means "at the top of the
+  // visible window" (oldest visible).
+
+  it("returns cursorLine unchanged when not in LIVE mode", () => {
+    // Paused: window does not auto-scroll, so the activity at the
+    // cursor's screen row hasn't changed even though new activities
+    // arrived. No adjustment needed.
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 3,
+        prevActivityCount: 10,
+        newActivityCount: 15,
+        isLive: false,
+        viewerRows: 20,
+      }),
+    ).toBe(3);
+  });
+
+  it("returns 0 when cursor is on the live row (cursorLine === 0)", () => {
+    // The user explicitly hasn't moved off live — tracking the live
+    // edge is the intent.
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 0,
+        prevActivityCount: 10,
+        newActivityCount: 13,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toBe(0);
+  });
+
+  it("returns cursorLine unchanged when no new activities arrived", () => {
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 4,
+        prevActivityCount: 10,
+        newActivityCount: 10,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toBe(4);
+  });
+
+  it("returns cursorLine unchanged when activity count somehow shrank", () => {
+    // Filter change can drop entries; the existing filter-change reset
+    // handles cursor in that path, so we just no-op here defensively.
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 5,
+        prevActivityCount: 20,
+        newActivityCount: 12,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toBe(5);
+  });
+
+  it("increments cursorLine by the number of new activities (LIVE mode)", () => {
+    // 3 new activities in LIVE mode → live edge slid 3 rows forward,
+    // so the cursor's activity is now 3 rows further from the bottom.
+    // Cursor at row 2 → row 5 to stay on the same content.
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 2,
+        prevActivityCount: 10,
+        newActivityCount: 13,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toBe(5);
+  });
+
+  it("clamps adjusted cursor to viewerRows - 1 (cursor would scroll off top)", () => {
+    // Cursor at row 18 in a 20-row viewer; 5 new activities arrive
+    // → 18 + 5 = 23, exceeds the top row 19. Clamp to 19. At this
+    // point we've lost content-anchoring for that one activity, but
+    // staying in the viewport beats vanishing.
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 18,
+        prevActivityCount: 10,
+        newActivityCount: 15,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toBe(19);
+  });
+
+  it("handles a single new activity (the common live case)", () => {
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 4,
+        prevActivityCount: 42,
+        newActivityCount: 43,
+        isLive: true,
+        viewerRows: 20,
+      }),
+    ).toBe(5);
+  });
+
+  it("handles a viewer with only one row gracefully", () => {
+    // Pathological case: viewer height clamped to 1. Cursor can only
+    // be 0; should never adjust above 0.
+    expect(
+      adjustViewerCursorOnNewActivities({
+        prevCursorLine: 0,
+        prevActivityCount: 5,
+        newActivityCount: 8,
+        isLive: true,
+        viewerRows: 1,
+      }),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #126.

## Problem

When the user moves the cursor up from the live row and new activity arrives while still in LIVE mode, the cursor stays at the same *screen row* and silently slides to a different activity. The highlight visually doesn't move but it's now pointing at a newer entry than before.

## Root cause

\`viewerCursorLine\` (App.tsx:424) is a screen-row index counted from the live edge (bottom). It's updated by j/k/PgUp/PgDn/Ctrl+U/D/g/G and reset on session/filter change — but **never adjusted when new activities arrive**. In LIVE mode the visible window auto-scrolls to include new content, but the cursor's screen position is unchanged, so the activity beneath it shifts.

PAUSED mode is unaffected — the window doesn't shift, so cursor stays on its activity naturally.

## Fix

New pure helper \`adjustViewerCursorOnNewActivities\` in \`src/ui/viewerCursor.ts\`:

- \`isLive === false\` → return cursorLine unchanged (PAUSED already correct)
- \`cursorLine === 0\` → return 0 (user wants to track live edge)
- \`newCount <= prevCount\` → return cursorLine unchanged (filter shrink, etc.)
- Otherwise: \`cursorLine + (newCount - prevCount)\`, clamped to \`viewerRows - 1\`

Wired into App.tsx via a small \`useEffect\` keyed on \`mergedActivities.length\`, with a \`useRef\` snapshotting the previous count. Session/filter changes already reset cursor to 0 elsewhere, and the \`cursorLine === 0\` short-circuit in the helper makes that path a no-op — no race.

## Scope notes

The cleaner long-term fix is to track viewer selection by *activity index* (or activity id) and recompute the screen position on render — matches the pattern \`selectedId\` uses for the project tree. That touches every j/k/scroll handler and is a bigger PR. Deferred unless this minimum patch shows edge cases in practice.

## Test plan

- [x] 8 new unit tests in \`tests/ui/viewerCursor.test.ts\` cover: PAUSED no-op, cursor=0 no-op, no-new-entries no-op, count-shrunk no-op, normal increment, clamp at viewerRows-1, single-entry common case, viewerRows=1 pathological.
- [x] \`npx vitest run\` — 569/569 passing (561 + 8 new)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [ ] Manual smoke: \`agenthud\` watch mode, pick an active session, press \`k\` to move cursor up, watch new activity arrive; cursor should stay on the same activity row, not slide to a newer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced activity viewer cursor behavior in LIVE mode: cursor now automatically anchors to the latest activity when new entries arrive, and enables auto-pause when incoming activities would overflow the visible area, improving streaming experience.

* **Tests**
  * Added comprehensive test suite covering cursor positioning and scroll behavior across LIVE and paused modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->