### PR TITLE
docs(readme): split install into try / daily-use with bun alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,21 @@ AgentHUD reads Claude Code's session files from `~/.claude/projects/` and gives 
 
 → **See [FEATURES.md](./FEATURES.md) for the full surface** — every flag, keybinding, config key, file path, and env var.
 
-## Install
+Requires Node.js 20+. Open agenthud in a separate terminal while using Claude Code; press `?` inside the TUI for in-app help.
 
-Requires Node.js 20+.
+## Try without installing
 
 ```bash
 npx agenthud
+# or: bunx agenthud
 ```
 
-Run this in a separate terminal while using Claude Code. Press `?` inside the TUI any time for in-app help.
+## Install for daily use
+
+```bash
+npm i -g agenthud
+# or: bun i -g agenthud
+```
 
 > **Platform support.** Primary development is on macOS and Linux; the full test suite runs on all three platforms in CI (including Windows). Windows runtime behavior is exercised by a manual smoke job but isn't daily-driven — issues there are valued bug reports.
 


### PR DESCRIPTION
Replaces #134 with a cleaner structure.

## Before

Install section showed only \`npx agenthud\` while Quickstart used bare \`agenthud …\` — copy-paste failed for trial users.

## After

Two clearly-labeled install sections at H2 level, each showing both npm and bun:

\`\`\`
## Try without installing
    npx agenthud
    # or: bunx agenthud

## Install for daily use
    npm i -g agenthud
    # or: bun i -g agenthud
\`\`\`

- **Trial users** get a clear "this is fire-and-forget" path
- **Daily users** see the canonical install + matching alias-free CLI form
- **Bun users** are first-class — no \"check the docs / fork the README\" friction

Quickstart commands stay as bare \`agenthud …\` since they target the daily-use path; trial users have the \`npx\` prefix idiom in front of them in the first install section.

Also rewords the prerequisite line so \"agenthud\" replaces a dangling \"this\" — the original phrasing assumed a command was immediately above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)