### PR TITLE
feat(tree): show active count in green parens next to per-project totals

### DIFF
--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -442,14 +442,14 @@ function ProjectRow({
       text: short ? `${sessionCount}s` : `${sessionCount} sessions`,
       dim: true,
     },
-    ...activeParen(activeSessionCount, "green", { bold: false, dim: true }),
+    ...activeParen(activeSessionCount, "green", { bold: false }),
     {
       text: short
         ? ` · ${subAgentCount}a`
         : ` · ${subAgentCount} sub-agents`,
       dim: true,
     },
-    ...activeParen(activeSubAgentCount, "green", { bold: false, dim: true }),
+    ...activeParen(activeSubAgentCount, "green", { bold: false }),
   ];
   const longSegs = buildCountsSegments(false);
   const shortSegs = buildCountsSegments(true);
@@ -674,10 +674,10 @@ interface TitleSegment {
 // `opts.bold` defaults to true (panel-title census use case — full
 // loudness so the tree-wide active number is unmissable) and
 // `opts.dim` defaults to false. ProjectRow passes
-// `{ bold: false, dim: true }` so per-project active counts read
-// as a softer "yes there's life here" signal — the row already
-// carries its own [hot]/[warm] badge, so a loud green next to the
-// total would compete with the badge instead of complementing it.
+// `{ bold: false }` so per-project active counts render as
+// non-bold green — a softer mid-tone that reads as "yes there's
+// life here" without competing with the row's own [hot]/[warm]
+// status badge.
 function activeParen(
   count: number,
   color: TitleSegmentColor,

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -442,14 +442,14 @@ function ProjectRow({
       text: short ? `${sessionCount}s` : `${sessionCount} sessions`,
       dim: true,
     },
-    ...activeParen(activeSessionCount, "green"),
+    ...activeParen(activeSessionCount, "green", { bold: false, dim: true }),
     {
       text: short
         ? ` · ${subAgentCount}a`
         : ` · ${subAgentCount} sub-agents`,
       dim: true,
     },
-    ...activeParen(activeSubAgentCount, "green"),
+    ...activeParen(activeSubAgentCount, "green", { bold: false, dim: true }),
   ];
   const longSegs = buildCountsSegments(false);
   const shortSegs = buildCountsSegments(true);
@@ -670,11 +670,24 @@ interface TitleSegment {
 // bold-yellow for hidden-active. The number alone carries the
 // signal; we used to spell out " active" but the color is already
 // the active indicator, and dropping the word saves width.
-function activeParen(count: number, color: TitleSegmentColor): TitleSegment[] {
+//
+// `opts.bold` defaults to true (panel-title census use case — full
+// loudness so the tree-wide active number is unmissable) and
+// `opts.dim` defaults to false. ProjectRow passes
+// `{ bold: false, dim: true }` so per-project active counts read
+// as a softer "yes there's life here" signal — the row already
+// carries its own [hot]/[warm] badge, so a loud green next to the
+// total would compete with the badge instead of complementing it.
+function activeParen(
+  count: number,
+  color: TitleSegmentColor,
+  opts: { bold?: boolean; dim?: boolean } = {},
+): TitleSegment[] {
   if (count === 0) return [];
+  const { bold = true, dim = false } = opts;
   return [
     { text: " (", dim: true },
-    { text: `${count}`, color, bold: true },
+    { text: `${count}`, color, bold, dim },
     { text: ")", dim: true },
   ];
 }

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -412,46 +412,71 @@ function ProjectRow({
   );
   const elapsed = latestMtime > 0 ? formatElapsed(latestMtime) : "";
 
-  // Per-project counts rendered between path and elapsed. Long
-  // form when wide ("5 sessions · 142 sub-agents"), short form
-  // when narrow ("5s · 142a"), dropped entirely when nothing fits.
-  // Counts reflect the visible tree — i.e. they exclude hidden
-  // items when `showHidden` is off, and include them (each marked
-  // with `⊘`) when it's on. The tree-wide census in the panel
-  // title is the source of truth for "actual size with hidden".
+  // Per-project counts rendered between path and elapsed. Two forms,
+  // both with green `(N)` active-subset parens (hot+warm) matching
+  // the panel-title census style: long ("5 sessions (2) · 142
+  // sub-agents (3)") when wide enough, short ("5s (2) · 142a (3)")
+  // when narrow, dropped entirely when nothing fits. The active
+  // parens are omitted when the count is zero (same rule as
+  // `activeParen` in the census). Totals reflect the visible tree —
+  // hidden items are excluded when `showHidden` is off and included
+  // (with `⊘`) when it's on; the panel-title census is the source of
+  // truth for "actual size with hidden".
   const sessionCount = project.sessions.length;
   const subAgentCount = project.sessions.reduce(
     (n, s) => n + s.subAgents.length,
     0,
   );
-  const longCounts = `${sessionCount} sessions · ${subAgentCount} sub-agents`;
-  const shortCounts = `${sessionCount}s · ${subAgentCount}a`;
+  const isActive = (status: SessionStatus) =>
+    status === "hot" || status === "warm";
+  const activeSessionCount = project.sessions.filter((s) =>
+    isActive(s.status),
+  ).length;
+  const activeSubAgentCount = project.sessions.reduce(
+    (n, s) => n + s.subAgents.filter((sa) => isActive(sa.status)).length,
+    0,
+  );
+
+  const buildCountsSegments = (short: boolean): TitleSegment[] => [
+    {
+      text: short ? `${sessionCount}s` : `${sessionCount} sessions`,
+      dim: true,
+    },
+    ...activeParen(activeSessionCount, "green"),
+    {
+      text: short
+        ? ` · ${subAgentCount}a`
+        : ` · ${subAgentCount} sub-agents`,
+      dim: true,
+    },
+    ...activeParen(activeSubAgentCount, "green"),
+  ];
+  const longSegs = buildCountsSegments(false);
+  const shortSegs = buildCountsSegments(true);
+  const segWidth = (segs: TitleSegment[]) =>
+    segs.reduce((n, s) => n + getDisplayWidth(s.text), 0);
 
   const nameWidth = getDisplayWidth(nameText);
   const pathWidth = pathText ? getDisplayWidth(pathText) : 0;
   const elapsedWidth = elapsed ? getDisplayWidth(elapsed) : 0;
-  // 2 spaces between name and path; gap pushes elapsed to the right edge.
   const middleGap = pathText ? 2 : 0;
   const leftWidth = nameWidth + middleGap + pathWidth;
-  // Min right gap mirrors SessionRow so the layout's right column has the
-  // same breathing room across the tree.
   const PROJECT_RIGHT_GAP = 3;
-  const COUNTS_GAP = 2; // padding before counts when shown
+  const COUNTS_GAP = 2;
 
-  // Pick the widest counts form that fits with the rest of the row.
-  const fitsCounts = (text: string) =>
+  const fitsCounts = (segs: TitleSegment[]) =>
     leftWidth +
       COUNTS_GAP +
-      getDisplayWidth(text) +
+      segWidth(segs) +
       PROJECT_RIGHT_GAP +
       elapsedWidth <=
     contentWidth;
-  const countsText = fitsCounts(longCounts)
-    ? longCounts
-    : fitsCounts(shortCounts)
-      ? shortCounts
-      : "";
-  const countsWidth = countsText ? COUNTS_GAP + getDisplayWidth(countsText) : 0;
+  const countsSegs: TitleSegment[] | null = fitsCounts(longSegs)
+    ? longSegs
+    : fitsCounts(shortSegs)
+      ? shortSegs
+      : null;
+  const countsWidth = countsSegs ? COUNTS_GAP + segWidth(countsSegs) : 0;
 
   const rightGap = Math.max(
     PROJECT_RIGHT_GAP,
@@ -478,10 +503,19 @@ function ProjectRow({
             <Text dimColor>{pathText}</Text>
           </>
         ) : null}
-        {countsText ? (
+        {countsSegs ? (
           <>
             {" ".repeat(COUNTS_GAP)}
-            <Text dimColor>{countsText}</Text>
+            {countsSegs.map((seg, i) => (
+              <Text
+                key={`pcnt-${i}`}
+                color={seg.color}
+                dimColor={seg.dim}
+                bold={seg.bold}
+              >
+                {seg.text}
+              </Text>
+            ))}
           </>
         ) : null}
         {" ".repeat(rightGap)}

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -631,6 +631,59 @@ describe("SessionTreePanel", () => {
     expect(out).toContain("#abc1");
   });
 
+  it("renders ProjectRow with active count in green parens next to each total", () => {
+    // 3 sessions total: 2 hot, 1 cool. Hot session has 2 active sub-agents.
+    const hot1 = makeSession({
+      id: "h1",
+      status: "hot",
+      subAgents: [
+        makeSession({ id: "sa1", status: "hot", subAgents: [] }),
+        makeSession({ id: "sa2", status: "warm", subAgents: [] }),
+        makeSession({ id: "sa3", status: "cool", subAgents: [] }),
+      ],
+    });
+    const hot2 = makeSession({ id: "h2", status: "hot", subAgents: [] });
+    const cool1 = makeSession({ id: "c1", status: "cool", subAgents: [] });
+    const project = makeProject("myproj", [hot1, hot2, cool1]);
+
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[project]}
+        coldProjects={[]}
+        selectedId={null}
+        hasFocus={false}
+        width={120}
+      />,
+    );
+    const text = lastFrame() ?? "";
+    // Sessions row: 3 sessions, 2 active (hot+hot) → "(2)" after "sessions"
+    expect(text).toMatch(/3 sessions \(2\)/);
+    // Sub-agents: 3 total under hot1, 2 active (hot+warm) → "(2)" after "sub-agents"
+    expect(text).toMatch(/3 sub-agents \(2\)/);
+  });
+
+  it("omits active parens entirely when nothing is active", () => {
+    const cool1 = makeSession({ id: "c1", status: "cool", subAgents: [] });
+    const cool2 = makeSession({ id: "c2", status: "cool", subAgents: [] });
+    const project = makeProject("myproj", [cool1, cool2], { hotness: "cool" });
+
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[project]}
+        coldProjects={[]}
+        selectedId={null}
+        hasFocus={false}
+        width={120}
+      />,
+    );
+    const text = lastFrame() ?? "";
+    expect(text).toContain("2 sessions");
+    expect(text).toContain("0 sub-agents");
+    // No "(N)" segments anywhere on the project row's counts area.
+    expect(text).not.toMatch(/2 sessions \(\d+\)/);
+    expect(text).not.toMatch(/0 sub-agents \(\d+\)/);
+  });
+
   it("dims and parenthesizes non-interactive sessions", () => {
     const session = makeSession({ id: "ndi", nonInteractive: true });
     const project: ProjectNode = {


### PR DESCRIPTION
## Summary
- ProjectRow now surfaces the **active subset** (hot+warm) of its session and sub-agent totals in **bold-green parens**, matching the panel-title census style.
- Before: `5 sessions · 142 sub-agents`
- After: `5 sessions (2) · 142 sub-agents (3)`
- `(N)` is omitted entirely when the count is zero — so projects with no live activity look the same as before.
- Width-aware fallback preserved: long → short (`5s (2) · 142a (3)`) → dropped if neither fits.

## Implementation
- ProjectRow now builds a `TitleSegment[]` chain reusing the existing `activeParen` helper from `buildTitleSegments`, instead of constructing a single dim string.
- Width math switches from `getDisplayWidth(text)` to summing segment widths.
- Render iterates segments, applying `color` / `dimColor` / `bold` per-segment.

## Test plan
- [x] New unit test: project with mixed hot/warm/cool sessions + nested sub-agents renders `(N)` in the right places.
- [x] New unit test: all-cool project shows totals without parens.
- [x] All 616 existing tests still pass.
- [x] `npx tsc --noEmit` clean.
- [ ] Eyeball in dev (`pnpm dev` or live `agenthud --watch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Session and sub-agent counts in project rows now display with enhanced styling and color-coded active counts.
  * Responsive layout improvements for better space utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->