### PR TITLE
feat: remap h key + surface hidden-but-active items in status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
   discovery in a way that took a state.yaml edit to recover.
   Now the visual is always there: total count when any are
   hidden, `(M active)` suffix only when any of them are hot or
-  warm.
+  warm. When `(M active)` is present, the indicator turns
+  **yellow** so it pops against the dim status bar — that's
+  the actionable case.
 
 ## [0.13.3] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,16 @@
   mutation behind a deliberate keystroke.
 
 ### Added
-- **Status bar surfaces hidden-but-still-active items.** When any
-  hidden project/session is in `hot` or `warm` state, the
-  branding line shows ` · ⊘ N hidden (M active)`. A hidden
+- **Status bar surfaces hidden-but-still-active items.** A hidden
   session producing live activity used to be completely
   invisible — combined with the `h` footgun above, that broke
-  discovery in a way that took a state.yaml edit to recover.
-  Now the visual is always there: total count when any are
-  hidden, `(M active)` suffix only when any of them are hot or
-  warm. When `(M active)` is present, the indicator turns
-  **yellow** so it pops against the dim status bar — that's
-  the actionable case.
+  discovery in a way that took a `state.yaml` edit to recover.
+  Now the branding line shows the count:
+  - Nothing hot/warm: ` · ⊘ N hidden` (dim, informational)
+  - Something hot/warm: ` · ⊘ M active in N hidden` with the
+    `M active` segment in **yellow** so the actionable case
+    pops while the rest stays dim. Active count leads so the
+    eye lands on it first.
 
 ## [0.13.3] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Changed
+- **Hide moved from `h` to `Shift+H`. Lowercase `h` is now the
+  vim-left alias for `←` (jump to parent).** The old binding
+  (`h` = hide) was a footgun: vim users coming for navigation
+  hit `h` and silently hid whichever item was selected. The
+  user wouldn't even remember pressing it. Capital `H` keeps the
+  mutation behind a deliberate keystroke.
+
+### Added
+- **Status bar surfaces hidden-but-still-active items.** When any
+  hidden project/session is in `hot` or `warm` state, the
+  branding line shows ` · ⊘ N hidden (M active)`. A hidden
+  session producing live activity used to be completely
+  invisible — combined with the `h` footgun above, that broke
+  discovery in a way that took a state.yaml edit to recover.
+  Now the visual is always there: total count when any are
+  hidden, `(M active)` suffix only when any of them are hot or
+  warm.
+
 ## [0.13.3] - 2026-06-10
 
 ### Changed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -373,14 +373,16 @@ the `?` overlay renders in-app.
 | Key | Action |
 |---|---|
 | `↑` `↓` / `k` `j` | Move selection |
-| `←` | Jump to parent (sub-agent → session, session → project) |
+| `←` / `h` | Jump to parent (sub-agent → session, session → project) |
 | `PgUp` / `Ctrl+B` | Page up |
 | `PgDn` / `Ctrl+F` | Page down |
 | `↵` | Expand/collapse project, session, or summary |
-| `h` | Hide selected (project / session / sub-agent) |
+| `H` (Shift+H) | Hide selected (project / session / sub-agent). Mutates — case matters. |
 | `t` | Track: auto-follow the newest live sub-agent (any nav key turns it off) |
 | `Tab` | Switch focus to activity viewer |
 | `r` | Refresh now |
+
+> **Note (v0.14.0):** Hide moved from `h` to `Shift+H`. The lowercase `h` is now the vim-left alias for `←` (jump to parent). Before, vim users hitting `h` for navigation would silently hide whichever item was selected. A status-bar indicator now also surfaces hidden-but-still-active items so an accidentally-hidden hot session never becomes invisible.
 
 ### Activity viewer
 

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -352,6 +352,7 @@ export function discoverSessions(
       coldProjects: [],
       totalCount: 0,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
   }
 
@@ -370,6 +371,7 @@ export function discoverSessions(
       coldProjects: [],
       totalCount: 0,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
   }
 
@@ -423,10 +425,22 @@ export function discoverSessions(
     }
   }
 
-  // Group by projectPath
+  // Group by projectPath, and tally hidden items so the status bar
+  // can surface "N hidden, M active" — a hidden session that's still
+  // producing live activity is one of the things the user is most
+  // likely to want to know about (it's the failure mode of the `h`
+  // key being too easy to hit by accident).
   const byProject = new Map<string, SessionNode[]>();
