### PR TITLE
feat(detail): surface Bash stdout/stderr in TUI detail view

### DIFF
--- a/src/data/toolDetails.ts
+++ b/src/data/toolDetails.ts
@@ -12,21 +12,25 @@
  *   we render specially?"
  * - `detailBody` is opt-in per tool: Edit gives a unified diff,
  *   Write gives the written content, Read gives line-numbered
- *   content, Task gives the subagent's returned text. Bash and
- *   everything else return null so the TUI just shows the
- *   one-liner.
+ *   content, Task gives the subagent's returned text, Bash gives
+ *   stdout / stderr / `[interrupted]` marker. Everything else
+ *   returns null so the TUI just shows the one-liner.
  * - Task's body is intentionally exposed to the markdown report
  *   (see `reportGenerator.ts:formatTaskBody`). Other tools'
  *   bodies stay TUI-only to keep LLM payload size bounded.
  *
- * Gotcha:
+ * Gotchas:
  * - Claude Code's JSONL stores tool results in a `toolUseResult`
  *   field with shape-per-tool. `Write` puts content on
  *   `result.content`, `Read` on `result.file.content`, `Task`
  *   also on `result.content`, `Edit` puts a structured patch on
- *   `result.structuredPatch`. Defensive null checks throughout
- *   because Claude Code's schema isn't versioned and this code
- *   runs against logs going back months.
+ *   `result.structuredPatch`, `Bash` uses `result.stdout` /
+ *   `result.stderr` / `result.interrupted`. Defensive null checks
+ *   throughout because Claude Code's schema isn't versioned and
+ *   this code runs against logs going back months.
+ * - Bash result has no `exitCode` field — verified by grepping
+ *   the user's actual session JSONL files. `interrupted` and
+ *   stderr presence are the only success/failure-ish signals.
  */
 
 import { basename } from "node:path";
