### PR TITLE
fix(ci): publish on Node 24 — OIDC trusted publishing needs npm 11.5+

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,13 +66,16 @@ jobs:
           echo "Timed out waiting for CI."
           exit 1
 
-      # Build on the LOWEST supported runtime (engines: >=20) so an
-      # accidental use of a newer-Node API fails here, not on a
-      # user's machine.
-      - name: Use Node.js 20
+      # npm OIDC trusted publishing (id-token + --provenance, no
+      # NPM_TOKEN) requires npm >= 11.5.1, which ships with Node 24+.
+      # Node 20's bundled npm 10.x can't authenticate via OIDC and
+      # the publish 404s. The "does it run on Node 20" guarantee is
+      # the typecheck's job (CI runs tsc against @types/node@^20),
+      # not the publish build's — so publish stays on Node 24.
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
The v0.16.0 publish **404'd** (npm still shows 0.15.0).

Root cause: the round-2 review fix (#146) moved the publish build to Node 20 to match the runtime floor. But npm OIDC trusted publishing (\`id-token: write\` + \`--provenance\`, no \`NPM_TOKEN\`) requires **npm >= 11.5.1**, which only ships with Node 24+. Node 20's bundled npm 10.x can't authenticate via OIDC, so \`npm publish\` returns \`404 PUT https://registry.npmjs.org/agenthud\`.

The "runs on Node 20" guarantee belongs to the **typecheck** (CI runs \`tsc\` against \`@types/node@^20\`), not the publish build. This reverts only the publish job to Node 24; \`@types/node@^20\` and the CI lint/typecheck lanes stay.

After merge: re-tag v0.16.0 on the new main HEAD to retry the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version in the publishing workflow to improve compatibility and ensure reliable package distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->