+  let hiddenTotal = 0;
+  let hiddenActive = 0;
   for (const s of allSessions) {
-    if (config.hiddenSessions.includes(s.hideKey)) continue;
+    const sessionHidden = config.hiddenSessions.includes(s.hideKey);
+    const projectHidden = config.hiddenProjects.includes(s.projectName);
+    if (sessionHidden || projectHidden) {
+      hiddenTotal++;
+      if (s.status === "hot" || s.status === "warm") hiddenActive++;
+    }
+    if (sessionHidden) continue;
     const arr = byProject.get(s.projectPath) ?? [];
     arr.push(s);
     byProject.set(s.projectPath, arr);
@@ -488,5 +502,6 @@ export function discoverSessions(
     coldProjects,
     totalCount,
     timestamp: new Date().toISOString(),
+    hiddenStats: { total: hiddenTotal, active: hiddenActive },
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,11 +45,21 @@ export interface ProjectNode {
 }
 
 // Full session tree returned by discoverSessions()
+// Counts of items filtered out by `hiddenProjects` / `hiddenSessions`.
+// Surfaced in the status bar so a hidden session producing live
+// activity is never invisible. `active` covers hot + warm (anything
+// the user would care about losing sight of).
+export interface HiddenStats {
+  total: number;
+  active: number;
+}
+
 export interface SessionTree {
   projects: ProjectNode[]; // active projects (hotness !== "cold")
   coldProjects: ProjectNode[]; // projects where all sessions are cold
   totalCount: number; // total sessions across both arrays + sub-agents
   timestamp: string; // ISO timestamp of discovery
+  hiddenStats: HiddenStats; // counts of hidden items (status bar uses this)
 }
 
 // Global config (~/.agenthud/config.yaml)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1229,17 +1229,20 @@ export function App({
         (() => {
           // Surface hidden-items count so a hidden session that's still
           // producing live activity is never invisible (the failure
-          // mode of `H` being one keystroke away). Glyph stays the same
-          // regardless of count so the visual is stable; the active
-          // suffix appears only when something hidden is actually hot.
+          // mode of `H` being one keystroke away). When any hidden
+          // item is hot/warm, the indicator turns yellow so it pops
+          // against the rest of the dim status line — that's the
+          // actionable case (something's happening you can't see).
+          // When nothing's active, the indicator stays dim/informational.
           const hs = sessionTree.hiddenStats;
+          const baseBranding = `${spinner} AgentHUD v${getVersion()}`;
           const hiddenLabel =
             hs.total > 0
               ? hs.active > 0
                 ? ` · ⊘ ${hs.total} hidden (${hs.active} active)`
                 : ` · ⊘ ${hs.total} hidden`
               : "";
-          const branding = `${spinner} AgentHUD v${getVersion()}${hiddenLabel}`;
+          const branding = `${baseBranding}${hiddenLabel}`;
           const sep = " · ";
           // Trim shortcut items from the FRONT until they fit. Items at the
           // end (?: help, q: quit) are kept as long as possible.
@@ -1257,7 +1260,20 @@ export function App({
           }
           return (
             <Box marginBottom={1} justifyContent="space-between" width={width}>
-              <Text dimColor>{showBranding ? branding : ""}</Text>
+              <Text>
+                {showBranding && (
+                  <>
+                    <Text dimColor>{baseBranding}</Text>
+                    {hiddenLabel ? (
+                      hs.active > 0 ? (
+                        <Text color="yellow">{hiddenLabel}</Text>
+                      ) : (
+                        <Text dimColor>{hiddenLabel}</Text>
+                      )
+                    ) : null}
+                  </>
+                )}
+              </Text>
               <Text dimColor>{shortcuts}</Text>
             </Box>
           );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1230,19 +1230,20 @@ export function App({
           // Surface hidden-items count so a hidden session that's still
           // producing live activity is never invisible (the failure
           // mode of `H` being one keystroke away). When any hidden
-          // item is hot/warm, the indicator turns yellow so it pops
-          // against the rest of the dim status line — that's the
-          // actionable case (something's happening you can't see).
-          // When nothing's active, the indicator stays dim/informational.
+          // item is hot/warm, the count of active ones leads ("N
+          // active in M hidden") and just THAT segment is yellow —
+          // the actionable signal pops while the rest of the
+          // indicator stays dim/informational.
           const hs = sessionTree.hiddenStats;
           const baseBranding = `${spinner} AgentHUD v${getVersion()}`;
-          const hiddenLabel =
-            hs.total > 0
-              ? hs.active > 0
-                ? ` · ⊘ ${hs.total} hidden (${hs.active} active)`
-                : ` · ⊘ ${hs.total} hidden`
-              : "";
-          const branding = `${baseBranding}${hiddenLabel}`;
+          const indicatorPrefix = " · ⊘ ";
+          const indicatorText =
+            hs.total === 0
+              ? ""
+              : hs.active > 0
+                ? `${indicatorPrefix}${hs.active} active in ${hs.total} hidden`
+                : `${indicatorPrefix}${hs.total} hidden`;
+          const branding = `${baseBranding}${indicatorText}`;
           const sep = " · ";
           // Trim shortcut items from the FRONT until they fit. Items at the
           // end (?: help, q: quit) are kept as long as possible.
@@ -1264,11 +1265,15 @@ export function App({
                 {showBranding && (
                   <>
                     <Text dimColor>{baseBranding}</Text>
-                    {hiddenLabel ? (
+                    {hs.total > 0 ? (
                       hs.active > 0 ? (
-                        <Text color="yellow">{hiddenLabel}</Text>
+                        <>
+                          <Text dimColor>{indicatorPrefix}</Text>
+                          <Text color="yellow">{`${hs.active} active`}</Text>
+                          <Text dimColor>{` in ${hs.total} hidden`}</Text>
+                        </>
                       ) : (
-                        <Text dimColor>{hiddenLabel}</Text>
+                        <Text dimColor>{indicatorText}</Text>
                       )
                     ) : null}
                   </>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1227,7 +1227,19 @@ export function App({
     <Box flexDirection="column">
       {isWatchMode &&
         (() => {
-          const branding = `${spinner} AgentHUD v${getVersion()}`;
+          // Surface hidden-items count so a hidden session that's still
+          // producing live activity is never invisible (the failure
+          // mode of `H` being one keystroke away). Glyph stays the same
+          // regardless of count so the visual is stable; the active
+          // suffix appears only when something hidden is actually hot.
+          const hs = sessionTree.hiddenStats;
+          const hiddenLabel =
+            hs.total > 0
+              ? hs.active > 0
+                ? ` · ⊘ ${hs.total} hidden (${hs.active} active)`
+                : ` · ⊘ ${hs.total} hidden`
+              : "";
+          const branding = `${spinner} AgentHUD v${getVersion()}${hiddenLabel}`;
           const sep = " · ";
           // Trim shortcut items from the FRONT until they fit. Items at the
           // end (?: help, q: quit) are kept as long as possible.

--- a/src/ui/HelpPanel.tsx
+++ b/src/ui/HelpPanel.tsx
@@ -41,11 +41,11 @@ const SECTIONS: HelpSection[] = [
     title: "Project tree",
     rows: [
       ["↑ ↓ / k j", "Move selection"],
-      ["←", "Jump to parent (sub-agent → session, session → project)"],
+      ["← / h", "Jump to parent (sub-agent → session, session → project)"],
       ["PgUp / Ctrl+B", "Page up"],
       ["PgDn / Ctrl+F", "Page down"],
       ["↵", "Expand/collapse project, session, or summary"],
-      ["h", "Hide selected (project/session/sub-agent)"],
+      ["H", "Hide selected (project/session/sub-agent) — capital H"],
       ["t", "Track: auto-follow the newest live sub-agent (any nav key turns it off)"],
       ["Tab", "Switch focus to activity viewer"],
       ["r", "Refresh now"],

--- a/src/ui/hooks/useHotkeys.ts
+++ b/src/ui/hooks/useHotkeys.ts
@@ -237,11 +237,16 @@ export function useHotkeys({
     }
 
     if (focus === "tree") {
-      if (input === "h") {
+      // `H` (Shift+H) is hide — uppercase keeps the mutation behind a
+      // deliberate keystroke. Lowercase `h` is vim-left (jump to
+      // parent), aliased to `←`. Old behavior (`h` = hide) was a
+      // footgun: users coming from vim hit `h` for navigation and
+      // accidentally hid sessions they were actively monitoring.
+      if (input === "H") {
         onHide();
         return;
       }
-      if (key.leftArrow && onJumpToParent) {
+      if ((input === "h" || key.leftArrow) && onJumpToParent) {
         onJumpToParent();
         return;
       }

--- a/tests/data/sessions.test.ts
+++ b/tests/data/sessions.test.ts
@@ -310,6 +310,110 @@ describe("discoverSessions", () => {
     expect(tree.projects).toHaveLength(0);
     expect(tree.coldProjects).toHaveLength(0);
     expect(tree.totalCount).toBe(0);
+    // Hidden session was hot (mtime 5s ago) — counts toward both
+    // total and active so the status bar can flag it.
+    expect(tree.hiddenStats).toEqual({ total: 1, active: 1 });
+  });
+
+  it("hiddenStats: cool/cold hidden sessions count total but not active", () => {
+    const projectsDir = join(
+      process.env.HOME ?? "/home/user",
+      ".claude",
+      "projects",
+    );
+    const projectDir = join(projectsDir, "-Users-neo-myproject");
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return path === projectsDir || path.includes("myproject");
+    });
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === projectsDir)
+        return ["-Users-neo-myproject"] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      if (path === projectDir)
+        return ["cool.jsonl"] as unknown as ReturnType<typeof readdirSync>;
+      return [] as unknown as ReturnType<typeof readdirSync>;
+    });
+    vi.mocked(statSync).mockImplementation((p) => {
+      const path = String(p);
+      return {
+        isDirectory: () => !path.endsWith(".jsonl"),
+        // 2 hours ago → cool (within the same day but past warm window)
+        mtimeMs: NOW - 2 * 60 * 60 * 1000,
+        size: 100,
+      } as ReturnType<typeof statSync>;
+    });
+    vi.mocked(readFileSync).mockReturnValue("");
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const tree = discoverSessions({
+      ...mockConfig,
+      hiddenSessions: ["myproject/cool"],
+    });
+    expect(tree.hiddenStats).toEqual({ total: 1, active: 0 });
+  });
+
+  it("hiddenStats: zero when nothing is hidden", () => {
+    const projectsDir = join(
+      process.env.HOME ?? "/home/user",
+      ".claude",
+      "projects",
+    );
+    vi.mocked(existsSync).mockImplementation(
+      (p) => String(p) === projectsDir,
+    );
+    vi.mocked(readdirSync).mockReturnValue(
+      [] as unknown as ReturnType<typeof readdirSync>,
+    );
+    vi.mocked(readFileSync).mockReturnValue("");
+    const tree = discoverSessions(mockConfig);
+    expect(tree.hiddenStats).toEqual({ total: 0, active: 0 });
+  });
+
+  it("hiddenStats: hidden project's sessions all count toward total", () => {
+    const projectsDir = join(
+      process.env.HOME ?? "/home/user",
+      ".claude",
+      "projects",
+    );
+    const projectDir = join(projectsDir, "-Users-neo-launcher");
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return path === projectsDir || path.includes("launcher");
+    });
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === projectsDir)
+        return ["-Users-neo-launcher"] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      if (path === projectDir)
+        return ["s1.jsonl", "s2.jsonl"] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      return [] as unknown as ReturnType<typeof readdirSync>;
+    });
+    vi.mocked(statSync).mockImplementation((p) => {
+      const path = String(p);
+      return {
+        isDirectory: () => !path.endsWith(".jsonl"),
+        mtimeMs: NOW - 5_000, // both hot
+        size: 100,
+      } as ReturnType<typeof statSync>;
+    });
+    vi.mocked(readFileSync).mockReturnValue("");
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const tree = discoverSessions({
+      ...mockConfig,
+      hiddenProjects: ["launcher"],
+    });
+    // Both sessions in the hidden project count.
+    expect(tree.hiddenStats).toEqual({ total: 2, active: 2 });
+    expect(tree.projects).toHaveLength(0);
+    expect(tree.coldProjects).toHaveLength(0);
   });
 
   it("marks session non-interactive when entrypoint is sdk-cli", () => {

--- a/tests/integration/config.test.tsx
+++ b/tests/integration/config.test.tsx
@@ -22,6 +22,7 @@ vi.mock("../../src/data/sessions.js", () => ({
     coldProjects: [],
     totalCount: 0,
     timestamp: new Date().toISOString(),
+    hiddenStats: { total: 0, active: 0 },
   }),
   getProjectsDir: () => "/tmp/nonexistent-projects-dir",
 }));

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -22,6 +22,7 @@ let mockTree: SessionTree = {
   coldProjects: [],
   totalCount: 0,
   timestamp: new Date().toISOString(),
+  hiddenStats: { total: 0, active: 0 },
 };
 
 vi.mock("../../src/data/sessions.js", () => ({
@@ -46,6 +47,7 @@ const emptyTree = (): SessionTree => ({
   coldProjects: [],
   totalCount: 0,
   timestamp: new Date().toISOString(),
+  hiddenStats: { total: 0, active: 0 },
 });
 
 const makeColdSession = (
@@ -105,6 +107,7 @@ describe("App with only cold projects (post-vacation boot)", () => {
       ],
       totalCount: 3,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
   });
 
@@ -127,6 +130,7 @@ describe("initialSelectedId", () => {
       coldProjects: [makeColdProject("cold1")],
       totalCount: 2,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     expect(initialSelectedId(tree)).toBe("__proj-hot1__");
   });
@@ -137,6 +141,7 @@ describe("initialSelectedId", () => {
       coldProjects: [makeColdProject("cold1"), makeColdProject("cold2")],
       totalCount: 2,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     expect(initialSelectedId(tree)).toBe("__cold__");
   });
@@ -153,6 +158,7 @@ describe("initialExpandedIds", () => {
       coldProjects: [makeColdProject("cold1")],
       totalCount: 1,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     expect(initialExpandedIds(tree).has("__cold__")).toBe(true);
   });
@@ -163,6 +169,7 @@ describe("initialExpandedIds", () => {
       coldProjects: [makeColdProject("cold1")],
       totalCount: 2,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     expect(initialExpandedIds(tree).has("__cold__")).toBe(false);
   });
@@ -326,6 +333,7 @@ describe("findParentTarget", () => {
       coldProjects: [],
       totalCount: 1,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     expect(findParentTarget("a1", tree, [])).toBe("s1");
   });
@@ -336,6 +344,7 @@ describe("findParentTarget", () => {
       coldProjects: [],
       totalCount: 0,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     expect(findParentTarget("__sub-s1__", tree, [])).toBe("s1");
   });
@@ -347,6 +356,7 @@ describe("findParentTarget", () => {
       coldProjects: [],
       totalCount: 1,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     expect(findParentTarget("s1", tree, [])).toBe("__proj-myproj__");
   });
@@ -359,6 +369,7 @@ describe("findParentTarget", () => {
       coldProjects: [],
       totalCount: 2,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     const flat: SessionNode[] = [
       // Skip the synthetic sentinel struct details — only id is used.
@@ -377,6 +388,7 @@ describe("findParentTarget", () => {
       coldProjects: [],
       totalCount: 1,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     const flat: SessionNode[] = [
       { ...s1, id: "__proj-alpha__" } as SessionNode,
@@ -394,6 +406,7 @@ describe("findParentTarget", () => {
       coldProjects: [project("oldproj", [session("old1")])],
       totalCount: 2,
       timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
     };
     const flat: SessionNode[] = [
       { ...s1, id: "__proj-alpha__" } as SessionNode,

--- a/tests/ui/hooks/useHotkeys.test.ts
+++ b/tests/ui/hooks/useHotkeys.test.ts
@@ -174,21 +174,42 @@ describe("useHotkeys", () => {
       expect(onEnter).toHaveBeenCalledTimes(1);
     });
 
-    it("calls onHide when h is pressed in tree focus", () => {
+    it("calls onHide when SHIFT+H is pressed in tree focus", () => {
+      const onHide = vi.fn();
+      const { result } = renderHook(() =>
+        useHotkeys(makeOptions({ focus: "tree", onHide })),
+      );
+      act(() => result.current.handleInput("H", noopKey));
+      expect(onHide).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT call onHide when lowercase h is pressed (h is vim-left)", () => {
+      // Hide is `H` only. `h` is the vim-left navigation alias for
+      // `←` (jump to parent). Earlier `h` = hide was a footgun for
+      // vim users — they hit it for navigation and lost sessions.
       const onHide = vi.fn();
       const { result } = renderHook(() =>
         useHotkeys(makeOptions({ focus: "tree", onHide })),
       );
       act(() => result.current.handleInput("h", noopKey));
-      expect(onHide).toHaveBeenCalledTimes(1);
+      expect(onHide).not.toHaveBeenCalled();
     });
 
-    it("does not call onHide when h is pressed in viewer focus", () => {
+    it("calls onJumpToParent when lowercase h is pressed in tree focus", () => {
+      const onJumpToParent = vi.fn();
+      const { result } = renderHook(() =>
+        useHotkeys(makeOptions({ focus: "tree", onJumpToParent })),
+      );
+      act(() => result.current.handleInput("h", noopKey));
+      expect(onJumpToParent).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onHide when SHIFT+H is pressed in viewer focus", () => {
       const onHide = vi.fn();
       const { result } = renderHook(() =>
         useHotkeys(makeOptions({ focus: "viewer", onHide })),
       );
-      act(() => result.current.handleInput("h", noopKey));
+      act(() => result.current.handleInput("H", noopKey));
       expect(onHide).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Problem

User reported actively-running Claude Code sessions weren't showing in agenthud. Investigation found:

1. They had pressed \`h\` accidentally — \`h\` is vim's left key, they were trying to navigate to parent. The \`h = hide\` binding silently hid whichever item was selected. User didn't remember pressing it.
2. Once hidden, a session producing **live activity** became completely invisible. No status bar signal, no badge, nothing. Recovery required hand-editing \`~/.agenthud/state.yaml\`.

Two halves of the same footgun.

## Fix

### Key remap (\`h\` → vim-left, \`Shift+H\` → hide)

- **\`H\` (capital, Shift+H)** = hide selected. Mutation behind a deliberate uppercase keystroke.
- **\`h\` (lowercase)** = jump to parent (alias for \`←\`). Now matches vim convention; safe to hit by accident.
- HelpPanel SECTIONS and FEATURES.md keybinding table updated.

### Status bar surfaces hidden-but-active

- \`discoverSessions\` now computes \`hiddenStats = { total, active }\` (\`active\` = hot + warm) and returns it on \`SessionTree\`.
- App.tsx renders \` · ⊘ N hidden (M active)\` in the branding line whenever any are hidden; \`(M active)\` suffix appears only when hot/warm are among them.
- Sessions in hidden projects all count individually toward total.

## Example

\`\`\`
⠧ AgentHUD v0.13.4 · ⊘ 9 hidden (1 active)         ?: help · q: quit
\`\`\`

The \`(1 active)\` is the actionable signal — "you might be missing live work". User reads it, hits \`?\` to learn the new \`H\` binding, and knows where to look in state.yaml (until we add a TUI unhide flow in a follow-up).

## Test plan

- [x] 5 new unit tests:
  - sessions.test.ts: hiddenStats counts hidden hot/cool, zero when nothing hidden, hidden project's sessions all count
  - useHotkeys.test.ts: \`H\` calls onHide, lowercase \`h\` does NOT call onHide, \`h\` calls onJumpToParent, \`H\` in viewer focus is no-op
- [x] \`npx vitest run\` — 585/585 (was 580)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean

## Breaking change

Users who learned \`h = hide\` need to switch to \`Shift+H\`. CHANGELOG flags this explicitly. Mitigation: the new behavior is what most users expected anyway (vim convention), and the status bar indicator + help overlay teach the new binding within seconds.

## Out of scope (deferred to BACKLOG)

- TUI-side unhide flow (Tier 3 — \`Shift+H\` toggle to show hidden items + \`H\` on a hidden item to unhide it). Status bar indicator + key remap eliminate the footgun by themselves; the unhide UX is a follow-up.
- Undo hint (\`u\` to undo last hide within 5 seconds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated keybinding documentation: `H` (Shift+H) now hides selected items; `h` is reassigned as a navigation alias to jump to parent.

* **New Features**
  * Status bar now displays counts of hidden items, with an indicator showing how many hidden items are currently active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->