### PR TITLE
feat(data): Kiro IDE as a third session provider

### DIFF
--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -6,13 +6,13 @@ observed via `jq` against real corpora) and includes verification
 commands at the bottom so you can re-run them against your own
 sessions to catch anything we missed.
 
-| Provider     | Doc                                       | Source                                                |
-|--------------|-------------------------------------------|-------------------------------------------------------|
-| Claude Code  | [claude-session.md](./claude-session.md)  | `~/.claude/projects/{encoded-path}/{uuid}.jsonl`      |
-| Kiro CLI     | [kiro-session.md](./kiro-session.md)      | `~/.kiro/sessions/cli/{uuid}.{json,jsonl,history,lock}` |
+| Provider     | Doc                                             | Source                                                |
+|--------------|-------------------------------------------------|-------------------------------------------------------|
+| Claude Code  | [claude-session.md](./claude-session.md)        | `~/.claude/projects/{encoded-path}/{uuid}.jsonl`      |
+| Kiro CLI     | [kiro-session.md](./kiro-session.md)            | `~/.kiro/sessions/cli/{uuid}.{json,jsonl,history,lock}` |
+| Kiro IDE     | [kiro-ide-session.md](./kiro-ide-session.md)    | `<app-storage>/Kiro/User/globalStorage/kiro.kiroagent/workspace-sessions/` |
 
-Future docs (when those providers land): `kiro-ide-session.md`,
-`opencode-session.md`.
+Future docs (when those providers land): `opencode-session.md`.
 
 ## How to keep these in sync
 

