### PR TITLE
feat(tree): dim project name when no session or sub-agent is active

### DIFF
--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -105,6 +105,26 @@ export function formatElapsed(
   return "<1s";
 }
 
+/**
+ * "Alive" = at least one session OR one sub-agent on the project is
+ * hot or warm. Drives ProjectRow's name styling — alive projects
+ * read as bold-white, inert ones (everything cool/cold) render dim
+ * so the eye lands on the rows that actually have running activity.
+ * Sub-agents count because a hot sub-agent under a cool parent still
+ * makes the project genuinely alive — it's where the work is.
+ */
+export function isProjectAlive(project: ProjectNode): boolean {
+  const isActive = (status: SessionStatus): boolean =>
+    status === "hot" || status === "warm";
+  for (const s of project.sessions) {
+    if (isActive(s.status)) return true;
+    for (const sa of s.subAgents) {
+      if (isActive(sa.status)) return true;
+    }
+  }
+  return false;
+}
+
 function getStatusColor(status: SessionStatus): string {
   switch (status) {
     case "hot":
@@ -487,13 +507,17 @@ function ProjectRow({
   const focused = isSelected && hasFocus;
   const muted = isSelected && !hasFocus;
   const showBg = focused || muted;
-  const dim = muted || !!project.hidden;
+  // Bold + bright name only when the project has live activity.
+  // Cool/cold-only projects render dim so the eye lands on rows
+  // where there's actually work in flight.
+  const alive = isProjectAlive(project);
+  const dim = muted || !!project.hidden || !alive;
   return (
     <Text>
       {BOX.v}{" "}
       <Text
         backgroundColor={showBg ? "blue" : undefined}
-        bold={!showBg && !project.hidden}
+        bold={!showBg && !project.hidden && alive}
         dimColor={dim}
       >
         {nameText}

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -8,6 +8,7 @@ import type {
 import {
   buildTitleSegments,
   getBadge,
+  isProjectAlive,
   SessionTreePanel,
 } from "../../src/ui/SessionTreePanel.js";
 
@@ -934,6 +935,42 @@ describe("SessionTreePanel", () => {
       />,
     );
     expect(lastFrame()).not.toMatch(/Projects \[/);
+  });
+});
+
+describe("isProjectAlive", () => {
+  it("returns true when any session is hot or warm", () => {
+    const p = makeProject("p", [
+      makeSession({ status: "cool" }),
+      makeSession({ status: "warm" }),
+    ]);
+    expect(isProjectAlive(p)).toBe(true);
+  });
+
+  it("returns true when an inactive parent has a hot sub-agent", () => {
+    const parent = makeSession({
+      status: "cool",
+      subAgents: [makeSession({ status: "hot" })],
+    });
+    const p = makeProject("p", [parent]);
+    expect(isProjectAlive(p)).toBe(true);
+  });
+
+  it("returns false when everything is cool or cold", () => {
+    const parent = makeSession({
+      status: "cool",
+      subAgents: [
+        makeSession({ status: "cool" }),
+        makeSession({ status: "cold" }),
+      ],
+    });
+    const p = makeProject("p", [parent, makeSession({ status: "cold" })]);
+    expect(isProjectAlive(p)).toBe(false);
+  });
+
+  it("returns false for an empty project", () => {
+    const p = makeProject("p", []);
+    expect(isProjectAlive(p)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
ProjectRow used to render every non-hidden project name as bold-white regardless of activity — so a tree full of cool/cold projects with one genuinely hot one all looked equally "alive" at a glance.

Now:
- Project with at least one hot/warm session OR sub-agent → bold bright name (previous default)
- Project with everything cool/cold → name renders **dim, non-bold**

Hidden projects still dim with `⊘`. Selection background still wins over both.

## Implementation
- New pure function `isProjectAlive(project)`: true when any session or sub-agent is hot/warm.
- ProjectRow uses it to compute `alive`, then `bold = ... && alive` and `dim = ... || !alive`.

## Test plan
- [x] 4 new unit tests on `isProjectAlive` cover: active session, active sub-agent under cool parent, all-cool, empty.
- [x] 620 existing tests pass.
- [x] `npx tsc --noEmit` clean.
- [ ] Eyeball in `agenthud --watch` — the live launcher/agenthud tree should now have cool projects dimmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects now display visual indicators of activity status. Inactive projects appear dimmed to help distinguish them from active ones, making it easier to identify which projects have live activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->