### PR TITLE
fix: address 12 findings from external code review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 20
+        run: npm run lint
+
       - name: Type check
         run: npx tsc --noEmit
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # A tag could be pushed on any commit — including one that
+      # never landed on main. Require the tagged commit to be an
+      # ancestor of origin/main so a stray `git tag vX && git push`
+      # from a feature branch can't trigger a publish.
+      - name: Verify tag commit is on main
+        run: |
+          git fetch origin main
+          if git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Tag commit $GITHUB_SHA is on main."
+          else
+            echo "Tag commit $GITHUB_SHA is NOT on main — refusing to publish."
+            exit 1
+          fi
 
       # The tag is expected to point at a commit on main that already passed CI.
       # Poll the API for that commit's CI run instead of re-running tests here.

--- a/scripts/diff-heap.ts
+++ b/scripts/diff-heap.ts
@@ -18,10 +18,14 @@ interface Snapshot {
   strings: string[];
 }
 
-function countByType(path: string): Map<string, { count: number; size: number }> {
+function countByType(
+  path: string,
+): Map<string, { count: number; size: number }> {
   const raw = JSON.parse(readFileSync(path, "utf-8")) as Snapshot;
   const fields = raw.snapshot.meta.node_fields;
-  const typeEnum = raw.snapshot.meta.node_types[fields.indexOf("type")] as string[];
+  const typeEnum = raw.snapshot.meta.node_types[
+    fields.indexOf("type")
+  ] as string[];
   const fieldCount = fields.length;
   const nameIdx = fields.indexOf("name");
   const typeIdx = fields.indexOf("type");

--- a/scripts/memcheck.ts
+++ b/scripts/memcheck.ts
@@ -37,7 +37,11 @@ for (let i = 1; i <= iterations; i++) {
   parseSessionHistory(session.filePath);
   if (session.projectPath) {
     const today = new Date();
-    const day = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    const day = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+    );
     parseGitCommits(session.projectPath, day);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ const ALL_TYPES = [
   "read",
   "glob",
   "user",
+  "task",
 ];
 
 export interface CliOptions {
@@ -216,6 +217,16 @@ function parseLocalMidnight(dateStr: string): Date | null {
   const [, y, m, d] = match.map(Number);
   const date = new Date(y, m - 1, d);
   if (Number.isNaN(date.getTime())) return null;
+  // Reject impossible dates that JS silently normalizes
+  // (2026-02-31 → Mar 3). Round-trip the components instead of
+  // trusting the constructor.
+  if (
+    date.getFullYear() !== y ||
+    date.getMonth() !== m - 1 ||
+    date.getDate() !== d
+  ) {
+    return null;
+  }
   return date;
 }
 

--- a/src/config/globalConfig.ts
+++ b/src/config/globalConfig.ts
@@ -116,12 +116,12 @@ filterPresets:
 
 # Defaults for \`agenthud report\` (CLI flags still win per-invocation).
 # include: activity types to keep. Types: user, response, bash, edit,
-#          thinking, read, glob.
+#          thinking, read, glob, task.
 # detailLimit: max chars per activity detail (0 = unlimited).
 # withGit: merge git commits from each session's project.
 # format: markdown | json.
 report:
-  include: [user, response, bash, edit, thinking]
+  include: [user, response, bash, edit, thinking, task]
   detailLimit: 120
   withGit: false
   format: markdown

--- a/src/data/providers/claude.ts
+++ b/src/data/providers/claude.ts
@@ -260,8 +260,7 @@ function readFirstUserPrompt(filePath: string): string | null {
     return null;
   }
 
-  const isSubstantial = (text: string): boolean =>
-    !text.trim().startsWith("/");
+  const isSubstantial = (text: string): boolean => !text.trim().startsWith("/");
 
   let first: string | null = null;
   let latestSubstantial: string | null = null;

--- a/src/data/providers/kiro-ide.ts
+++ b/src/data/providers/kiro-ide.ts
@@ -55,11 +55,7 @@ import type {
 } from "../../types/index.js";
 import { ICONS } from "../../types/index.js";
 import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
-import type {
-  ParseContext,
-  ParseResult,
-  SessionProvider,
-} from "./types.js";
+import type { ParseContext, ParseResult, SessionProvider } from "./types.js";
 
 export function getKiroIdeSessionsDir(): string {
   if (process.env.KIRO_IDE_SESSIONS_DIR) {
@@ -307,8 +303,7 @@ function buildSubAgentsBySession(
         // Collect sub-agent groups within this execution.
         for (const action of exec.actions) {
           if (action.actionType !== "invokeSubAgent") continue;
-          const subId =
-            action.output?.subExecutionId ?? action.subExecutionId;
+          const subId = action.output?.subExecutionId ?? action.subExecutionId;
           if (!subId) continue;
 
           const groupActions = exec.actions.filter(
@@ -327,9 +322,7 @@ function buildSubAgentsBySession(
           );
           const running =
             exec.status === "running" &&
-            !groupActions.some(
-              (a) => a.actionType === "subagent_response",
-            );
+            !groupActions.some((a) => a.actionType === "subagent_response");
           // Recency gate (same 30m rule as the other providers): a
           // quit IDE leaves executions parked in "running" /
           // "PendingAction" forever — without the gate those dead

--- a/src/data/providers/kiro.ts
+++ b/src/data/providers/kiro.ts
@@ -232,8 +232,7 @@ function toSessionNode(raw: RawSession, hidden: boolean): SessionNode {
   // rule Claude's detectLiveState uses, so idle-but-open sessions
   // fall back to the time-based [cool]/[cold] badge instead of
   // showing [waiting] forever.
-  const recentlyActive =
-    Date.now() - raw.lastModifiedMs < THIRTY_MINUTES_MS;
+  const recentlyActive = Date.now() - raw.lastModifiedMs < THIRTY_MINUTES_MS;
   const liveState: LiveState | null =
     raw.hasLock && recentlyActive ? "waiting" : null;
   const node: SessionNode = {

--- a/src/data/reportGenerator.ts
+++ b/src/data/reportGenerator.ts
@@ -160,11 +160,20 @@ export function generateReport(
   };
   const blocks: SessionBlock[] = [];
 
+  // Git commits are per-PROJECT, not per-session — fetch them once
+  // per projectPath and attach to the first qualifying session, or
+  // every session of the same project would repeat the same commits.
+  const commitsFetched = new Set<string>();
+
   for (const session of sessions) {
     const allActivities = parseSessionHistory(session.filePath);
     if (!sessionIsOnDate(session, date, allActivities)) continue;
 
-    const commits = withGit ? parseGitCommits(session.projectPath, date) : [];
+    let commits: ActivityEntry[] = [];
+    if (withGit && !commitsFetched.has(session.projectPath)) {
+      commitsFetched.add(session.projectPath);
+      commits = parseGitCommits(session.projectPath, date);
+    }
     const dayActivities = [
       ...allActivities
         .filter((a) => isSameLocalDay(a.timestamp, date))

--- a/src/data/sessionHistory.ts
+++ b/src/data/sessionHistory.ts
@@ -14,22 +14,41 @@
  */
 
 import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname } from "node:path";
 import type { ActivityEntry } from "../types/index.js";
 import { claudeProvider } from "./providers/claude.js";
-import { kiroProvider } from "./providers/kiro.js";
-import { kiroIdeProvider } from "./providers/kiro-ide.js";
+import { getKiroSessionsDir, kiroProvider } from "./providers/kiro.js";
+import {
+  getKiroIdeSessionsDir,
+  kiroIdeProvider,
+} from "./providers/kiro-ide.js";
 import type { SessionProvider } from "./providers/types.js";
 
-// Provider routing by path segment. Each check normalizes
-// backslashes first so Windows paths match too. Order matters only
-// in that Claude is the default fallback.
+const norm = (p: string) => p.replace(/\\/g, "/");
+
+// Provider routing by path. Primary check is a prefix match against
+// each provider's ACTUAL configured root (so KIRO_SESSIONS_DIR /
+// KIRO_IDE_SESSIONS_DIR overrides route correctly — a hardcoded
+// segment check alone would silently send overridden Kiro paths to
+// the Claude parser). The well-known segments stay as fallbacks for
+// nodes constructed before an env change. Claude is the default.
 function providerForPath(filePath: string): SessionProvider {
-  const p = filePath.replace(/\\/g, "/");
-  if (p.includes("/.kiro/sessions/")) return kiroProvider;
-  // Covers both workspace-sessions (session docs) and the profile
-  // dirs (execution docs — sub-agent rows point their filePath at
-  // these). The IDE parser sniffs which document shape it received.
-  if (p.includes("kiro.kiroagent/")) return kiroIdeProvider;
+  const p = norm(filePath);
+  if (
+    p.startsWith(`${norm(getKiroSessionsDir())}/`) ||
+    p.includes("/.kiro/sessions/")
+  ) {
+    return kiroProvider;
+  }
+  // The IDE root env points at workspace-sessions; execution docs
+  // (sub-agent filePaths) live under its PARENT, so prefix on the
+  // parent covers both.
+  if (
+    p.startsWith(`${norm(dirname(getKiroIdeSessionsDir()))}/`) ||
+    p.includes("kiro.kiroagent/")
+  ) {
+    return kiroIdeProvider;
+  }
   return claudeProvider;
 }
 

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -28,6 +28,7 @@
 import type {
   GlobalConfig,
   ProjectNode,
+  SessionNode,
   SessionStatus,
   SessionTree,
 } from "../types/index.js";
@@ -124,8 +125,33 @@ function mergeTrees(trees: SessionTree[]): SessionTree {
     }
   }
 
+  // Re-sort after coalescing. Each provider sorted its own tree,
+  // but concat order inside merged projects (and the project list
+  // itself) would otherwise depend on provider registration order —
+  // a Kiro hot session could render below a Claude cool one. Same
+  // comparators the providers use.
+  const sessionCmp = (a: SessionNode, b: SessionNode) => {
+    if (a.nonInteractive !== b.nonInteractive) {
+      return a.nonInteractive ? 1 : -1;
+    }
+    const d = statusRank[a.status] - statusRank[b.status];
+    if (d !== 0) return d;
+    return b.lastModifiedMs - a.lastModifiedMs;
+  };
+  for (const p of byPath.values()) p.sessions.sort(sessionCmp);
+  for (const p of coldByPath.values()) p.sessions.sort(sessionCmp);
+
+  const projects = [...byPath.values()].sort((a, b) => {
+    const d = statusRank[a.hotness] - statusRank[b.hotness];
+    if (d !== 0) return d;
+    return (
+      (b.sessions[0]?.lastModifiedMs ?? 0) -
+      (a.sessions[0]?.lastModifiedMs ?? 0)
+    );
+  });
+
   return {
-    projects: [...byPath.values()],
+    projects,
     coldProjects: [...coldByPath.values()],
     totalCount: trees.reduce((n, t) => n + t.totalCount, 0),
     timestamp: trees[trees.length - 1].timestamp,

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -51,6 +51,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   unlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -337,9 +338,15 @@ function spawnClaude(opts: SpawnClaudeOpts): Promise<SpawnClaudeResult> {
       cwd: agenthudHomeDir(),
     });
 
+    // Stream to a temp file and rename into place on success. A
+    // direct stream to the final path leaves a PARTIAL summary
+    // behind if the process dies mid-generation (SIGKILL, crash,
+    // power loss) — and a partial file at the cache path is
+    // indistinguishable from a complete summary on the next run.
     let cacheStream: ReturnType<typeof createWriteStream> | null = null;
-    if (opts.cachePath) {
-      cacheStream = createWriteStream(opts.cachePath, { encoding: "utf-8" });
+    const cacheTmpPath = opts.cachePath ? `${opts.cachePath}.tmp` : null;
+    if (cacheTmpPath) {
+      cacheStream = createWriteStream(cacheTmpPath, { encoding: "utf-8" });
       cacheStream.on("error", (err: Error) => {
         process.stderr.write(
           `agenthud: warning: cannot write cache (${err.message})\n`,
@@ -442,16 +449,8 @@ function spawnClaude(opts: SpawnClaudeOpts): Promise<SpawnClaudeResult> {
         lineBuf = "";
       }
       if (opts.streamToStdout) process.stdout.write("\n");
-      cacheStream?.end();
 
       if (code !== 0) {
-        if (opts.cachePath) {
-          try {
-            unlinkSync(opts.cachePath);
-          } catch {
-            // ignore
-          }
-        }
         const combined = (stderrBuf + stdoutErrBuf).toLowerCase();
         if (
           combined.includes("not logged in") ||
@@ -464,7 +463,33 @@ function spawnClaude(opts: SpawnClaudeOpts): Promise<SpawnClaudeResult> {
           );
         }
       }
-      resolve({ code: code ?? 1, text: assembledText, usage });
+
+      // Promote the temp cache into place (success) or discard it
+      // (failure) BEFORE resolving — callers read the cache path
+      // right after this promise settles.
+      const finishCache = () => {
+        if (cacheTmpPath && opts.cachePath) {
+          if (code === 0) {
+            try {
+              renameSync(cacheTmpPath, opts.cachePath);
+            } catch {
+              // best-effort — worst case the cache is just absent
+            }
+          } else {
+            try {
+              unlinkSync(cacheTmpPath);
+            } catch {
+              // ignore
+            }
+          }
+        }
+        resolve({ code: code ?? 1, text: assembledText, usage });
+      };
+      if (cacheStream) {
+        cacheStream.end(() => finishCache());
+      } else {
+        finishCache();
+      }
     });
 
     proc.stdin.end(opts.stdin);
@@ -511,8 +536,6 @@ interface DailyGenResult {
 async function generateDailySummary(
   opts: DailyGenOpts,
 ): Promise<DailyGenResult> {
-  ensureUserPromptFile("daily");
-
   const isToday = isSameLocalDay(opts.date, opts.today);
   const cached = dailyCachePath(opts.date);
   const dateLabel = dateKey(opts.date);
@@ -542,6 +565,11 @@ async function generateDailySummary(
   if (opts.announce) {
     process.stderr.write(`scanning sessions for ${dateLabel}...\n`);
   }
+
+  // Materialize the user-editable prompt template only on the
+  // generate path — a cache hit (early-returned above) is read-only
+  // and shouldn't write files into the user's home directory.
+  ensureUserPromptFile("daily");
 
   const config = loadGlobalConfig();
   const tree = discoverSessions(config);
@@ -723,9 +751,6 @@ export async function runSummary(options: SummaryOptions): Promise<number> {
 export async function runRangeSummary(
   options: RangeSummaryOptions,
 ): Promise<number> {
-  ensureUserPromptFile("daily");
-  ensureUserPromptFile("range");
-
   const dates = enumerateDates(options.from, options.to);
   const fromLabel = dateKey(options.from);
   const toLabel = dateKey(options.to);
@@ -761,12 +786,20 @@ export async function runRangeSummary(
     }
   }
 
-  // Classify cached vs missing for the pre-run report (today is never cached).
+  // Generate path from here on — safe to materialize the
+  // user-editable prompt templates now (the range-cache hit above
+  // returns without writing anything to the home directory).
+  ensureUserPromptFile("daily");
+  ensureUserPromptFile("range");
+
+  // Classify cached vs missing for the pre-run report (today is never
+  // cached; --force treats everything as missing).
   let cachedCount = 0;
   let missingCount = 0;
   for (const d of dates) {
     const isToday = isSameLocalDay(d, options.today);
-    if (!isToday && existsSync(dailyCachePath(d))) cachedCount++;
+    if (!options.force && !isToday && existsSync(dailyCachePath(d)))
+      cachedCount++;
     else missingCount++;
   }
 
@@ -778,14 +811,14 @@ export async function runRangeSummary(
   // Generate dailies sequentially. Confirm just-in-time after scan (when --yes is off).
   // Each prompt comes with concrete context (session/activity/commit counts).
   const dailyMarkdowns: { date: Date; markdown: string }[] = [];
-  let skippedCount = 0;
   for (const d of dates) {
     const label = dateKey(d);
     const isToday = isSameLocalDay(d, options.today);
     process.stderr.write(`\n--- ${label} ---\n`);
 
     const willPrompt =
-      !options.assumeYes && (isToday || !existsSync(dailyCachePath(d)));
+      !options.assumeYes &&
+      (isToday || options.force || !existsSync(dailyCachePath(d)));
     const confirmer = willPrompt
       ? async () => {
           const hint = isToday ? " (today — regenerated every time)" : "";
@@ -796,7 +829,10 @@ export async function runRangeSummary(
     const res = await generateDailySummary({
       date: d,
       today: options.today,
-      force: false,
+      // --force regenerates the dailies too, not just the range
+      // synthesis — otherwise `summary --last 7d --force` would
+      // rebuild the range from stale daily markdown.
+      force: options.force,
       streamToStdout: false,
       announce: true,
       confirmBeforeSpawn: confirmer,
@@ -813,7 +849,6 @@ export async function runRangeSummary(
       // identical at the result-shape level; one neutral message
       // works for both.
       process.stderr.write(`agenthud: ${label} — skipped.\n`);
-      skippedCount++;
       continue;
     }
     if (res.code !== 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,10 +53,31 @@ import { App } from "./ui/App.js";
 import { enterAltScreen, installAltScreenCleanup } from "./utils/altScreen.js";
 import { isLegacyProjectConfig } from "./utils/legacyConfig.js";
 
+// Short-circuit help/version BEFORE touching the config: these are
+// read-only queries and shouldn't create ~/.agenthud/config.yaml as
+// a side effect (loadGlobalConfig materializes the default file).
+const rawArgs = process.argv.slice(2);
+if (
+  rawArgs.includes("--help") ||
+  rawArgs.includes("-h") ||
+  rawArgs[0] === "help"
+) {
+  console.log(getHelp());
+  process.exit(0);
+}
+if (
+  rawArgs.includes("--version") ||
+  rawArgs.includes("-v") ||
+  rawArgs[0] === "version"
+) {
+  console.log(getVersion());
+  process.exit(0);
+}
+
 // Load config up front so parseArgs can layer flags over user defaults
 // (report.* / summary.* keys in ~/.agenthud/config.yaml).
 const globalConfig = loadGlobalConfig();
-const options = parseArgs(process.argv.slice(2), globalConfig);
+const options = parseArgs(rawArgs, globalConfig);
 
 // exit(0) immediately after a large stdout write TRUNCATES piped
 // output — pipe writes are async and the unflushed remainder is

--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -201,7 +201,6 @@ const ActivityRow = memo(function ActivityRow({
   const countSuffix = count && count > 1 ? ` (×${count})` : "";
   const countSuffixWidth = countSuffix.length;
 
-  const prefixWidth = 2 + timestampWidth + iconWidth + 1;
   const labelPart = detail ? `${label}: ` : label;
   const labelWidth = labelPart.length;
   const detailMaxWidth =

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -704,7 +704,10 @@ export function App({
     }
   }, [selectedId, sessionTree]);
 
-  // Reset scroll when filter changes
+  // Reset scroll when filter changes. `filterIndex` isn't read in
+  // the body — it's the trigger. biome's exhaustive-deps flags it,
+  // so spell the intent out for both the linter and the reader.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: filterIndex is the change trigger, not a body dependency
   useEffect(() => {
     setScrollOffset(0);
     setIsLive(true);
@@ -811,38 +814,38 @@ export function App({
     refreshRef.current = refresh;
   }, [refresh]);
 
-  // Auto-refresh in watch mode: fs.watch on macOS/Windows, polling fallback on Linux
+  // Auto-refresh in watch mode. POLLING IS PRIMARY and always on:
+  // it guarantees the tree converges within one interval on every
+  // platform, and it's the only signal that covers non-Claude
+  // providers — fs.watch below only watches the Claude projects
+  // dir, so without the poll, Kiro CLI/IDE changes would never
+  // trigger a refresh on macOS/Windows. fs.watch is a supplemental
+  // accelerator (sub-second updates) where recursive watch works.
   useEffect(() => {
     if (!isWatchMode) return;
 
-    const projectsDir = getProjectsDir();
-    const usePolling = process.platform === "linux" || !existsSync(projectsDir);
-
-    if (usePolling) {
-      const timer = setInterval(
-        () => refreshRef.current(),
-        config.refreshIntervalMs,
-      );
-      return () => clearInterval(timer);
-    }
+    const timer = setInterval(
+      () => refreshRef.current(),
+      config.refreshIntervalMs,
+    );
 
     let debounce: ReturnType<typeof setTimeout> | null = null;
     let watcher: FSWatcher | null = null;
-    try {
-      watcher = watch(projectsDir, { recursive: true }, () => {
-        if (debounce) clearTimeout(debounce);
-        debounce = setTimeout(() => refreshRef.current(), 150);
-      });
-    } catch {
-      // If watch() fails for any reason, fall back to polling
-      const timer = setInterval(
-        () => refreshRef.current(),
-        config.refreshIntervalMs,
-      );
-      return () => clearInterval(timer);
+    const projectsDir = getProjectsDir();
+    if (process.platform !== "linux" && existsSync(projectsDir)) {
+      try {
+        watcher = watch(projectsDir, { recursive: true }, () => {
+          if (debounce) clearTimeout(debounce);
+          debounce = setTimeout(() => refreshRef.current(), 150);
+        });
+      } catch {
+        // Recursive watch unsupported or failed — the poll above
+        // already covers us.
+      }
     }
 
     return () => {
+      clearInterval(timer);
       watcher?.close();
       if (debounce) clearTimeout(debounce);
     };

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -165,12 +165,6 @@ function formatProjectPath(projectPath: string): string {
   return raw;
 }
 
-function truncatePath(path: string, maxWidth: number): string {
-  if (getDisplayWidth(path) <= maxWidth) return path;
-  if (maxWidth < 4) return "";
-  return `...${path.slice(-(maxWidth - 3))}`;
-}
-
 function SessionRow({
   session,
   isSelected,

--- a/src/utils/openInDefaultApp.ts
+++ b/src/utils/openInDefaultApp.ts
@@ -141,7 +141,7 @@ export async function openInDefaultApp(path: string): Promise<void> {
       resolve();
     };
 
-    let child;
+    let child: ReturnType<typeof spawn>;
     try {
       child = spawn(cmd.command, cmd.args, {
         detached: true,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -126,6 +126,15 @@ describe("parseArgs", () => {
       expect(opts.reportDate!.getDate()).toBe(today.getDate());
     });
 
+    it("rejects impossible dates instead of letting JS normalize them", () => {
+      // new Date(2026, 1, 31) silently becomes Mar 3 — the parser
+      // must surface an error, not run the report for a different
+      // day than the user typed. (reportDate still carries the
+      // default; main.ts exits on reportError before using it.)
+      const opts = parseArgs(["report", "--date", "2026-02-31"]);
+      expect(opts.reportError).toBeDefined();
+    });
+
     it("uses default include types when --include not given", () => {
       const opts = parseArgs(["report"]);
       expect(opts.reportInclude).toEqual([
@@ -148,6 +157,7 @@ describe("parseArgs", () => {
         "read",
         "glob",
         "user",
+        "task",
       ]);
     });
 
@@ -536,6 +546,7 @@ describe("parseArgs", () => {
           "read",
           "glob",
           "user",
+          "task",
         ]);
       });
 

--- a/tests/data/providers/kiro.test.ts
+++ b/tests/data/providers/kiro.test.ts
@@ -106,12 +106,6 @@ describe("kiroProvider.discoverSessions", () => {
   });
 
   it("links sub-agents to their parent via parent_session_id", () => {
-    const sessionsDir = join(
-      process.env.HOME ?? "/home/user",
-      ".kiro",
-      "sessions",
-      "cli",
-    );
     const parentId = "bbb22222-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
     const childId = "ccc33333-cccc-cccc-cccc-cccccccccccc";
 
@@ -166,12 +160,6 @@ describe("kiroProvider.discoverSessions", () => {
   });
 
   it("extracts model_id from session_state.rts_model_state.model_info", () => {
-    const sessionsDir = join(
-      process.env.HOME ?? "/home/user",
-      ".kiro",
-      "sessions",
-      "cli",
-    );
     const id = "fff66666-ffff-ffff-ffff-ffffffffffff";
 
     vi.mocked(existsSync).mockReturnValue(true);
@@ -210,12 +198,6 @@ describe("kiroProvider.discoverSessions", () => {
   });
 
   it("shortens concrete model ids (drops vendor prefix, date, version)", () => {
-    const sessionsDir = join(
-      process.env.HOME ?? "/home/user",
-      ".kiro",
-      "sessions",
-      "cli",
-    );
     const id = "ggg77777-gggg-gggg-gggg-gggggggggggg";
 
     vi.mocked(existsSync).mockReturnValue(true);
@@ -256,12 +238,6 @@ describe("kiroProvider.discoverSessions", () => {
   });
 
   it("extracts contextUsage from rts_model_state.context_usage_percentage", () => {
-    const sessionsDir = join(
-      process.env.HOME ?? "/home/user",
-      ".kiro",
-      "sessions",
-      "cli",
-    );
     const id = "iii99999-iiii-iiii-iiii-iiiiiiiiiiii";
 
     vi.mocked(existsSync).mockReturnValue(true);
@@ -305,12 +281,6 @@ describe("kiroProvider.discoverSessions", () => {
   });
 
   it("leaves contextUsage undefined when percent is null", () => {
-    const sessionsDir = join(
-      process.env.HOME ?? "/home/user",
-      ".kiro",
-      "sessions",
-      "cli",
-    );
     const id = "jjjaaaaa-jjjj-jjjj-jjjj-jjjjjjjjjjjj";
 
     vi.mocked(existsSync).mockReturnValue(true);
@@ -350,12 +320,6 @@ describe("kiroProvider.discoverSessions", () => {
   });
 
   it("falls back to null modelName when model_info is missing", () => {
-    const sessionsDir = join(
-      process.env.HOME ?? "/home/user",
-      ".kiro",
-      "sessions",
-      "cli",
-    );
     const id = "hhh88888-hhhh-hhhh-hhhh-hhhhhhhhhhhh";
 
     vi.mocked(existsSync).mockReturnValue(true);
@@ -393,12 +357,6 @@ describe("kiroProvider.discoverSessions", () => {
     // A Kiro terminal left open for hours keeps its .lock alive,
     // but the conversation is idle — same recency rule as Claude's
     // detectLiveState: no live badge past 30 minutes of mtime.
-    const sessionsDir = join(
-      process.env.HOME ?? "/home/user",
-      ".kiro",
-      "sessions",
-      "cli",
-    );
     const id = "stale444-dddd-dddd-dddd-dddddddddddd";
 
     vi.mocked(existsSync).mockReturnValue(true); // .lock exists
@@ -478,12 +436,6 @@ describe("kiroProvider.discoverSessions", () => {
   });
 
   it("respects hiddenSessions config (marks but keeps in tree)", () => {
-    const sessionsDir = join(
-      process.env.HOME ?? "/home/user",
-      ".kiro",
-      "sessions",
-      "cli",
-    );
     const id = "eee55555-eeee-eeee-eeee-eeeeeeeeeeee";
 
     vi.mocked(existsSync).mockReturnValue(true);

--- a/tests/data/providers/kiroIde.test.ts
+++ b/tests/data/providers/kiroIde.test.ts
@@ -11,11 +11,8 @@ vi.mock("node:fs", () => ({
 const { existsSync, readdirSync, statSync, readFileSync } = await import(
   "node:fs"
 );
-const {
-  kiroIdeProvider,
-  parseKiroIdeActivities,
-  clearKiroIdeExecutionCache,
-} = await import("../../../src/data/providers/kiro-ide.js");
+const { kiroIdeProvider, parseKiroIdeActivities, clearKiroIdeExecutionCache } =
+  await import("../../../src/data/providers/kiro-ide.js");
 
 const NOW = 1_700_000_000_000;
 
@@ -233,7 +230,6 @@ describe("kiroIdeProvider sub-agents from execution files", () => {
   const AGENT_ROOT = join("/tmp", "kiro-ide-test");
   const PROFILE = join(AGENT_ROOT, "profileA");
   const EXEC_DIR = join(PROFILE, "dirB");
-  const EXEC_FILE = join(EXEC_DIR, "exechash01");
 
   function executionJson() {
     return JSON.stringify({
@@ -253,7 +249,10 @@ describe("kiroIdeProvider sub-agents from execution files", () => {
           input: {
             prompt: "Run the test suite for the launcher project.\nSteps: ...",
           },
-          output: { response: "## Results\n905 passed", subExecutionId: "sub-9999" },
+          output: {
+            response: "## Results\n905 passed",
+            subExecutionId: "sub-9999",
+          },
         },
         {
           type: "AgentExecutionAction",
@@ -322,8 +321,7 @@ describe("kiroIdeProvider sub-agents from execution files", () => {
       if (path.endsWith("sessions.json")) return indexJson();
       if (path.endsWith("ide-1111.json")) return sessionJson();
       if (path.endsWith("exechash01")) return execContent;
-      if (path.endsWith("indexhash"))
-        return JSON.stringify({ executions: [] });
+      if (path.endsWith("indexhash")) return JSON.stringify({ executions: [] });
       return "";
     });
     vi.spyOn(Date, "now").mockReturnValue(NOW);

--- a/tests/data/reportGenerator.test.ts
+++ b/tests/data/reportGenerator.test.ts
@@ -598,6 +598,39 @@ describe("generateReport", () => {
     );
   });
 
+  it("fetches commits once per project even with multiple sessions", () => {
+    vi.mocked(statSync).mockReturnValue({
+      mtimeMs: new Date("2026-05-14T10:00:00Z").getTime(),
+    } as ReturnType<typeof statSync>);
+    vi.mocked(parseSessionHistory).mockReturnValue([
+      makeActivity({
+        type: "response",
+        icon: "<",
+        label: "Response",
+        detail: "Done.",
+      }),
+    ]);
+    vi.mocked(parseGitCommits).mockReturnValue([
+      {
+        timestamp: new Date(2026, 4, 14, 11, 0),
+        type: "commit",
+        icon: "◆",
+        label: "abc1234",
+        detail: "feat: add report command",
+      },
+    ]);
+
+    // Two sessions in the SAME project — the commit must appear in
+    // the report exactly once, not once per session.
+    const result = generateReport(
+      [makeSession({ id: "s1" }), makeSession({ id: "s2" })],
+      { date: DAY, include: ["response"], withGit: true },
+    );
+    expect(vi.mocked(parseGitCommits)).toHaveBeenCalledTimes(1);
+    const occurrences = result.split("◆ abc1234").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
   it("does not call parseGitCommits when withGit is false", () => {
     vi.mocked(statSync).mockReturnValue({
       mtimeMs: new Date("2026-05-14T10:00:00Z").getTime(),

--- a/tests/data/sessionHistory.test.ts
+++ b/tests/data/sessionHistory.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   readFileSync: vi.fn(),
+  statSync: vi.fn(),
 }));
 
 const { existsSync, readFileSync } = await import("node:fs");
@@ -10,7 +11,10 @@ const { parseSessionHistory } = await import(
   "../../src/data/sessionHistory.js"
 );
 
-afterEach(() => vi.resetAllMocks());
+afterEach(() => {
+  vi.resetAllMocks();
+  delete process.env.KIRO_SESSIONS_DIR;
+});
 
 const makeLines = (count: number) =>
   Array.from({ length: count }, (_, i) =>
@@ -73,6 +77,29 @@ describe("parseSessionHistory", () => {
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe("user");
     expect(result[0].detail).toBe("Hello Kiro");
+  });
+
+  it("routes paths under a KIRO_SESSIONS_DIR override to the Kiro parser", () => {
+    // The override moves the Kiro root to a path that contains
+    // neither `/.kiro/sessions/` nor `kiro.kiroagent/` — a
+    // segment-only check would silently route these to the Claude
+    // parser and the activities would come back empty.
+    process.env.KIRO_SESSIONS_DIR = "/tmp/kiro-alt";
+    const kiroLine = JSON.stringify({
+      version: "v1",
+      kind: "Prompt",
+      data: {
+        message_id: "p1",
+        content: [{ kind: "text", data: "Hello from override" }],
+        meta: { timestamp: 1781220419 },
+      },
+    });
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(kiroLine);
+    const result = parseSessionHistory("/tmp/kiro-alt/aaa.jsonl");
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("user");
+    expect(result[0].detail).toBe("Hello from override");
   });
 
   it("routes non-Kiro paths to the Claude parser (default)", () => {

--- a/tests/data/sessionsOrchestrator.test.ts
+++ b/tests/data/sessionsOrchestrator.test.ts
@@ -88,9 +88,14 @@ describe("discoverSessions orchestrator", () => {
     vi.mocked(statSync).mockImplementation((p) => {
       const path = String(p);
       const isDir = !path.endsWith(".jsonl") && !path.endsWith(".json");
+      // Claude session is OLDER (2h → cool), Kiro session is fresh
+      // (60s → hot). Exercises the post-merge re-sort: the hot Kiro
+      // session must come first inside the merged project even
+      // though the Claude provider ran first.
+      const isClaudeSession = path.endsWith("claude-id.jsonl");
       return {
         isDirectory: () => isDir,
-        mtimeMs: NOW - 60_000,
+        mtimeMs: isClaudeSession ? NOW - 2 * 60 * 60 * 1000 : NOW - 60_000,
         size: 100,
       } as ReturnType<typeof statSync>;
     });
@@ -116,6 +121,10 @@ describe("discoverSessions orchestrator", () => {
     expect(tree.projects).toHaveLength(1);
     expect(tree.projects[0].projectPath).toBe("/shared/proj");
     expect(tree.projects[0].sessions).toHaveLength(2);
+    // Post-merge re-sort: hot (kiro, 60s) before cool (claude, 2h)
+    // regardless of provider registration order.
+    expect(tree.projects[0].sessions[0].id).toBe(kiroId);
+    expect(tree.projects[0].sessions[1].id).toBe("claude-id");
 
     delete process.env.CLAUDE_PROJECTS_DIR;
     delete process.env.KIRO_SESSIONS_DIR;

--- a/tests/data/summaryRunner.test.ts
+++ b/tests/data/summaryRunner.test.ts
@@ -9,6 +9,8 @@ vi.mock("node:fs", () => ({
   writeFileSync: vi.fn(),
   createWriteStream: vi.fn(),
   copyFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  unlinkSync: vi.fn(),
 }));
 vi.mock("node:child_process", () => ({
   spawn: vi.fn(),
@@ -93,7 +95,9 @@ describe("runSummary cache behavior", () => {
     vi.mocked(readFileSync).mockReturnValue("ignored");
     const mockStream = {
       write: vi.fn(),
-      end: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
       on: vi.fn().mockReturnThis(),
     };
     vi.mocked(createWriteStream).mockReturnValue(
@@ -117,7 +121,9 @@ describe("runSummary cache behavior", () => {
     vi.mocked(readFileSync).mockReturnValue("ignored");
     const mockStream = {
       write: vi.fn(),
-      end: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
       on: vi.fn().mockReturnThis(),
     };
     vi.mocked(createWriteStream).mockReturnValue(
@@ -142,7 +148,9 @@ describe("runSummary prompt resolution", () => {
     vi.mocked(existsSync).mockReturnValue(false);
     const mockStream = {
       write: vi.fn(),
-      end: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
       on: vi.fn().mockReturnThis(),
     };
     vi.mocked(createWriteStream).mockReturnValue(
@@ -171,7 +179,9 @@ describe("runSummary prompt resolution", () => {
     vi.mocked(readFileSync).mockReturnValue("user file prompt");
     const mockStream = {
       write: vi.fn(),
-      end: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
       on: vi.fn().mockReturnThis(),
     };
     vi.mocked(createWriteStream).mockReturnValue(
@@ -195,7 +205,9 @@ describe("runSummary prompt resolution", () => {
     vi.mocked(existsSync).mockReturnValue(false);
     const mockStream = {
       write: vi.fn(),
-      end: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
       on: vi.fn().mockReturnThis(),
     };
     vi.mocked(createWriteStream).mockReturnValue(
@@ -223,7 +235,9 @@ describe("runSummary spawn options", () => {
     vi.mocked(existsSync).mockReturnValue(false);
     const mockStream = {
       write: vi.fn(),
-      end: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
       on: vi.fn().mockReturnThis(),
     };
     vi.mocked(createWriteStream).mockReturnValue(
@@ -251,7 +265,9 @@ describe("runSummary cache write error", () => {
     vi.mocked(existsSync).mockReturnValue(false);
 
     const writeFn = vi.fn();
-    const endFn = vi.fn();
+    const endFn = vi.fn((cb?: () => void) => {
+      if (cb) cb();
+    });
     let errorHandler: ((err: Error) => void) | undefined;
     const fakeStream = {
       write: writeFn,

--- a/tests/ui/DetailViewPanel.test.tsx
+++ b/tests/ui/DetailViewPanel.test.tsx
@@ -213,7 +213,7 @@ describe("wrapText", () => {
   });
 
   it("word-wraps long lines independently", () => {
-    const text = "short\n" + "word ".repeat(20).trim();
+    const text = `short\n${"word ".repeat(20).trim()}`;
     const result = wrapText(text, 30);
     expect(result[0]).toBe("short");
     expect(result.length).toBeGreaterThan(2);


### PR DESCRIPTION
External review (Codex) reported 12 findings. **All 12 verified true** before fixing — including reproducing the date normalization (\`2026-02-31\` → Mar 3) and confirming macOS watch mode never refreshes on Kiro activity.

## High

| # | Finding | Fix |
|---|---|---|
| 1 | macOS/Windows watch mode had NO polling — fs.watch only covers the Claude dir, so **Kiro sessions never triggered a refresh** | Poll always runs (primary); fs.watch is a sub-second accelerator |
| 2 | \`KIRO_SESSIONS_DIR\` override routed Kiro activity to the **Claude parser** (segment-match only) | Prefix-match against the providers' actual configured roots |
| 3 | \`summary --last 7d --force\` rebuilt the range from **stale daily caches** | \`options.force\` forwarded to per-day generation |
| 4 | \`task\` include type present in defaults but missing from \`--include all\` and the config template | All three surfaces aligned |
| 5 | No lint gate in CI, and lint was failing | Lint now passes (10 unused vars, implicit any, format); CI gains a lint step |
| 6 | Publish workflow accepted tags on commits **not on main** | \`git merge-base --is-ancestor\` guard before publish |

## Medium

| # | Finding | Fix |
|---|---|---|
| 7 | \`--date 2026-02-31\` accepted as Mar 3 | Component round-trip validation |
| 8 | \`--help\`/\`--version\` created \`~/.agenthud/config.yaml\` | Short-circuit before config load |
| 9 | Cache-hit summaries wrote prompt templates to home dir | Templates materialize only on the generate path |
| 10 | Summary cache streamed directly to final path (partial-cache risk on crash) | Stream to \`.tmp\`, rename on success, before promise resolution |
| 11 | Merged multi-provider projects kept provider registration order | Post-merge re-sort with the providers' own comparators |
| 12 | \`--with-git\` duplicated commits once per session of the same project | Fetch once per projectPath |

## Tests

3 new regression tests (env-override routing, impossible dates, commit dedup) + 1 extended (merge re-sort). **676/676 pass.** lint/tsc/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "task" activity type in reports and CLI.
  * Improved session discovery ordering—sessions now display by recency and status rather than provider order.

* **Bug Fixes**
  * Invalid calendar dates (e.g., 2026-02-31) now properly rejected.
  * Help and version commands no longer create config files as side effects.
  * Enhanced auto-refresh reliability in watch mode with improved polling and file-watching fallback.

* **Optimizations**
  * Git commit timelines now fetched once per project and reused across sessions.
  * Atomic cache writes for better reliability.

* **Improvements**
  * Enhanced project path display—home directory paths shown as `~/…`.
  * Added CI linting step for code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->