@@ -60,6 +64,13 @@ export interface ToolUseResult {
   statusChange?: { from?: string; to?: string };
   updatedFields?: string[];
   taskId?: string;
+  // Bash result shape (verified from real session JSONL): stdout +
+  // stderr strings, `interrupted` flag for user-cancelled commands.
+  // No exitCode field is emitted by Claude Code for Bash — `interrupted`
+  // and stderr presence are the only success/failure-ish signals.
+  stdout?: string;
+  stderr?: string;
+  interrupted?: boolean;
 }
 
 function stripAnsi(text: string): string {
@@ -172,6 +183,30 @@ function numberLines(content: string, start: number): string {
     .join("\n");
 }
 
+/**
+ * Compose the Bash detail body from stdout / stderr / interrupted.
+ * Returns null when there's nothing to show. Sections are separated
+ * by a blank line; the `--- stderr ---` divider sits tight against
+ * the stderr block (no blank line between divider and content) and
+ * only appears when stdout is non-empty (otherwise stderr stands on
+ * its own). `[interrupted]` marker tags user-cancelled commands so
+ * they don't look like silent successes.
+ */
+function formatBashBody(
+  stdout: string | undefined,
+  stderr: string | undefined,
+  interrupted: boolean | undefined,
+): string | null {
+  const out = stdout?.replace(/\n+$/, "");
+  const err = stderr?.replace(/\n+$/, "");
+  const sections: string[] = [];
+  if (out) sections.push(out);
+  if (err) sections.push(out ? `--- stderr ---\n${err}` : err);
+  if (interrupted) sections.push("[interrupted]");
+  if (sections.length === 0) return null;
+  return sections.join("\n\n");
+}
+
 export function buildToolDetailBody(
   name: string,
   input: ToolInput | undefined,
@@ -189,6 +224,20 @@ export function buildToolDetailBody(
   if (name === "Task") {
     const content = result?.content;
     if (content) return { text: content, kind: "code" };
+  }
+  // Bash: stdout + stderr + interrupted marker. TUI-only — the body
+  // never flows into the markdown report path (see reportGenerator's
+  // formatTaskBody which is the only one that unrolls a body inline).
+  // Bash output is high-volume and noisy; the row's one-line command
+  // label is enough for the LLM summary, and the full output is one
+  // `↵` keystroke away in the TUI for the user.
+  if (name === "Bash") {
+    const text = formatBashBody(
+      result?.stdout,
+      result?.stderr,
+      result?.interrupted,
+    );
+    if (text) return { text, kind: "code" };
   }
   if (name === "Read") {
     const content = result?.file?.content;

--- a/tests/data/toolDetails.test.ts
+++ b/tests/data/toolDetails.test.ts
@@ -313,4 +313,98 @@ describe("buildToolDetailBody", () => {
   it("Task: null when result has no content", () => {
     expect(buildToolDetailBody("Task", { description: "x" }, {})).toBeNull();
   });
+
+  it("Bash: stdout only, not interrupted → trims trailing newline", () => {
+    expect(
+      buildToolDetailBody(
+        "Bash",
+        { command: "ls" },
+        { stdout: "file1.ts\nfile2.ts\n", stderr: "", interrupted: false },
+      ),
+    ).toEqual({ text: "file1.ts\nfile2.ts", kind: "code" });
+  });
+
+  it("Bash: stderr only → just the stderr text", () => {
+    expect(
+      buildToolDetailBody(
+        "Bash",
+        { command: "cat missing" },
+        {
+          stdout: "",
+          stderr: "cat: missing: No such file or directory\n",
+          interrupted: false,
+        },
+      ),
+    ).toEqual({
+      text: "cat: missing: No such file or directory",
+      kind: "code",
+    });
+  });
+
+  it("Bash: stdout + stderr → stdout, blank, --- stderr ---, blank, stderr", () => {
+    expect(
+      buildToolDetailBody(
+        "Bash",
+        { command: "npm test" },
+        {
+          stdout: "PASS test1\nFAIL test2",
+          stderr: "warning: deprecation",
+          interrupted: false,
+        },
+      ),
+    ).toEqual({
+      text: "PASS test1\nFAIL test2\n\n--- stderr ---\nwarning: deprecation",
+      kind: "code",
+    });
+  });
+
+  it("Bash: interrupted appends [interrupted] marker after output", () => {
+    expect(
+      buildToolDetailBody(
+        "Bash",
+        { command: "long-running-thing" },
+        { stdout: "started...", stderr: "", interrupted: true },
+      ),
+    ).toEqual({ text: "started...\n\n[interrupted]", kind: "code" });
+  });
+
+  it("Bash: interrupted only, no output → just the [interrupted] marker", () => {
+    expect(
+      buildToolDetailBody(
+        "Bash",
+        { command: "sleep 100" },
+        { stdout: "", stderr: "", interrupted: true },
+      ),
+    ).toEqual({ text: "[interrupted]", kind: "code" });
+  });
+
+  it("Bash: null when result is missing", () => {
+    expect(
+      buildToolDetailBody("Bash", { command: "ls" }, undefined),
+    ).toBeNull();
+  });
+
+  it("Bash: null when all three fields are absent or empty", () => {
+    expect(buildToolDetailBody("Bash", { command: "ls" }, {})).toBeNull();
+    expect(
+      buildToolDetailBody(
+        "Bash",
+        { command: "ls" },
+        { stdout: "", stderr: "", interrupted: false },
+      ),
+    ).toBeNull();
+  });
+
+  it("Bash branch does not affect non-Bash tools (Edit unaffected)", () => {
+    // Sanity — adding the Bash branch shouldn't accidentally swallow
+    // results that happen to carry stdout-shaped fields for unrelated
+    // tools (defensive against future shape drift).
+    expect(
+      buildToolDetailBody(
+        "Edit",
+        { file_path: "/x/a.ts" },
+        { stdout: "should not be used" } as unknown as never,
+      ),
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #128.

## Summary

Pressing \`↵\` on a Bash row now shows the command's stdout, stderr, and an \`[interrupted]\` marker for user-cancelled commands. Previously \`buildToolDetailBody\` returned \`null\` for Bash and the detail view just echoed the one-line command label.

## Schema additions

\`ToolUseResult\` gains three optional fields verified from real session JSONL:

- \`stdout?: string\`
- \`stderr?: string\`
- \`interrupted?: boolean\`

**No \`exitCode\`** — Claude Code doesn't emit one for Bash (grepped every JSONL in \`~/.claude/projects/\`). So \`interrupted\` and stderr presence are the only success/failure-ish signals available.

## Format

\`formatBashBody\` composes the body from non-empty sections:

\`\`\`
<stdout>

--- stderr ---
<stderr>

[interrupted]
\`\`\`

- \`--- stderr ---\` divider tight against the stderr block (no blank line between them).
- Divider only appears when stdout is non-empty too — pure-stderr commands stand alone.
- All-empty / missing result → \`null\` (no body shown, same as before).

## Scope

**In:** TUI detail view only.

**Out:** Markdown report path (the LLM summary pipeline). Bash output is high-volume and noisy — think \`npm test\`, \`find /\`. The one-line command label is enough for the LLM; the full output is one \`↵\` keystroke away in the TUI when the user actually wants it. Mirrors the same in/out split as Edit/Write/Read.

## Test plan

- [x] 8 new unit cases covering: stdout-only, stderr-only, both-with-divider, stdout+interrupted, interrupted-only, missing result, all-empty result, Edit-unaffected.
- [x] \`npx vitest run\` — 580/580 passing (572 + 8).
- [x] \`npx tsc --noEmit\` — clean.
- [x] \`npm run build\` — clean.
- [ ] Manual smoke: \`agenthud\` watch mode, pick a session with Bash activity, press \`↵\` on a Bash row, confirm stdout appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Bash tool result formatting with proper display of standard output and error streams
  * Added support for tracking interrupted command states
  * Improved output readability through automatic formatting and separator rendering between output sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->