--- a/docs/schemas/kiro-ide-session.md
+++ b/docs/schemas/kiro-ide-session.md
@@ -1,0 +1,209 @@
+# Kiro IDE Session Files — On-Disk Schema
+
+Empirical schema from a live Kiro IDE (VSCode fork) install on
+macOS, including a completed `invokeSubAgent` run. Verification
+commands at the bottom.
+
+## File layout
+
+```
+<storage-root>/                                  # see platform table
+└── User/globalStorage/kiro.kiroagent/
+    ├── workspace-sessions/
+    │   └── <base64-of-workspace-path>/
+    │       ├── sessions.json                    # per-workspace index
+    │       └── <session-uuid>.json              # full session, ONE JSON doc
+    ├── <profile-hash>/
+    │   ├── <index-hash>                         # executions index
+    │   └── <dir-hash>/
+    │       └── <execution-hash>                 # one file per execution
+    └── dev_data/
+        └── tokens_generated.jsonl               # token usage log
+```
+
+| Platform | `<storage-root>` |
+|---|---|
+| macOS    | `~/Library/Application Support/Kiro` |
+| Windows  | `%APPDATA%\Kiro` |
+| Linux    | `~/.config/Kiro` |
+
+agenthud override: `KIRO_IDE_SESSIONS_DIR` (points directly at the
+`workspace-sessions` directory).
+
+The base64 directory name decodes to the absolute workspace path
+(e.g. `L1VzZXJzL25lby96aXBzYQ==` → `/Users/neo/zipsa`), but the
+`workspaceDirectory` field inside the files is authoritative.
+
+## `sessions.json` — per-workspace index
+
+```json
+[
+  {
+    "sessionId": "cb1a6b5b-c21a-4519-becf-7743cce6b546",
+    "title": "Clean State",
+    "dateCreated": "1781225776989",
+    "workspaceDirectory": "/Users/neo/zipsa"
+  }
+]
+```
+
+`dateCreated` is unix **milliseconds as a string**.
+
+## `<session-uuid>.json` — session state
+
+Single JSON document (not JSONL), rewritten at turn end — its mtime
+is stale while a turn is in flight. Key fields:
+
+```ts
+interface KiroIdeSession {
+  sessionId: string;
+  title: string;
+  workspaceDirectory: string;
+  selectedModel: string;            // "auto" or a pinned model id
+  contextUsagePercentage: number;   // float 0..100; no window size in file
+  active: boolean;                  // session-open flag; STALE during a run
+  sessionType: string;              // "vibe" observed
+  history: HistoryEntry[];
+  // also: contextItems, config, activeTabs, autonomyMode ("Autopilot"),
+  // perSessionModelSelection, contextUsagePercentageBySession,
+  // initialContextEstimate, sessionStartHookResultsBySession, ...
+}
+
+interface HistoryEntry {
+  message: {
+    role: "user" | "assistant";
+    content: UserContentBlock[] | string;
+    // user → array of {type: "text", text} blocks (+ images)
+    // assistant → PLAIN STRING
+    id: string;
+  };
+  executionId?: string;     // assistant turns link to an execution
+  promptLogs?: unknown;     // assistant-side prompt/tool telemetry
+  contextItems?: unknown[];
+  editorState?: unknown;    // rich-text editor doc of the prompt
+}
+```
+
+**No per-entry timestamps in `history[]`.** Real timestamps live in
+the execution files.
+
+## Execution files — live tool activity + sub-agents
+
+The executions index (`<profile-hash>/<index-hash>`) lists every run:
+
+```json
+{ "executions": [
+  { "executionId": "ec90b8bc-…", "type": "chat-agent",
+    "status": "succeed" | "running", "startTime": 1781239893081,
+    "endTime": 1781240381000 }
+] }
+```
+
+Each execution's own file (`<dir-hash>/<execution-hash>` — the file
+name is a hash, NOT the executionId; you must read the file to map)
+contains:
+
+```ts
+interface KiroIdeExecution {
+  executionId: string;
+  workflowType: "chat-agent";
+  status: "running" | "succeed";
+  startTime: number;                // unix ms
+  chatSessionId: string;            // ← joins back to the session uuid
+  autonomyMode: string;             // "Autopilot"
+  contextUsagePercentage: number;
+  usageSummary: { usedTools: string[]; usage: number; unit: "credit" }[];
+  input: { data: { messages: [...] } };  // full prompt replay
+  actions: AgentExecutionAction[];
+}
+
+interface AgentExecutionAction {
+  type: "AgentExecutionAction";
+  executionId: string;
+  actionId: string;
+  actionType:
+    | "readFiles" | "runCommand" | "say" | "model"
+    | "invokeSubAgent" | "subagent_response" | string;
+  actionState: "PendingAction" | "Accepted" | "Running" | "Success";
+  subExecutionId?: string;   // present on actions belonging to a sub-agent
+  input?: unknown;           // e.g. {command, cwd} for runCommand
+  output?: unknown;          // e.g. {response, subExecutionId} for invokeSubAgent
+  emittedAt?: number;
+  endTime?: number;
+}
+```
+
+### Sub-agents — actions, not files
+
+Unlike Kiro CLI (separate session bundle + `parent_session_id`),
+IDE sub-agents live INSIDE the parent's execution file:
+
+1. Parent emits an `invokeSubAgent` action; its `output` carries
+   `subExecutionId` and (on completion) the sub-agent's full
+   markdown report in `response`.
+2. The sub-agent's own steps (`model`, `runCommand`, `say`, ...)
+   appear as further actions tagged with that `subExecutionId`.
+3. A terminal `subagent_response` action closes the group.
+
+### `PendingAction` — the approval gate
+
+Even in Autopilot mode, `runCommand` actions can park at
+`actionState: "PendingAction"` until the user approves in the IDE
+UI. Observed live: a sub-agent stuck on `which uv` while the user
+thought nothing was happening. Surfacing this state is the planned
+follow-up for agenthud's liveness badge.
+
+## What agenthud currently consumes (MVP)
+
+| Signal | Source |
+|---|---|
+| Project grouping | `workspaceDirectory` |
+| Row description | `title` |
+| Model | `selectedModel` |
+| Context gauge | `contextUsagePercentage` (window unknown → 200K assumed for used/total; only percent rendered) |
+| Recency | session `.json` mtime |
+| Activities | `history[]` user/assistant text (timestamps unavailable → epoch placeholder) |
+
+Not yet consumed: execution files (tool-level activity, sub-agent
+nesting, `PendingAction` badge, real timestamps), `tokens_generated
+.jsonl`.
+
+## Verify the schema yourself
+
+```bash
+ROOT="$HOME/Library/Application Support/Kiro/User/globalStorage/kiro.kiroagent"
+
+# Decode workspace dir names
+for d in "$ROOT/workspace-sessions"/*/; do basename "$d" | base64 -d; echo; done
+
+# Index fields
+cat "$ROOT/workspace-sessions"/*/sessions.json | jq -r '.[0] | keys[]'
+
+# Session file top-level keys
+cat "$ROOT/workspace-sessions"/*/<uuid>.json | jq -r 'keys[]'
+
+# History roles + content types
+jq -r '.history[] | "\(.message.role) \(.message.content | type)"' \
+  "$ROOT/workspace-sessions"/*/<uuid>.json | sort | uniq -c
+
+# Execution index statuses
+jq -r '.executions[] | "\(.type) \(.status)"' "$ROOT"/<profile-hash>/<index-hash> | sort | uniq -c
+
+# Action types + states across an execution file
+jq -r '.actions[] | "\(.actionType) \(.actionState)"' \
+  "$ROOT"/<profile-hash>/<dir-hash>/<exec-hash> | sort | uniq -c
+```
+
+If any output line surprises you, this doc is wrong — open an issue.
+
+## Notes / caveats
+
+- The session `.json` is rewritten wholesale at turn end. Watching
+  its mtime misses in-flight activity; the execution file is the
+  live signal.
+- `active: false` while a turn is running (stale flag). Don't use
+  it for liveness; use the executions index `status == "running"`.
+- `session_created_reason` does not exist here (that's a CLI field).
+- The `<profile-hash>` / `<dir-hash>` directory names are opaque;
+  semantics unconfirmed (suspected account/workspace digests).
+  Globbing over them works regardless.

--- a/src/data/providers/claude.ts
+++ b/src/data/providers/claude.ts
@@ -237,15 +237,15 @@ function isSystemNoise(text: string): boolean {
  * Walk the session JSONL and pick the best user message to surface
  * as the session's row description. Preference order:
  *
- *   1. The LATEST "substantial" user message — long enough to carry
- *      intent (≥ 10 chars after trim) and not a slash command
+ *   1. The LATEST user message that isn't a slash command
  *      (`/compact`, `/clear`, …). For long sessions, this reflects
- *      what the user is doing NOW, not just what they asked at
- *      session start (which is often stale by hour 3).
- *   2. The FIRST natural-language user message — fallback when no
- *      later message qualifies as substantial. Preserves the
- *      original "first user prompt" behavior so short / quick
- *      sessions still show something meaningful.
+ *      what the user is doing NOW, not what they asked at session
+ *      start. Short follow-ups ("ok", "go") count — a length
+ *      threshold was tried (≥ 10 chars) and dropped by user
+ *      request: seeing the literal latest reply beats a stale
+ *      longer one.
+ *   2. The FIRST natural-language user message — fallback when
+ *      every later message is a slash command.
  *
  * Returns null when neither exists (empty session, all system
  * reminders, only tool results). The field is still named
@@ -260,13 +260,8 @@ function readFirstUserPrompt(filePath: string): string | null {
     return null;
   }
 
-  const MIN_SUBSTANTIAL_LEN = 10;
-  const isSubstantial = (text: string): boolean => {
-    const trimmed = text.trim();
-    if (trimmed.length < MIN_SUBSTANTIAL_LEN) return false;
-    if (trimmed.startsWith("/")) return false;
-    return true;
-  };
+  const isSubstantial = (text: string): boolean =>
+    !text.trim().startsWith("/");
 
   let first: string | null = null;
   let latestSubstantial: string | null = null;

--- a/src/data/providers/claude.ts
+++ b/src/data/providers/claude.ts
@@ -44,11 +44,8 @@ import type {
   SessionTree,
 } from "../../types/index.js";
 import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
-import {
-  parseActivitiesFromLines,
-  parseModelName,
-} from "./claude-activity.js";
 import { detectLiveState } from "../sessionLiveness.js";
+import { parseActivitiesFromLines, parseModelName } from "./claude-activity.js";
 import type { DiscoverOptions, SessionProvider } from "./types.js";
 
 export function getProjectsDir(): string {

--- a/src/data/providers/kiro-activity.ts
+++ b/src/data/providers/kiro-activity.ts
@@ -64,7 +64,9 @@ function iconForCanonicalLabel(label: string): string {
   return known ?? ICONS.Default;
 }
 
-function summarizeToolInput(input: Record<string, unknown> | undefined): string {
+function summarizeToolInput(
+  input: Record<string, unknown> | undefined,
+): string {
   if (!input) return "";
   const filtered = { ...input };
   delete filtered.__tool_use_purpose;
@@ -91,10 +93,10 @@ function summarizeToolInput(input: Record<string, unknown> | undefined): string 
 
 export function parseKiroActivitiesFromLines(lines: string[]): ParseResult {
   const activities: ActivityEntry[] = [];
-  let modelName: string | null = null;
+  const modelName: string | null = null;
   let sessionStartTime: Date | null = null;
   let lastTimestamp: Date | null = null;
-  let tokenCount = 0;
+  const tokenCount = 0;
 
   for (const line of lines) {
     if (!line.trim()) continue;

--- a/src/data/providers/kiro-ide.ts
+++ b/src/data/providers/kiro-ide.ts
@@ -1,0 +1,372 @@
+/**
+ * Kiro IDE session provider. The IDE (a VSCode fork) stores agent
+ * sessions under its extension globalStorage — a different layout
+ * and record format from Kiro CLI:
+ *
+ *   <storage>/workspace-sessions/<base64-of-workspace-path>/
+ *   ├── sessions.json        index: [{sessionId, title, dateCreated,
+ *   │                                 workspaceDirectory}]
+ *   └── <session-uuid>.json  full session state as ONE JSON document
+ *                            (not JSONL) — history[], model, context
+ *
+ * Design decisions:
+ * - Discovery iterates workspace dirs and reads each `sessions.json`
+ *   index, then the per-session file for model/context/history. The
+ *   `workspaceDirectory` field is used for project grouping (the
+ *   base64 directory name decodes to the same value but the field
+ *   is authoritative and cheaper).
+ * - `history[]` entries carry NO timestamps. Activities therefore
+ *   all carry the session file's mtime — good enough for "what
+ *   happened in this session", wrong for intra-session ordering by
+ *   wall-clock. Documented limitation; execution files have real
+ *   timestamps and are the planned follow-up source.
+ * - `liveState` stays null in this MVP. The `active` field in the
+ *   session file is stale during a run (the file is only rewritten
+ *   at turn end), so it can't drive a working/waiting badge.
+ *   Execution-index parsing (status: "running" + PendingAction
+ *   detection) is the follow-up that makes this provider live.
+ * - Sub-agents are NOT separate sessions in the IDE — they're
+ *   actions inside the parent's execution log tagged with
+ *   `subExecutionId`. This MVP shows none; follow-up will surface
+ *   them from execution files.
+ *
+ * Gotchas:
+ * - `contextUsagePercentage` is a percent with no window size in
+ *   the file. `used`/`total` are synthesized against an assumed
+ *   200K window (Kiro CLI reports 200_000 for the same models);
+ *   the renderer only displays `percent`, so the assumption is
+ *   cosmetic.
+ * - Default storage root is platform-dependent (VSCode-fork
+ *   convention). `KIRO_IDE_SESSIONS_DIR` overrides — point it at
+ *   the `workspace-sessions` directory itself.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import type {
+  ActivityEntry,
+  GlobalConfig,
+  ProjectNode,
+  SessionNode,
+  SessionStatus,
+  SessionTree,
+} from "../../types/index.js";
+import { ICONS } from "../../types/index.js";
+import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
+import type { ParseResult, SessionProvider } from "./types.js";
+
+export function getKiroIdeSessionsDir(): string {
+  if (process.env.KIRO_IDE_SESSIONS_DIR) {
+    return process.env.KIRO_IDE_SESSIONS_DIR;
+  }
+  const sub = join(
+    "Kiro",
+    "User",
+    "globalStorage",
+    "kiro.kiroagent",
+    "workspace-sessions",
+  );
+  if (process.platform === "darwin") {
+    return join(homedir(), "Library", "Application Support", sub);
+  }
+  if (process.platform === "win32") {
+    return join(
+      process.env.APPDATA ?? join(homedir(), "AppData", "Roaming"),
+      sub,
+    );
+  }
+  return join(homedir(), ".config", sub);
+}
+
+function getSessionStatus(mtimeMs: number): SessionStatus {
+  const now = Date.now();
+  const age = now - mtimeMs;
+  if (age < THIRTY_MINUTES_MS) return "hot";
+  if (age < ONE_HOUR_MS) return "warm";
+  const mtime = new Date(mtimeMs);
+  const nowDate = new Date(now);
+  if (
+    mtime.getUTCFullYear() === nowDate.getUTCFullYear() &&
+    mtime.getUTCMonth() === nowDate.getUTCMonth() &&
+    mtime.getUTCDate() === nowDate.getUTCDate()
+  ) {
+    return "cool";
+  }
+  return "cold";
+}
+
+interface IdeIndexEntry {
+  sessionId?: string;
+  title?: string;
+  dateCreated?: string;
+  workspaceDirectory?: string;
+}
+
+interface IdeHistoryEntry {
+  message?: {
+    role?: string;
+    content?: unknown;
+    id?: string;
+  };
+}
+
+interface IdeSessionFile {
+  sessionId?: string;
+  title?: string;
+  workspaceDirectory?: string;
+  selectedModel?: unknown;
+  contextUsagePercentage?: number | null;
+  history?: IdeHistoryEntry[];
+}
+
+// Kiro CLI reports context_window_tokens: 200000 for the same
+// model family; the IDE file carries only the percentage, so we
+// synthesize used/total against that assumption. Only `percent`
+// is rendered.
+const ASSUMED_WINDOW = 200_000;
+
+function readSessionFile(path: string): IdeSessionFile | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as IdeSessionFile;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function toNode(
+  meta: IdeIndexEntry,
+  file: IdeSessionFile | null,
+  jsonPath: string,
+  mtimeMs: number,
+  hidden: boolean,
+): SessionNode | null {
+  const id = meta.sessionId ?? file?.sessionId;
+  const workspace = meta.workspaceDirectory ?? file?.workspaceDirectory;
+  if (!id || !workspace) return null;
+  const projectName = basename(workspace);
+
+  const pct = file?.contextUsagePercentage;
+  const contextUsage =
+    typeof pct === "number" && pct >= 0
+      ? {
+          used: Math.round((pct / 100) * ASSUMED_WINDOW),
+          total: ASSUMED_WINDOW,
+          percent: Math.min(100, Math.round(pct)),
+        }
+      : undefined;
+
+  const model = file?.selectedModel;
+  const node: SessionNode = {
+    id,
+    hideKey: `${projectName}/${id}`,
+    filePath: jsonPath,
+    projectPath: workspace,
+    projectName,
+    lastModifiedMs: mtimeMs,
+    status: getSessionStatus(mtimeMs),
+    modelName: typeof model === "string" && model.length > 0 ? model : null,
+    subAgents: [],
+    nonInteractive: false,
+    firstUserPrompt: meta.title ?? file?.title ?? null,
+    liveState: null,
+    provider: "kiro-ide",
+    contextUsage,
+  };
+  if (hidden) node.hidden = true;
+  return node;
+}
+
+function discoverKiroIdeSessions(config: GlobalConfig): SessionTree {
+  const root = getKiroIdeSessionsDir();
+  const empty: SessionTree = {
+    projects: [],
+    coldProjects: [],
+    totalCount: 0,
+    timestamp: new Date().toISOString(),
+    hiddenStats: { total: 0, active: 0 },
+  };
+  if (!existsSync(root)) return empty;
+
+  let workspaceDirs: string[];
+  try {
+    workspaceDirs = readdirSync(root) as unknown as string[];
+  } catch {
+    return empty;
+  }
+
+  const byProject = new Map<string, SessionNode[]>();
+  let hiddenTotal = 0;
+  let hiddenActive = 0;
+
+  for (const ws of workspaceDirs) {
+    const wsDir = join(root, ws);
+    const indexPath = join(wsDir, "sessions.json");
+    if (!existsSync(indexPath)) continue;
+
+    let index: IdeIndexEntry[];
+    try {
+      const parsed = JSON.parse(readFileSync(indexPath, "utf-8"));
+      if (!Array.isArray(parsed)) continue;
+      index = parsed as IdeIndexEntry[];
+    } catch {
+      continue;
+    }
+
+    for (const meta of index) {
+      if (!meta?.sessionId) continue;
+      const jsonPath = join(wsDir, `${meta.sessionId}.json`);
+      let mtimeMs: number;
+      try {
+        mtimeMs = statSync(jsonPath).mtimeMs;
+      } catch {
+        continue;
+      }
+      const file = readSessionFile(jsonPath);
+      const workspace = meta.workspaceDirectory ?? file?.workspaceDirectory;
+      if (!workspace) continue;
+      const projectName = basename(workspace);
+      const projectHidden = config.hiddenProjects.includes(projectName);
+      const sessionHidden = config.hiddenSessions.includes(
+        `${projectName}/${meta.sessionId}`,
+      );
+      const hidden = projectHidden || sessionHidden;
+
+      const node = toNode(meta, file, jsonPath, mtimeMs, hidden);
+      if (!node) continue;
+      if (hidden) {
+        hiddenTotal++;
+        if (node.status === "hot" || node.status === "warm") hiddenActive++;
+      }
+      const arr = byProject.get(workspace) ?? [];
+      arr.push(node);
+      byProject.set(workspace, arr);
+    }
+  }
+
+  const statusOrder: Record<SessionStatus, number> = {
+    hot: 0,
+    warm: 1,
+    cool: 2,
+    cold: 3,
+  };
+
+  const allProjects: ProjectNode[] = [];
+  for (const [projectPath, sessions] of byProject) {
+    if (sessions.length === 0) continue;
+    const projectName = sessions[0].projectName;
+    sessions.sort((a, b) => {
+      const d = statusOrder[a.status] - statusOrder[b.status];
+      if (d !== 0) return d;
+      return b.lastModifiedMs - a.lastModifiedMs;
+    });
+    allProjects.push({
+      name: projectName,
+      projectPath,
+      sessions,
+      hotness: sessions[0].status,
+      hidden: config.hiddenProjects.includes(projectName) || undefined,
+    });
+  }
+
+  const activeProjects = allProjects.filter((p) => p.hotness !== "cold");
+  const coldProjects = allProjects.filter((p) => p.hotness === "cold");
+  activeProjects.sort((a, b) => {
+    const d = statusOrder[a.hotness] - statusOrder[b.hotness];
+    if (d !== 0) return d;
+    return b.sessions[0].lastModifiedMs - a.sessions[0].lastModifiedMs;
+  });
+
+  const count = (projects: ProjectNode[]) =>
+    projects.reduce((sum, p) => sum + p.sessions.length, 0);
+
+  return {
+    projects: activeProjects,
+    coldProjects,
+    totalCount: count(activeProjects) + count(coldProjects),
+    timestamp: new Date().toISOString(),
+    hiddenStats: { total: hiddenTotal, active: hiddenActive },
+  };
+}
+
+function firstTextBlock(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const block = content.find(
+      (b: { type?: string; text?: string }) =>
+        b && b.type === "text" && typeof b.text === "string",
+    ) as { text?: string } | undefined;
+    return block?.text ?? "";
+  }
+  return "";
+}
+
+/**
+ * Parse a Kiro IDE session file's `history[]` into activities.
+ * Receives the file content as lines (per the SessionProvider
+ * interface) and re-joins before parsing — the session file is a
+ * single JSON document, possibly pretty-printed across lines.
+ *
+ * Limitation: history entries carry no timestamps; every activity
+ * gets epoch 0 here and the caller's display layer falls back to
+ * relative ordering. Execution files have real timestamps and are
+ * the follow-up source.
+ */
+export function parseKiroIdeActivities(lines: string[]): ParseResult {
+  const empty: ParseResult = {
+    activities: [],
+    tokenCount: 0,
+    modelName: null,
+    sessionStartTime: null,
+  };
+  let doc: IdeSessionFile;
+  try {
+    doc = JSON.parse(lines.join("\n")) as IdeSessionFile;
+  } catch {
+    return empty;
+  }
+  if (!doc || !Array.isArray(doc.history)) return empty;
+
+  const activities: ActivityEntry[] = [];
+  const ts = new Date(0);
+  for (const entry of doc.history) {
+    const role = entry?.message?.role;
+    const text = firstTextBlock(entry?.message?.content);
+    if (!text || !text.trim()) continue;
+    if (role === "user") {
+      activities.push({
+        timestamp: ts,
+        type: "user",
+        icon: ICONS.User,
+        label: "User",
+        detail: text.split("\n")[0] ?? "",
+        detailBody: text,
+      });
+    } else if (role === "assistant") {
+      activities.push({
+        timestamp: ts,
+        type: "response",
+        icon: ICONS.Response,
+        label: "Response",
+        detail: text.split("\n")[0] ?? "",
+        detailBody: text,
+      });
+    }
+  }
+
+  const model = doc.selectedModel;
+  return {
+    activities,
+    tokenCount: 0,
+    modelName: typeof model === "string" ? model : null,
+    sessionStartTime: activities.length > 0 ? ts : null,
+  };
+}
+
+export const kiroIdeProvider: SessionProvider = {
+  name: "kiro-ide",
+  isAvailable: () => existsSync(getKiroIdeSessionsDir()),
+  discoverSessions: discoverKiroIdeSessions,
+  parseActivities: parseKiroIdeActivities,
+};

--- a/src/data/providers/kiro-ide.ts
+++ b/src/data/providers/kiro-ide.ts
@@ -43,10 +43,11 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type {
   ActivityEntry,
   GlobalConfig,
+  LiveState,
   ProjectNode,
   SessionNode,
   SessionStatus,
@@ -178,6 +179,186 @@ function toNode(
   return node;
 }
 
+interface IdeExecutionAction {
+  actionType?: string;
+  actionState?: string;
+  subExecutionId?: string;
+  input?: { prompt?: string; command?: string };
+  output?: { response?: string; subExecutionId?: string };
+  emittedAt?: number;
+  endTime?: number;
+}
+
+interface IdeExecution {
+  executionId?: string;
+  status?: string;
+  startTime?: number;
+  endTime?: number;
+  chatSessionId?: string;
+  actions?: IdeExecutionAction[];
+}
+
+// Execution-file parse cache keyed by path → {mtime, value}. The
+// files are rewritten constantly while a turn runs but stay
+// untouched afterward; without the cache every 2s poll re-reads
+// and re-parses every historical execution (some are 200KB+).
+const execCache = new Map<
+  string,
+  { mtimeMs: number; value: IdeExecution | null }
+>();
+
+/** Test hook: the cache is module-level and keyed by (path, mtime),
+ * which collides across test cases that mock the same fake path
+ * with the same fake mtime. Production never needs this. */
+export function clearKiroIdeExecutionCache(): void {
+  execCache.clear();
+}
+
+function readExecutionFile(path: string, mtimeMs: number): IdeExecution | null {
+  const cached = execCache.get(path);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.value;
+  let value: IdeExecution | null = null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as IdeExecution;
+    // Identify execution files structurally — profile dirs also
+    // hold index files and other JSON we don't care about.
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.chatSessionId === "string" &&
+      Array.isArray(parsed.actions)
+    ) {
+      value = parsed;
+    }
+  } catch {
+    value = null;
+  }
+  execCache.set(path, { mtimeMs, value });
+  return value;
+}
+
+/**
+ * Walk the agent root's profile directories for execution files and
+ * synthesize sub-agent SessionNodes, grouped by the parent session's
+ * uuid (`chatSessionId`).
+ *
+ * IDE sub-agents aren't separate session files (unlike the CLI) —
+ * they exist as actions inside the parent's execution log:
+ *   - `invokeSubAgent` carries the spawning prompt (input.prompt)
+ *     and the child's id (output.subExecutionId)
+ *   - subsequent actions tagged with that subExecutionId are the
+ *     child's own steps; their timestamps drive recency
+ *   - any action still in `PendingAction` ⇒ the child is parked on
+ *     the IDE's approval gate ⇒ liveState "waiting" (the user-facing
+ *     answer to "is it even running?")
+ */
+function buildSubAgentsBySession(
+  agentRoot: string,
+  config: GlobalConfig,
+): Map<string, SessionNode[]> {
+  const out = new Map<string, SessionNode[]>();
+  let profileDirs: string[];
+  try {
+    profileDirs = readdirSync(agentRoot) as unknown as string[];
+  } catch {
+    return out;
+  }
+
+  for (const profile of profileDirs) {
+    if (profile === "workspace-sessions" || profile === "dev_data") continue;
+    const profilePath = join(agentRoot, profile);
+    let entries: string[];
+    try {
+      if (!statSync(profilePath).isDirectory()) continue;
+      entries = readdirSync(profilePath) as unknown as string[];
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const entryPath = join(profilePath, entry);
+      let isDir: boolean;
+      try {
+        isDir = statSync(entryPath).isDirectory();
+      } catch {
+        continue;
+      }
+      if (!isDir) continue; // top-level files are indexes, skip
+      let execFiles: string[];
+      try {
+        execFiles = readdirSync(entryPath) as unknown as string[];
+      } catch {
+        continue;
+      }
+      for (const f of execFiles) {
+        const execPath = join(entryPath, f);
+        let mtimeMs: number;
+        try {
+          mtimeMs = statSync(execPath).mtimeMs;
+        } catch {
+          continue;
+        }
+        const exec = readExecutionFile(execPath, mtimeMs);
+        if (!exec?.chatSessionId || !exec.actions) continue;
+
+        // Collect sub-agent groups within this execution.
+        for (const action of exec.actions) {
+          if (action.actionType !== "invokeSubAgent") continue;
+          const subId =
+            action.output?.subExecutionId ?? action.subExecutionId;
+          if (!subId) continue;
+
+          const groupActions = exec.actions.filter(
+            (a) => a.subExecutionId === subId,
+          );
+          const timestamps = groupActions
+            .flatMap((a) => [a.emittedAt, a.endTime])
+            .filter((t): t is number => typeof t === "number");
+          const lastMs =
+            timestamps.length > 0
+              ? Math.max(...timestamps)
+              : (exec.endTime ?? exec.startTime ?? mtimeMs);
+
+          const pending = groupActions.some(
+            (a) => a.actionState === "PendingAction",
+          );
+          const running =
+            exec.status === "running" &&
+            !groupActions.some(
+              (a) => a.actionType === "subagent_response",
+            );
+          const liveState: LiveState | null = pending
+            ? "waiting"
+            : running
+              ? "working"
+              : null;
+
+          const prompt = action.input?.prompt ?? "";
+          out.set(exec.chatSessionId, [
+            ...(out.get(exec.chatSessionId) ?? []),
+            {
+              id: subId,
+              hideKey: "", // parent fills in projectName below
+              filePath: execPath,
+              projectPath: "",
+              projectName: "",
+              lastModifiedMs: lastMs,
+              status: getSessionStatus(lastMs),
+              modelName: null,
+              subAgents: [],
+              taskDescription: prompt.split("\n")[0] || undefined,
+              nonInteractive: false,
+              firstUserPrompt: null,
+              liveState,
+              provider: "kiro-ide",
+            },
+          ]);
+        }
+      }
+    }
+  }
+  return out;
+}
+
 function discoverKiroIdeSessions(config: GlobalConfig): SessionTree {
   const root = getKiroIdeSessionsDir();
   const empty: SessionTree = {
@@ -199,6 +380,11 @@ function discoverKiroIdeSessions(config: GlobalConfig): SessionTree {
   const byProject = new Map<string, SessionNode[]>();
   let hiddenTotal = 0;
   let hiddenActive = 0;
+
+  // Sub-agents come from execution files, which live under sibling
+  // profile dirs of workspace-sessions — i.e. the agent root is the
+  // parent directory of the sessions root.
+  const subAgentsBySession = buildSubAgentsBySession(dirname(root), config);
 
   for (const ws of workspaceDirs) {
     const wsDir = join(root, ws);
@@ -239,6 +425,24 @@ function discoverKiroIdeSessions(config: GlobalConfig): SessionTree {
         hiddenTotal++;
         if (node.status === "hot" || node.status === "warm") hiddenActive++;
       }
+
+      // Attach sub-agents discovered in execution files. Fill in
+      // the project-scoped fields the builder couldn't know.
+      const subs = subAgentsBySession.get(node.id) ?? [];
+      for (const sub of subs) {
+        sub.projectPath = workspace;
+        sub.projectName = projectName;
+        sub.hideKey = `${projectName}/${sub.id}`;
+        const subHidden =
+          projectHidden || config.hiddenSubAgents.includes(sub.hideKey);
+        if (subHidden) {
+          sub.hidden = true;
+          hiddenTotal++;
+          if (sub.status === "hot" || sub.status === "warm") hiddenActive++;
+        }
+        node.subAgents.push(sub);
+      }
+
       const arr = byProject.get(workspace) ?? [];
       arr.push(node);
       byProject.set(workspace, arr);
@@ -279,7 +483,13 @@ function discoverKiroIdeSessions(config: GlobalConfig): SessionTree {
   });
 
   const count = (projects: ProjectNode[]) =>
-    projects.reduce((sum, p) => sum + p.sessions.length, 0);
+    projects.reduce(
+      (sum, p) =>
+        sum +
+        p.sessions.length +
+        p.sessions.reduce((s, sn) => s + sn.subAgents.length, 0),
+      0,
+    );
 
   return {
     projects: activeProjects,
@@ -313,6 +523,56 @@ function firstTextBlock(content: unknown): string {
  * relative ordering. Execution files have real timestamps and are
  * the follow-up source.
  */
+function actionToActivity(a: IdeExecutionAction): ActivityEntry | null {
+  const ts = new Date(a.emittedAt ?? a.endTime ?? 0);
+  switch (a.actionType) {
+    case "runCommand":
+      return {
+        timestamp: ts,
+        type: "tool",
+        icon: ICONS.Bash,
+        label: "Bash",
+        detail: a.input?.command ?? "",
+      };
+    case "readFiles":
+      return {
+        timestamp: ts,
+        type: "tool",
+        icon: ICONS.Read,
+        label: "Read",
+        detail: "",
+      };
+    case "invokeSubAgent": {
+      const prompt = a.input?.prompt ?? "";
+      return {
+        timestamp: ts,
+        type: "tool",
+        icon: ICONS.Task,
+        label: "Task",
+        detail: prompt.split("\n")[0] ?? "",
+        detailBody: a.output?.response || prompt,
+      };
+    }
+    case "say": {
+      const text =
+        typeof a.output === "string"
+          ? a.output
+          : ((a.output as { response?: string } | undefined)?.response ?? "");
+      if (!text) return null;
+      return {
+        timestamp: ts,
+        type: "response",
+        icon: ICONS.Response,
+        label: "Response",
+        detail: text.split("\n")[0] ?? "",
+        detailBody: text,
+      };
+    }
+    default:
+      return null; // model / bookkeeping actions add no user-facing info
+  }
+}
+
 export function parseKiroIdeActivities(lines: string[]): ParseResult {
   const empty: ParseResult = {
     activities: [],
@@ -320,13 +580,34 @@ export function parseKiroIdeActivities(lines: string[]): ParseResult {
     modelName: null,
     sessionStartTime: null,
   };
-  let doc: IdeSessionFile;
+  let doc: IdeSessionFile & IdeExecution;
   try {
-    doc = JSON.parse(lines.join("\n")) as IdeSessionFile;
+    doc = JSON.parse(lines.join("\n")) as IdeSessionFile & IdeExecution;
   } catch {
     return empty;
   }
-  if (!doc || !Array.isArray(doc.history)) return empty;
+  if (!doc || typeof doc !== "object") return empty;
+
+  // Execution document (sub-agent filePath points here): map the
+  // actions[] stream to activities. The whole execution is shown —
+  // parent steps and every sub-agent's steps interleaved in emit
+  // order — which is more context, not less, when inspecting a
+  // sub-agent row.
+  if (Array.isArray(doc.actions)) {
+    const activities = doc.actions
+      .map(actionToActivity)
+      .filter((a): a is ActivityEntry => a !== null)
+      .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+    return {
+      activities,
+      tokenCount: 0,
+      modelName: null,
+      sessionStartTime:
+        typeof doc.startTime === "number" ? new Date(doc.startTime) : null,
+    };
+  }
+
+  if (!Array.isArray(doc.history)) return empty;
 
   const activities: ActivityEntry[] = [];
   const ts = new Date(0);

--- a/src/data/providers/kiro-ide.ts
+++ b/src/data/providers/kiro-ide.ts
@@ -326,11 +326,18 @@ function buildSubAgentsBySession(
             !groupActions.some(
               (a) => a.actionType === "subagent_response",
             );
-          const liveState: LiveState | null = pending
-            ? "waiting"
-            : running
-              ? "working"
-              : null;
+          // Recency gate (same 30m rule as the other providers): a
+          // quit IDE leaves executions parked in "running" /
+          // "PendingAction" forever — without the gate those dead
+          // approvals would wear a live badge indefinitely.
+          const recentlyActive = Date.now() - lastMs < THIRTY_MINUTES_MS;
+          const liveState: LiveState | null = !recentlyActive
+            ? null
+            : pending
+              ? "waiting"
+              : running
+                ? "working"
+                : null;
 
           const prompt = action.input?.prompt ?? "";
           out.set(exec.chatSessionId, [

--- a/src/data/providers/kiro-ide.ts
+++ b/src/data/providers/kiro-ide.ts
@@ -55,7 +55,11 @@ import type {
 } from "../../types/index.js";
 import { ICONS } from "../../types/index.js";
 import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
-import type { ParseResult, SessionProvider } from "./types.js";
+import type {
+  ParseContext,
+  ParseResult,
+  SessionProvider,
+} from "./types.js";
 
 export function getKiroIdeSessionsDir(): string {
   if (process.env.KIRO_IDE_SESSIONS_DIR) {
@@ -580,7 +584,10 @@ function actionToActivity(a: IdeExecutionAction): ActivityEntry | null {
   }
 }
 
-export function parseKiroIdeActivities(lines: string[]): ParseResult {
+export function parseKiroIdeActivities(
+  lines: string[],
+  context?: ParseContext,
+): ParseResult {
   const empty: ParseResult = {
     activities: [],
     tokenCount: 0,
@@ -617,7 +624,12 @@ export function parseKiroIdeActivities(lines: string[]): ParseResult {
   if (!Array.isArray(doc.history)) return empty;
 
   const activities: ActivityEntry[] = [];
-  const ts = new Date(0);
+  // History entries carry no timestamps. The session file's mtime
+  // (passed via context) is the best stand-in — it makes the
+  // activities land on the day the session was last touched so the
+  // report's same-day filter doesn't silently drop the session.
+  // Epoch fallback keeps direct callers (tests) working.
+  const ts = new Date(context?.mtimeMs ?? 0);
   for (const entry of doc.history) {
     const role = entry?.message?.role;
     const text = firstTextBlock(entry?.message?.content);

--- a/src/data/providers/kiro.ts
+++ b/src/data/providers/kiro.ts
@@ -52,8 +52,7 @@ import type { DiscoverOptions, SessionProvider } from "./types.js";
 
 export function getKiroSessionsDir(): string {
   return (
-    process.env.KIRO_SESSIONS_DIR ??
-    join(homedir(), ".kiro", "sessions", "cli")
+    process.env.KIRO_SESSIONS_DIR ?? join(homedir(), ".kiro", "sessions", "cli")
   );
 }
 

--- a/src/data/providers/kiro.ts
+++ b/src/data/providers/kiro.ts
@@ -226,7 +226,16 @@ function readRawSessions(
 }
 
 function toSessionNode(raw: RawSession, hidden: boolean): SessionNode {
-  const liveState: LiveState | null = raw.hasLock ? "waiting" : null;
+  // `.lock` means the Kiro process is alive, NOT that the
+  // conversation is active — a terminal left open for hours keeps
+  // its lock. Gate the live badge by the same 30-minute recency
+  // rule Claude's detectLiveState uses, so idle-but-open sessions
+  // fall back to the time-based [cool]/[cold] badge instead of
+  // showing [waiting] forever.
+  const recentlyActive =
+    Date.now() - raw.lastModifiedMs < THIRTY_MINUTES_MS;
+  const liveState: LiveState | null =
+    raw.hasLock && recentlyActive ? "waiting" : null;
   const node: SessionNode = {
     id: raw.id,
     hideKey: raw.hideKey,

--- a/src/data/providers/types.ts
+++ b/src/data/providers/types.ts
@@ -44,6 +44,14 @@ export interface ParseResult {
   sessionStartTime: Date | null;
 }
 
+/** Optional out-of-band context for parsers whose record format
+ * lacks information the activities need. Kiro IDE history entries
+ * carry no timestamps, so the caller supplies the session file's
+ * mtime as the best available stand-in. */
+export interface ParseContext {
+  mtimeMs?: number;
+}
+
 export interface SessionProvider {
   readonly name: ProviderName;
   /** True when the provider's storage location exists and looks
@@ -58,6 +66,8 @@ export interface SessionProvider {
   ): SessionTree;
   /** Parse the given JSONL lines into the canonical activity list.
    * Lines are passed in instead of a file path so the caller can
-   * reuse a single read for both tail and full-history use cases. */
-  parseActivities(lines: string[]): ParseResult;
+   * reuse a single read for both tail and full-history use cases.
+   * `context` carries out-of-band info (e.g. file mtime) for
+   * formats that lack it inline; providers may ignore it. */
+  parseActivities(lines: string[], context?: ParseContext): ParseResult;
 }

--- a/src/data/providers/types.ts
+++ b/src/data/providers/types.ts
@@ -28,7 +28,7 @@ import type {
   SessionTree,
 } from "../../types/index.js";
 
-export type ProviderName = "claude" | "kiro";
+export type ProviderName = "claude" | "kiro" | "kiro-ide";
 
 export interface DiscoverOptions {
   // When set, drop every project whose decoded path is not exactly this

--- a/src/data/reportGenerator.ts
+++ b/src/data/reportGenerator.ts
@@ -248,8 +248,7 @@ export function generateReport(
     const provenance: string[] = [];
     if (session.provider) provenance.push(session.provider);
     if (session.modelName) provenance.push(session.modelName);
-    const suffix =
-      provenance.length > 0 ? ` · ${provenance.join(" · ")}` : "";
+    const suffix = provenance.length > 0 ? ` · ${provenance.join(" · ")}` : "";
     lines.push(`## ${session.projectName} (${first} – ${last})${suffix}`);
     lines.push("");
     for (const activity of activities) {

--- a/src/data/sessionHistory.ts
+++ b/src/data/sessionHistory.ts
@@ -13,7 +13,7 @@
  *   reportGenerator, etc.) work unchanged for Claude paths.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import type { ActivityEntry } from "../types/index.js";
 import { claudeProvider } from "./providers/claude.js";
 import { kiroProvider } from "./providers/kiro.js";
@@ -46,7 +46,17 @@ export function parseSessionHistory(filePath: string): ActivityEntry[] {
   }
 
   const lines = content.trim().split("\n").filter(Boolean);
-  const { activities } = providerForPath(filePath).parseActivities(lines);
+  // mtime rides along for formats whose records carry no timestamps
+  // (Kiro IDE history[]). Providers that don't need it ignore it.
+  let mtimeMs: number | undefined;
+  try {
+    mtimeMs = statSync(filePath).mtimeMs;
+  } catch {
+    mtimeMs = undefined;
+  }
+  const { activities } = providerForPath(filePath).parseActivities(lines, {
+    mtimeMs,
+  });
 
   return activities;
 }

--- a/src/data/sessionHistory.ts
+++ b/src/data/sessionHistory.ts
@@ -26,7 +26,10 @@ import type { SessionProvider } from "./providers/types.js";
 function providerForPath(filePath: string): SessionProvider {
   const p = filePath.replace(/\\/g, "/");
   if (p.includes("/.kiro/sessions/")) return kiroProvider;
-  if (p.includes("kiro.kiroagent/workspace-sessions/")) return kiroIdeProvider;
+  // Covers both workspace-sessions (session docs) and the profile
+  // dirs (execution docs — sub-agent rows point their filePath at
+  // these). The IDE parser sniffs which document shape it received.
+  if (p.includes("kiro.kiroagent/")) return kiroIdeProvider;
   return claudeProvider;
 }
 

--- a/src/data/sessionHistory.ts
+++ b/src/data/sessionHistory.ts
@@ -17,17 +17,20 @@ import { existsSync, readFileSync } from "node:fs";
 import type { ActivityEntry } from "../types/index.js";
 import { claudeProvider } from "./providers/claude.js";
 import { kiroProvider } from "./providers/kiro.js";
+import { kiroIdeProvider } from "./providers/kiro-ide.js";
+import type { SessionProvider } from "./providers/types.js";
 
-function isKiroPath(filePath: string): boolean {
-  // Match both the default `~/.kiro/sessions/` location and
-  // the test/override path via `KIRO_SESSIONS_DIR`. Looking for
-  // the literal segment is robust against home-directory
-  // variations; normalize separators first so Windows paths
-  // (`C:\Users\x\.kiro\sessions\...`) match too.
-  return filePath.replace(/\\/g, "/").includes("/.kiro/sessions/");
+// Provider routing by path segment. Each check normalizes
+// backslashes first so Windows paths match too. Order matters only
+// in that Claude is the default fallback.
+function providerForPath(filePath: string): SessionProvider {
+  const p = filePath.replace(/\\/g, "/");
+  if (p.includes("/.kiro/sessions/")) return kiroProvider;
+  if (p.includes("kiro.kiroagent/workspace-sessions/")) return kiroIdeProvider;
+  return claudeProvider;
 }
 
-// Parse the full, untruncated activity history from a JSONL file.
+// Parse the full, untruncated activity history from a session file.
 // Returns entries in chronological order (oldest first).
 export function parseSessionHistory(filePath: string): ActivityEntry[] {
   if (!existsSync(filePath)) return [];
@@ -40,8 +43,7 @@ export function parseSessionHistory(filePath: string): ActivityEntry[] {
   }
 
   const lines = content.trim().split("\n").filter(Boolean);
-  const provider = isKiroPath(filePath) ? kiroProvider : claudeProvider;
-  const { activities } = provider.parseActivities(lines);
+  const { activities } = providerForPath(filePath).parseActivities(lines);
 
   return activities;
 }

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -33,6 +33,7 @@ import type {
 } from "../types/index.js";
 import { claudeProvider } from "./providers/claude.js";
 import { kiroProvider } from "./providers/kiro.js";
+import { kiroIdeProvider } from "./providers/kiro-ide.js";
 import type { DiscoverOptions, SessionProvider } from "./providers/types.js";
 
 export {
@@ -42,7 +43,11 @@ export {
 } from "./providers/claude.js";
 export type { DiscoverOptions } from "./providers/types.js";
 
-const PROVIDERS: SessionProvider[] = [claudeProvider, kiroProvider];
+const PROVIDERS: SessionProvider[] = [
+  claudeProvider,
+  kiroProvider,
+  kiroIdeProvider,
+];
 
 /**
  * Walk every enabled provider, build per-provider `SessionTree`s,
@@ -92,10 +97,7 @@ function mergeTrees(trees: SessionTree[]): SessionTree {
   const hotter = (a: SessionStatus, b: SessionStatus) =>
     statusRank[a] <= statusRank[b] ? a : b;
 
-  const merge = (
-    target: Map<string, ProjectNode>,
-    p: ProjectNode,
-  ) => {
+  const merge = (target: Map<string, ProjectNode>, p: ProjectNode) => {
     const existing = target.get(p.projectPath);
     if (!existing) {
       target.set(p.projectPath, { ...p, sessions: [...p.sessions] });

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,18 @@ import { isLegacyProjectConfig } from "./utils/legacyConfig.js";
 const globalConfig = loadGlobalConfig();
 const options = parseArgs(process.argv.slice(2), globalConfig);
 
+// exit(0) immediately after a large stdout write TRUNCATES piped
+// output — pipe writes are async and the unflushed remainder is
+// discarded on exit. Reproduced live: `agenthud report | grep` got
+// 574 of 966 lines and silently lost the trailing session blocks
+// (a file redirect got all 966 — file fds flush synchronously).
+// Await this before any exit that follows stdout output.
+function flushStdout(): Promise<void> {
+  return new Promise((resolve) => {
+    process.stdout.write("", () => resolve());
+  });
+}
+
 if (options.error) {
   process.stderr.write(`agenthud: ${options.error}\n`);
   process.exit(1);
@@ -125,6 +137,7 @@ if (options.mode === "report") {
     withGit: options.reportWithGit,
   });
   process.stdout.write(`${markdown}\n`);
+  await flushStdout();
   process.exit(0);
 }
 
@@ -163,6 +176,7 @@ if (options.mode === "summary") {
       open: options.summaryOpen,
       openIndex: options.summaryOpenIndex,
     });
+    await flushStdout();
     process.exit(exitCode);
   }
   const exitCode = await runSummary({
@@ -177,6 +191,7 @@ if (options.mode === "summary") {
     open: options.summaryOpen,
     openIndex: options.summaryOpenIndex,
   });
+  await flushStdout();
   process.exit(exitCode);
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,7 +35,7 @@ export interface SessionNode {
   firstUserPrompt: string | null; // Display description: latest substantial (≥10 chars, non-slash) user message, falling back to the first natural-language one. Name kept for backwards compat.
   liveState: LiveState | null; // working/waiting from JSONL tail; null = fall back to time-based status
   hidden?: boolean; // true when matched by hiddenSessions/hiddenSubAgents, or descendant of a hidden project
-  provider?: "claude" | "kiro"; // origin source of this node. Renderer uses it for a small per-row label so users can tell at a glance which CLI created the session.
+  provider?: "claude" | "kiro" | "kiro-ide"; // origin source of this node. Renderer uses it for a small per-row label so users can tell at a glance which CLI created the session.
   /**
    * Most-recent context-window usage observed for this session.
    * `percent` is the fraction-of-window (0..100) the renderer shows

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -200,12 +200,13 @@ function SessionRow({
   // CLI created the session. Claude rows get a gold tint (Anthropic
   // brand), Kiro rows magenta.
   const providerTag = isParent && session.provider ? session.provider : "";
-  const providerColor =
-    session.provider === "kiro"
-      ? "magenta"
-      : session.provider === "claude"
-        ? "yellow"
-        : undefined;
+  // Both Kiro surfaces share magenta — the label text (`kiro` vs
+  // `kiro-ide`) carries the distinction.
+  const providerColor = session.provider?.startsWith("kiro")
+    ? "magenta"
+    : session.provider === "claude"
+      ? "yellow"
+      : undefined;
 
   // Context-window usage gauge. Shown on BOTH top-level sessions and
   // sub-agents (they have independent contexts). Color encodes
@@ -296,9 +297,7 @@ function SessionRow({
         {middleText ? <Text dimColor>{middleSection}</Text> : null}
         <Text>{gap}</Text>
         <Text dimColor>{elapsed}</Text>
-        {ctxTag ? (
-          <Text color={ctxColor}>{` ${ctxTag}`}</Text>
-        ) : null}
+        {ctxTag ? <Text color={ctxColor}>{` ${ctxTag}`}</Text> : null}
         {providerTag ? (
           <Text color={providerColor} dimColor>
             {` ${providerTag}`}
@@ -487,9 +486,7 @@ function ProjectRow({
   const isActive = (status: SessionStatus) =>
     status === "hot" || status === "warm";
   const entry = census?.perProject.get(project.projectPath);
-  const sessionCount = entry
-    ? entry.sessions.total
-    : project.sessions.length;
+  const sessionCount = entry ? entry.sessions.total : project.sessions.length;
   const activeSessionCount = entry
     ? entry.sessions.active
     : project.sessions.filter((s) => isActive(s.status)).length;
@@ -510,9 +507,7 @@ function ProjectRow({
     },
     ...activeParen(activeSessionCount, "green", { bold: false }),
     {
-      text: short
-        ? ` · ${subAgentCount}a`
-        : ` · ${subAgentCount} sub-agents`,
+      text: short ? ` · ${subAgentCount}a` : ` · ${subAgentCount} sub-agents`,
       dim: true,
     },
     ...activeParen(activeSubAgentCount, "green", { bold: false }),

--- a/tests/data/providers/kiro.test.ts
+++ b/tests/data/providers/kiro.test.ts
@@ -389,6 +389,49 @@ describe("kiroProvider.discoverSessions", () => {
     expect(tree.projects[0].sessions[0].modelName).toBeNull();
   });
 
+  it("does NOT mark stale sessions waiting even with a .lock present", () => {
+    // A Kiro terminal left open for hours keeps its .lock alive,
+    // but the conversation is idle — same recency rule as Claude's
+    // detectLiveState: no live badge past 30 minutes of mtime.
+    const sessionsDir = join(
+      process.env.HOME ?? "/home/user",
+      ".kiro",
+      "sessions",
+      "cli",
+    );
+    const id = "stale444-dddd-dddd-dddd-dddddddddddd";
+
+    vi.mocked(existsSync).mockReturnValue(true); // .lock exists
+    vi.mocked(readdirSync).mockReturnValue([
+      `${id}.json`,
+      `${id}.jsonl`,
+      `${id}.lock`,
+    ] as unknown as ReturnType<typeof readdirSync>);
+    vi.mocked(statSync).mockImplementation(
+      () =>
+        ({
+          isDirectory: () => false,
+          mtimeMs: NOW - 2 * 60 * 60 * 1000, // 2h idle
+          size: 100,
+        }) as ReturnType<typeof statSync>,
+    );
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).endsWith(".json")) {
+        return JSON.stringify({
+          session_id: id,
+          cwd: "/Users/neo/p",
+          title: "idle",
+          parent_session_id: null,
+        });
+      }
+      return "";
+    });
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const tree = kiroProvider.discoverSessions(mockConfig);
+    expect(tree.projects[0].sessions[0].liveState).toBeNull();
+  });
+
   it("sets liveState=waiting when a .lock file is present", () => {
     const sessionsDir = join(
       process.env.HOME ?? "/home/user",

--- a/tests/data/providers/kiro.test.ts
+++ b/tests/data/providers/kiro.test.ts
@@ -11,9 +11,7 @@ vi.mock("node:fs", () => ({
 const { existsSync, readdirSync, statSync, readFileSync } = await import(
   "node:fs"
 );
-const { kiroProvider } = await import(
-  "../../../src/data/providers/kiro.js"
-);
+const { kiroProvider } = await import("../../../src/data/providers/kiro.js");
 
 const NOW = 1_700_000_000_000;
 
@@ -98,9 +96,7 @@ describe("kiroProvider.discoverSessions", () => {
     expect(tree.projects[0].projectPath).toBe("/Users/neo/myproject");
     expect(tree.projects[0].sessions).toHaveLength(1);
     expect(tree.projects[0].sessions[0].id).toBe(sessionId);
-    expect(tree.projects[0].sessions[0].hideKey).toBe(
-      `myproject/${sessionId}`,
-    );
+    expect(tree.projects[0].sessions[0].hideKey).toBe(`myproject/${sessionId}`);
     expect(tree.projects[0].sessions[0].firstUserPrompt).toBe(
       "Hello world prompt",
     );

--- a/tests/data/providers/kiroIde.test.ts
+++ b/tests/data/providers/kiroIde.test.ts
@@ -1,0 +1,269 @@
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
+  statSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+const { existsSync, readdirSync, statSync, readFileSync } = await import(
+  "node:fs"
+);
+const { kiroIdeProvider, parseKiroIdeActivities } = await import(
+  "../../../src/data/providers/kiro-ide.js"
+);
+
+const NOW = 1_700_000_000_000;
+
+const mockConfig = {
+  refreshIntervalMs: 2000,
+  hiddenSessions: [] as string[],
+  hiddenSubAgents: [] as string[],
+  filterPresets: [[]] as string[][],
+  hiddenProjects: [] as string[],
+};
+
+// The env override points the provider at a fixed root so tests are
+// platform-independent (the macOS default lives under
+// ~/Library/Application Support which doesn't exist on CI Linux).
+const ROOT = join("/tmp", "kiro-ide-test", "workspace-sessions");
+
+function setRoot() {
+  process.env.KIRO_IDE_SESSIONS_DIR = ROOT;
+}
+
+afterEach(() => {
+  vi.resetAllMocks();
+  delete process.env.KIRO_IDE_SESSIONS_DIR;
+});
+
+const WS_B64 = Buffer.from("/Users/neo/myproject").toString("base64");
+
+function sessionJson(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    sessionId: "ide-1111",
+    title: "Refactor the auth flow",
+    workspaceDirectory: "/Users/neo/myproject",
+    selectedModel: "auto",
+    contextUsagePercentage: 12.34,
+    active: false,
+    sessionType: "vibe",
+    history: [
+      {
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "hello." }],
+          id: "m1",
+        },
+      },
+      {
+        message: { role: "assistant", content: "On it.", id: "m2" },
+        executionId: "e1",
+      },
+    ],
+    ...overrides,
+  });
+}
+
+function indexJson() {
+  return JSON.stringify([
+    {
+      sessionId: "ide-1111",
+      title: "Refactor the auth flow",
+      dateCreated: String(NOW - 100_000),
+      workspaceDirectory: "/Users/neo/myproject",
+    },
+  ]);
+}
+
+describe("kiroIdeProvider.isAvailable", () => {
+  it("returns false when the storage root does not exist", () => {
+    setRoot();
+    vi.mocked(existsSync).mockReturnValue(false);
+    expect(kiroIdeProvider.isAvailable()).toBe(false);
+  });
+
+  it("returns true when the root exists", () => {
+    setRoot();
+    vi.mocked(existsSync).mockReturnValue(true);
+    expect(kiroIdeProvider.isAvailable()).toBe(true);
+  });
+});
+
+describe("kiroIdeProvider.discoverSessions", () => {
+  it("discovers a session from the workspace index and groups by workspaceDirectory", () => {
+    setRoot();
+    const wsDir = join(ROOT, WS_B64);
+    const sessFile = join(wsDir, "ide-1111.json");
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === ROOT)
+        return [WS_B64] as unknown as ReturnType<typeof readdirSync>;
+      if (path === wsDir)
+        return ["sessions.json", "ide-1111.json"] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      return [] as unknown as ReturnType<typeof readdirSync>;
+    });
+    vi.mocked(statSync).mockImplementation((p) => {
+      const path = String(p);
+      return {
+        isDirectory: () => !path.endsWith(".json"),
+        mtimeMs: NOW - 60_000,
+        size: 1000,
+      } as ReturnType<typeof statSync>;
+    });
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === join(wsDir, "sessions.json")) return indexJson();
+      if (path === sessFile) return sessionJson();
+      return "";
+    });
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const tree = kiroIdeProvider.discoverSessions(mockConfig);
+    expect(tree.projects).toHaveLength(1);
+    expect(tree.projects[0].name).toBe("myproject");
+    expect(tree.projects[0].projectPath).toBe("/Users/neo/myproject");
+    const s = tree.projects[0].sessions[0];
+    expect(s.id).toBe("ide-1111");
+    expect(s.firstUserPrompt).toBe("Refactor the auth flow");
+    expect(s.modelName).toBe("auto");
+    expect(s.provider).toBe("kiro-ide");
+    expect(s.hideKey).toBe("myproject/ide-1111");
+  });
+
+  it("extracts contextUsage percent (200K assumed window)", () => {
+    setRoot();
+    const wsDir = join(ROOT, WS_B64);
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === ROOT)
+        return [WS_B64] as unknown as ReturnType<typeof readdirSync>;
+      if (path === wsDir)
+        return ["sessions.json", "ide-1111.json"] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      return [] as unknown as ReturnType<typeof readdirSync>;
+    });
+    vi.mocked(statSync).mockImplementation(
+      (p) =>
+        ({
+          isDirectory: () => !String(p).endsWith(".json"),
+          mtimeMs: NOW - 60_000,
+          size: 100,
+        }) as ReturnType<typeof statSync>,
+    );
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path.endsWith("sessions.json")) return indexJson();
+      if (path.endsWith("ide-1111.json"))
+        return sessionJson({ contextUsagePercentage: 42.6 });
+      return "";
+    });
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const tree = kiroIdeProvider.discoverSessions(mockConfig);
+    const ctx = tree.projects[0].sessions[0].contextUsage;
+    expect(ctx?.percent).toBe(43);
+    expect(ctx?.total).toBe(200_000);
+  });
+
+  it("marks hidden sessions but keeps them in the tree", () => {
+    setRoot();
+    const wsDir = join(ROOT, WS_B64);
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === ROOT)
+        return [WS_B64] as unknown as ReturnType<typeof readdirSync>;
+      if (path === wsDir)
+        return ["sessions.json", "ide-1111.json"] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      return [] as unknown as ReturnType<typeof readdirSync>;
+    });
+    vi.mocked(statSync).mockImplementation(
+      (p) =>
+        ({
+          isDirectory: () => !String(p).endsWith(".json"),
+          mtimeMs: NOW - 60_000,
+          size: 100,
+        }) as ReturnType<typeof statSync>,
+    );
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path.endsWith("sessions.json")) return indexJson();
+      if (path.endsWith("ide-1111.json")) return sessionJson();
+      return "";
+    });
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const tree = kiroIdeProvider.discoverSessions({
+      ...mockConfig,
+      hiddenSessions: ["myproject/ide-1111"],
+    });
+    expect(tree.projects[0].sessions[0].hidden).toBe(true);
+    expect(tree.hiddenStats.total).toBe(1);
+  });
+
+  it("returns empty tree when the root is missing", () => {
+    setRoot();
+    vi.mocked(existsSync).mockReturnValue(false);
+    const tree = kiroIdeProvider.discoverSessions(mockConfig);
+    expect(tree.projects).toHaveLength(0);
+    expect(tree.totalCount).toBe(0);
+  });
+});
+
+describe("parseKiroIdeActivities", () => {
+  it("maps history user/assistant entries to activities", () => {
+    const lines = sessionJson().split("\n");
+    const { activities } = parseKiroIdeActivities(lines);
+    expect(activities).toHaveLength(2);
+    expect(activities[0].type).toBe("user");
+    expect(activities[0].detail).toBe("hello.");
+    expect(activities[1].type).toBe("response");
+    expect(activities[1].detail).toBe("On it.");
+  });
+
+  it("handles assistant content as plain string and user content as block array", () => {
+    const json = sessionJson({
+      history: [
+        {
+          message: {
+            role: "user",
+            content: [
+              { type: "text", text: "first line" },
+              { type: "text", text: "second block" },
+            ],
+            id: "m1",
+          },
+        },
+        {
+          message: {
+            role: "assistant",
+            content: "multi\nline\nanswer",
+            id: "m2",
+          },
+        },
+      ],
+    });
+    const { activities } = parseKiroIdeActivities([json]);
+    expect(activities[0].detail).toBe("first line");
+    expect(activities[1].detail).toBe("multi");
+    expect(activities[1].detailBody).toBe("multi\nline\nanswer");
+  });
+
+  it("returns empty result on malformed JSON", () => {
+    const { activities } = parseKiroIdeActivities(["not json at all"]);
+    expect(activities).toHaveLength(0);
+  });
+});

--- a/tests/data/providers/kiroIde.test.ts
+++ b/tests/data/providers/kiroIde.test.ts
@@ -11,9 +11,11 @@ vi.mock("node:fs", () => ({
 const { existsSync, readdirSync, statSync, readFileSync } = await import(
   "node:fs"
 );
-const { kiroIdeProvider, parseKiroIdeActivities } = await import(
-  "../../../src/data/providers/kiro-ide.js"
-);
+const {
+  kiroIdeProvider,
+  parseKiroIdeActivities,
+  clearKiroIdeExecutionCache,
+} = await import("../../../src/data/providers/kiro-ide.js");
 
 const NOW = 1_700_000_000_000;
 
@@ -37,6 +39,7 @@ function setRoot() {
 afterEach(() => {
   vi.resetAllMocks();
   delete process.env.KIRO_IDE_SESSIONS_DIR;
+  clearKiroIdeExecutionCache();
 });
 
 const WS_B64 = Buffer.from("/Users/neo/myproject").toString("base64");
@@ -223,6 +226,157 @@ describe("kiroIdeProvider.discoverSessions", () => {
   });
 });
 
+describe("kiroIdeProvider sub-agents from execution files", () => {
+  // Executions live OUTSIDE workspace-sessions, under sibling
+  // profile dirs: <agent-root>/<profile>/<dir>/<execution-file>.
+  // agent-root = dirname(workspace-sessions).
+  const AGENT_ROOT = join("/tmp", "kiro-ide-test");
+  const PROFILE = join(AGENT_ROOT, "profileA");
+  const EXEC_DIR = join(PROFILE, "dirB");
+  const EXEC_FILE = join(EXEC_DIR, "exechash01");
+
+  function executionJson() {
+    return JSON.stringify({
+      executionId: "exec-1",
+      workflowType: "chat-agent",
+      status: "succeed",
+      startTime: NOW - 300_000,
+      endTime: NOW - 60_000,
+      chatSessionId: "ide-1111",
+      actions: [
+        {
+          type: "AgentExecutionAction",
+          executionId: "exec-1",
+          actionId: "a1",
+          actionType: "invokeSubAgent",
+          actionState: "Success",
+          input: {
+            prompt: "Run the test suite for the launcher project.\nSteps: ...",
+          },
+          output: { response: "## Results\n905 passed", subExecutionId: "sub-9999" },
+        },
+        {
+          type: "AgentExecutionAction",
+          executionId: "exec-1",
+          actionId: "a2",
+          actionType: "runCommand",
+          actionState: "Success",
+          subExecutionId: "sub-9999",
+          input: { command: "which uv" },
+          emittedAt: NOW - 200_000,
+          endTime: NOW - 150_000,
+        },
+        {
+          type: "AgentExecutionAction",
+          executionId: "exec-1",
+          actionId: "a3",
+          actionType: "subagent_response",
+          actionState: "Success",
+          subExecutionId: "sub-9999",
+          emittedAt: NOW - 70_000,
+        },
+      ],
+    });
+  }
+
+  function mockFullLayout(execContent: string) {
+    const wsDir = join(ROOT, WS_B64);
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === ROOT)
+        return [WS_B64] as unknown as ReturnType<typeof readdirSync>;
+      if (path === wsDir)
+        return ["sessions.json", "ide-1111.json"] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      if (path === AGENT_ROOT)
+        return [
+          "workspace-sessions",
+          "profileA",
+          "dev_data",
+          "config.json",
+        ] as unknown as ReturnType<typeof readdirSync>;
+      if (path === PROFILE)
+        return ["indexhash", "dirB"] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      if (path === EXEC_DIR)
+        return ["exechash01"] as unknown as ReturnType<typeof readdirSync>;
+      return [] as unknown as ReturnType<typeof readdirSync>;
+    });
+    vi.mocked(statSync).mockImplementation((p) => {
+      const path = String(p);
+      const isFile =
+        path.endsWith(".json") ||
+        path.endsWith("indexhash") ||
+        path.endsWith("exechash01");
+      return {
+        isDirectory: () => !isFile,
+        mtimeMs: NOW - 60_000,
+        size: 100,
+      } as ReturnType<typeof statSync>;
+    });
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path.endsWith("sessions.json")) return indexJson();
+      if (path.endsWith("ide-1111.json")) return sessionJson();
+      if (path.endsWith("exechash01")) return execContent;
+      if (path.endsWith("indexhash"))
+        return JSON.stringify({ executions: [] });
+      return "";
+    });
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+  }
+
+  it("attaches sub-agents from execution files via chatSessionId", () => {
+    setRoot();
+    mockFullLayout(executionJson());
+
+    const tree = kiroIdeProvider.discoverSessions(mockConfig);
+    const session = tree.projects[0].sessions[0];
+    expect(session.id).toBe("ide-1111");
+    expect(session.subAgents).toHaveLength(1);
+    const sub = session.subAgents[0];
+    expect(sub.id).toBe("sub-9999");
+    expect(sub.taskDescription).toBe(
+      "Run the test suite for the launcher project.",
+    );
+    expect(sub.provider).toBe("kiro-ide");
+    expect(sub.hideKey).toBe("myproject/sub-9999");
+    // mtime from the latest action timestamp (NOW-70s → hot)
+    expect(sub.lastModifiedMs).toBe(NOW - 70_000);
+    expect(sub.status).toBe("hot");
+  });
+
+  it("marks a sub-agent waiting when any of its actions is PendingAction", () => {
+    setRoot();
+    const exec = JSON.parse(executionJson());
+    exec.status = "running";
+    exec.actions[1].actionState = "PendingAction";
+    exec.actions = exec.actions.slice(0, 2); // drop the response action
+    mockFullLayout(JSON.stringify(exec));
+
+    const tree = kiroIdeProvider.discoverSessions(mockConfig);
+    const sub = tree.projects[0].sessions[0].subAgents[0];
+    expect(sub.liveState).toBe("waiting");
+  });
+
+  it("counts sub-agents in totalCount", () => {
+    setRoot();
+    mockFullLayout(executionJson());
+    const tree = kiroIdeProvider.discoverSessions(mockConfig);
+    expect(tree.totalCount).toBe(2); // 1 session + 1 sub-agent
+  });
+
+  it("tolerates execution files that are not JSON", () => {
+    setRoot();
+    mockFullLayout("garbage not json");
+    const tree = kiroIdeProvider.discoverSessions(mockConfig);
+    expect(tree.projects[0].sessions[0].subAgents).toHaveLength(0);
+  });
+});
+
 describe("parseKiroIdeActivities", () => {
   it("maps history user/assistant entries to activities", () => {
     const lines = sessionJson().split("\n");
@@ -265,5 +419,42 @@ describe("parseKiroIdeActivities", () => {
   it("returns empty result on malformed JSON", () => {
     const { activities } = parseKiroIdeActivities(["not json at all"]);
     expect(activities).toHaveLength(0);
+  });
+
+  it("parses execution documents (actions[]) into tool/response activities", () => {
+    const exec = JSON.stringify({
+      executionId: "exec-1",
+      status: "succeed",
+      startTime: 1_700_000_000_000,
+      chatSessionId: "ide-1111",
+      actions: [
+        {
+          actionType: "runCommand",
+          actionState: "Success",
+          input: { command: "npm test" },
+          emittedAt: 1_700_000_100_000,
+        },
+        {
+          actionType: "invokeSubAgent",
+          actionState: "Success",
+          input: { prompt: "Run the suite.\nDetails..." },
+          output: { response: "## 905 passed", subExecutionId: "sub-1" },
+          emittedAt: 1_700_000_050_000,
+        },
+        {
+          actionType: "model",
+          actionState: "Success",
+          emittedAt: 1_700_000_060_000,
+        },
+      ],
+    });
+    const { activities } = parseKiroIdeActivities([exec]);
+    // model action dropped; remaining two sorted by emit time
+    expect(activities).toHaveLength(2);
+    expect(activities[0].label).toBe("Task");
+    expect(activities[0].detail).toBe("Run the suite.");
+    expect(activities[0].detailBody).toBe("## 905 passed");
+    expect(activities[1].label).toBe("Bash");
+    expect(activities[1].detail).toBe("npm test");
   });
 });

--- a/tests/data/providers/kiroIde.test.ts
+++ b/tests/data/providers/kiroIde.test.ts
@@ -362,6 +362,25 @@ describe("kiroIdeProvider sub-agents from execution files", () => {
     expect(sub.liveState).toBe("waiting");
   });
 
+  it("does NOT mark a stale PendingAction sub-agent waiting (IDE closed)", () => {
+    // If the IDE was quit while an approval was parked, the
+    // execution file stays "running"/"PendingAction" forever. The
+    // recency gate (30m on the group's last action) keeps dead
+    // approvals from showing a live badge indefinitely.
+    setRoot();
+    const exec = JSON.parse(executionJson());
+    exec.status = "running";
+    exec.actions[1].actionState = "PendingAction";
+    exec.actions[1].emittedAt = NOW - 2 * 60 * 60 * 1000; // 2h ago
+    exec.actions[1].endTime = undefined;
+    exec.actions = exec.actions.slice(0, 2);
+    mockFullLayout(JSON.stringify(exec));
+
+    const tree = kiroIdeProvider.discoverSessions(mockConfig);
+    const sub = tree.projects[0].sessions[0].subAgents[0];
+    expect(sub.liveState).toBeNull();
+  });
+
   it("counts sub-agents in totalCount", () => {
     setRoot();
     mockFullLayout(executionJson());

--- a/tests/data/providers/kiroIde.test.ts
+++ b/tests/data/providers/kiroIde.test.ts
@@ -440,6 +440,18 @@ describe("parseKiroIdeActivities", () => {
     expect(activities).toHaveLength(0);
   });
 
+  it("stamps history activities with the file mtime from context", () => {
+    // history[] has no timestamps; without the mtime stand-in every
+    // activity lands on epoch and the report's same-day filter
+    // silently drops the whole session.
+    const { activities } = parseKiroIdeActivities([sessionJson()], {
+      mtimeMs: NOW - 5_000,
+    });
+    expect(activities).toHaveLength(2);
+    expect(activities[0].timestamp.getTime()).toBe(NOW - 5_000);
+    expect(activities[1].timestamp.getTime()).toBe(NOW - 5_000);
+  });
+
   it("parses execution documents (actions[]) into tool/response activities", () => {
     const exec = JSON.stringify({
       executionId: "exec-1",

--- a/tests/data/reportGenerator.test.ts
+++ b/tests/data/reportGenerator.test.ts
@@ -79,9 +79,7 @@ describe("generateReport", () => {
     ]);
 
     const result = generateReport(
-      [
-        makeSession({ provider: "claude", modelName: "opus-4.7" }),
-      ],
+      [makeSession({ provider: "claude", modelName: "opus-4.7" })],
       { date: DAY, include: ["response"] },
     );
     expect(result).toMatch(/## myproject \(.+ – .+\) · claude · opus-4\.7/);

--- a/tests/data/sessionHistory.test.ts
+++ b/tests/data/sessionHistory.test.ts
@@ -69,9 +69,7 @@ describe("parseSessionHistory", () => {
     });
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue(kiroLine);
-    const result = parseSessionHistory(
-      "/Users/x/.kiro/sessions/cli/aaa.jsonl",
-    );
+    const result = parseSessionHistory("/Users/x/.kiro/sessions/cli/aaa.jsonl");
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe("user");
     expect(result[0].detail).toBe("Hello Kiro");

--- a/tests/data/sessions.test.ts
+++ b/tests/data/sessions.test.ts
@@ -965,7 +965,7 @@ describe("discoverSessions", () => {
     );
   });
 
-  it("prefers the latest substantial user message over the first", () => {
+  it("shows the latest user message regardless of length (slash commands skipped)", () => {
     const projectsDir = join(
       process.env.HOME ?? "/home/user",
       ".claude",
@@ -1004,7 +1004,7 @@ describe("discoverSessions", () => {
       }),
       JSON.stringify({
         type: "user",
-        message: { content: "ok" }, // trivial follow-up, must NOT win
+        message: { content: "Implement the OAuth2 callback handler" },
       }),
       JSON.stringify({
         type: "user",
@@ -1012,23 +1012,17 @@ describe("discoverSessions", () => {
       }),
       JSON.stringify({
         type: "user",
-        message: { content: "Implement the OAuth2 callback handler" },
-      }),
-      JSON.stringify({
-        type: "user",
-        message: { content: "yes" }, // trivial, must NOT win
+        message: { content: "yes" }, // short but real — WINS (no length filter)
       }),
     ].join("\n");
     vi.mocked(readFileSync).mockReturnValue(lines);
     vi.spyOn(Date, "now").mockReturnValue(NOW);
 
     const tree = discoverSessions(mockConfig);
-    expect(tree.projects[0].sessions[0].firstUserPrompt).toBe(
-      "Implement the OAuth2 callback handler",
-    );
+    expect(tree.projects[0].sessions[0].firstUserPrompt).toBe("yes");
   });
 
-  it("falls back to first prompt when all later messages are trivial or slash commands", () => {
+  it("falls back to first prompt when all later messages are slash commands", () => {
     const projectsDir = join(
       process.env.HOME ?? "/home/user",
       ".claude",
@@ -1067,15 +1061,11 @@ describe("discoverSessions", () => {
       }),
       JSON.stringify({
         type: "user",
-        message: { content: "ok" },
-      }),
-      JSON.stringify({
-        type: "user",
         message: { content: "/clear" },
       }),
       JSON.stringify({
         type: "user",
-        message: { content: "go" },
+        message: { content: "/compact" },
       }),
     ].join("\n");
     vi.mocked(readFileSync).mockReturnValue(lines);


### PR DESCRIPTION
Closes #143 (MVP scope; follow-ups tracked there).

## What

Kiro IDE (VSCode fork) sessions now appear in the tree, merged with Claude Code and Kiro CLI sessions. Live-verified:

\`\`\`
> zipsa  ~/WestbrookAI/zipsa  3 sessions (1) · 0 sub-agents      7m
    #cb1a [hot] Clean State               7m 5% kiro-ide auto
\`\`\`

(3 sessions = Claude 1 + Kiro CLI 1 + Kiro IDE 1, one project row.)

## Design

| Signal | Source |
|---|---|
| Discovery | `workspace-sessions/<b64>/sessions.json` index per workspace |
| Project grouping | `workspaceDirectory` field |
| Row description | `title` |
| Model | `selectedModel` |
| Context gauge | `contextUsagePercentage` (percent only on disk; 200K window assumed for used/total, only percent renders) |
| Recency | session `.json` mtime |
| Activities | `history[]` — user content is a block array, assistant content is a **plain string** |

Platform-aware default root (macOS / Windows / Linux VSCode-fork convention) + `KIRO_IDE_SESSIONS_DIR` override.

## Documented MVP limitations (follow-ups in #143)

- `history[]` has no per-entry timestamps → activities carry an epoch placeholder. Execution files have real timestamps.
- `liveState` stays null — the session file's `active` flag is stale during a run. Executions-index parsing (status `running` + `PendingAction` detection) is the planned liveness source, including a "waiting for approval" badge.
- Sub-agents not surfaced — in the IDE they're actions inside the parent's execution file (`subExecutionId`), not separate files.

## Schema doc

`docs/schemas/kiro-ide-session.md` documents the full layout including the execution-file format the follow-ups will consume (actions[], state transitions, `invokeSubAgent` embedding, the `PendingAction` approval gate) — all empirically verified against a live sub-agent run.

## Tests

9 new (availability, discovery, context, hidden, empty root, history parsing both content shapes, malformed JSON). **665/665 pass.** tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kiro IDE (VSCode fork) as a session provider alongside Claude and Kiro.
  * Sessions from Kiro IDE workspaces are now auto-discovered and displayed in the session tree.
  * Context usage tracking now available for Kiro IDE sessions.
  * Sub-agent activity detection and display for Kiro IDE sessions.

* **Documentation**
  * Added comprehensive schema documentation for Kiro IDE session storage format.

* **Tests**
  * Added extensive test coverage for the new Kiro IDE provider integration.

* **Refactor**
  * Code organization and import statement cleanup across provider modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->