### PR TITLE
fix(summary): Kiro engine — route prompt+report via stdin, survive EPIPE

### DIFF
--- a/src/data/summaryEngines.ts
+++ b/src/data/summaryEngines.ts
@@ -57,6 +57,13 @@ export interface SummaryEngine {
    *  "file": stdout is progress noise; the text is read from the
    *  `outFile` the caller passed in buildArgs. */
   readonly outputMode: "stream" | "file";
+  /** How the engine receives the prompt.
+   *  "arg" (default): prompt is a positional in buildArgs; the report
+   *  is piped to stdin and the CLI merges the two.
+   *  "stdin": the CLI reads stdin only when given NO positional
+   *  question (Kiro), so the prompt is prepended to the stdin payload
+   *  and kept out of argv. */
+  readonly inputMode?: "arg" | "stdin";
   /** Human label for the "CLI not found" hint. */
   readonly installHint: string;
   buildArgs(ctx: BuildArgsCtx): string[];
@@ -208,11 +215,13 @@ export const kiroEngine: SummaryEngine = {
   name: "kiro",
   command: "kiro-cli",
   outputMode: "stream",
+  // Kiro reads stdin only when no positional question is supplied, so
+  // the prompt rides on stdin (see buildArgs — it adds no positional).
+  inputMode: "stdin",
   installHint: "see https://kiro.dev for the Kiro CLI",
-  buildArgs: ({ prompt, model }) => {
+  buildArgs: ({ model }) => {
     const args = ["chat", "--no-interactive", "--trust-tools="];
     if (model) args.push("--model", model);
-    args.push(prompt);
     return args;
   },
   // Plain text on stdout; strip ANSI so the cached summary is clean.

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -459,7 +459,19 @@ function spawnEngine(opts: SpawnEngineOpts): Promise<SpawnEngineResult> {
       });
     });
 
-    proc.stdin.end(opts.stdin);
+    // "stdin"-mode engines (Kiro) ignore stdin once a positional
+    // question is present, so their prompt is kept out of argv and
+    // prepended to the piped payload here instead.
+    const stdinPayload =
+      engine.inputMode === "stdin"
+        ? `${opts.prompt}\n\n${opts.stdin}`
+        : opts.stdin;
+    // An engine that reads only part of stdin (or none) closes the pipe
+    // early; the in-flight write then surfaces as EPIPE. Swallow it —
+    // the summary still streams from stdout — rather than letting the
+    // unhandled 'error' event abort the whole process.
+    proc.stdin.on("error", () => {});
+    proc.stdin.end(stdinPayload);
   });
 }
 

--- a/tests/data/summaryEngines.test.ts
+++ b/tests/data/summaryEngines.test.ts
@@ -74,12 +74,24 @@ describe("engine arg building", () => {
     ).toContain("-m");
   });
 
-  it("kiro: non-interactive chat, no tools, prompt as input arg", () => {
+  it("kiro: non-interactive chat, no tools, NO positional (prompt goes via stdin)", () => {
     const args = kiroEngine.buildArgs({ prompt: "P" });
     expect(args[0]).toBe("chat");
     expect(args).toContain("--no-interactive");
     expect(args).toContain("--trust-tools=");
-    expect(args[args.length - 1]).toBe("P");
+    // Kiro reads stdin only when no positional question is given; if we
+    // pass the prompt as a positional it ignores the piped report. So
+    // the prompt must NOT appear in argv — it's prepended to stdin.
+    expect(args).not.toContain("P");
+  });
+});
+
+describe("engine inputMode", () => {
+  it("kiro takes its prompt via stdin; claude and codex via argv", () => {
+    expect(kiroEngine.inputMode).toBe("stdin");
+    // arg-mode engines either omit the field or set it to "arg".
+    expect(claudeEngine.inputMode ?? "arg").toBe("arg");
+    expect(codexEngine.inputMode ?? "arg").toBe("arg");
   });
 });
 

--- a/tests/data/summaryRunner.test.ts
+++ b/tests/data/summaryRunner.test.ts
@@ -31,7 +31,13 @@ vi.mock("node:child_process", () => ({
 vi.mock("../../src/data/summaryEngines.js", async (importActual) => {
   const actual =
     await importActual<typeof import("../../src/data/summaryEngines.js")>();
-  return { ...actual, resolveSummaryEngine: () => actual.claudeEngine };
+  // A vi.fn (not a plain arrow) so individual tests can override the
+  // resolved engine via mockReturnValueOnce — e.g. to exercise the
+  // stdin-input Kiro path. clearAllMocks keeps the default impl.
+  return {
+    ...actual,
+    resolveSummaryEngine: vi.fn(() => actual.claudeEngine),
+  };
 });
 
 vi.mock("../../src/data/sessions.js", () => ({
@@ -65,6 +71,9 @@ const {
   copyFileSync,
 } = await import("node:fs");
 const { spawn } = await import("node:child_process");
+const { kiroEngine, resolveSummaryEngine } = await import(
+  "../../src/data/summaryEngines.js"
+);
 const { runSummary } = await import("../../src/data/summaryRunner.js");
 
 beforeEach(() => {
@@ -96,6 +105,42 @@ function mockClaudeProcess(text = "OK", exitCode = 0, stderr = "") {
   proc.stdout = Readable.from([streamJson]);
   proc.stderr = Readable.from([stderr]);
   setImmediate(() => proc.emit("close", exitCode));
+  return proc;
+}
+
+// A Kiro-style process: plain text on stdout (the kiro parser strips
+// ANSI and passes it through), and a capturable stdin. `onStdin`
+// receives each chunk written to the child's stdin. `failStdin` makes
+// the stdin pipe emit an EPIPE on end() — simulating Kiro closing its
+// input early — to prove the runner doesn't crash on it.
+function mockKiroProcess(
+  opts: {
+    onStdin?: (chunk: string) => void;
+    failStdin?: boolean;
+    exitCode?: number;
+  } = {},
+) {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: Readable;
+    stderr: Readable;
+  };
+  proc.stdin = new PassThrough();
+  if (opts.onStdin) {
+    proc.stdin.on("data", (c: Buffer) => opts.onStdin?.(c.toString()));
+  }
+  if (opts.failStdin) {
+    proc.stdin.end = (() => {
+      proc.stdin.emit(
+        "error",
+        Object.assign(new Error("write EPIPE"), { code: "EPIPE" }),
+      );
+      return proc.stdin;
+    }) as typeof proc.stdin.end;
+  }
+  proc.stdout = Readable.from(["kiro summary text"]);
+  proc.stderr = Readable.from([""]);
+  setImmediate(() => proc.emit("close", opts.exitCode ?? 0));
   return proc;
 }
 
@@ -300,6 +345,80 @@ describe("runSummary spawn options", () => {
     const opts = callArgs[2] as { cwd: string };
     expect(opts).toBeDefined();
     expect(opts.cwd).toContain(".agenthud");
+  });
+});
+
+describe("runSummary stdin-input engine (Kiro)", () => {
+  it("sends the prompt AND the report on stdin for a stdin-mode engine", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(resolveSummaryEngine).mockReturnValueOnce(kiroEngine);
+
+    let stdin = "";
+    const mockStream = {
+      write: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
+      on: vi.fn().mockReturnThis(),
+    };
+    vi.mocked(createWriteStream).mockReturnValue(
+      mockStream as unknown as ReturnType<typeof createWriteStream>,
+    );
+    vi.mocked(spawn).mockReturnValue(
+      mockKiroProcess({
+        onStdin: (c) => {
+          stdin += c;
+        },
+      }) as unknown as ReturnType<typeof spawn>,
+    );
+
+    await runSummary({
+      date: new Date(2026, 4, 15),
+      force: false,
+      today: new Date(2026, 4, 15),
+      prompt: "SUMMARIZE THIS",
+    });
+
+    // Kiro ignores a positional question when stdin is piped, so the
+    // instruction prompt has to ride along on stdin with the report.
+    const callArgs = vi.mocked(spawn).mock.calls[0];
+    expect(callArgs[0]).toBe("kiro-cli");
+    expect(callArgs[1]).not.toContain("SUMMARIZE THIS");
+    expect(stdin).toContain("SUMMARIZE THIS");
+    // ...followed by the generated report payload (the mocked report).
+    expect(stdin).toContain("## test");
+  });
+
+  it("does not crash when the engine closes stdin early (EPIPE)", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(resolveSummaryEngine).mockReturnValueOnce(kiroEngine);
+
+    const mockStream = {
+      write: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
+      on: vi.fn().mockReturnThis(),
+    };
+    vi.mocked(createWriteStream).mockReturnValue(
+      mockStream as unknown as ReturnType<typeof createWriteStream>,
+    );
+    vi.mocked(spawn).mockReturnValue(
+      mockKiroProcess({ failStdin: true }) as unknown as ReturnType<
+        typeof spawn
+      >,
+    );
+
+    const code = await runSummary({
+      date: new Date(2026, 4, 15),
+      force: false,
+      today: new Date(2026, 4, 15),
+      prompt: "p",
+    });
+
+    // An unhandled 'error' on the stdin socket would throw and abort the
+    // process; reaching here with a clean exit proves it's swallowed.
+    expect(code).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Problem

The Kiro summary engine shipped in v0.18.0 is unusable. Running
`agenthud summary --engine kiro` produced:

> The activity log appears to be empty — no entries were included after the format description.

…followed by an `EPIPE` crash:

```
Error: write EPIPE
Emitted 'error' event on Socket instance
```

### Root cause

1. **Data never reached the model.** `kiro-cli chat --no-interactive`
   reads piped **stdin only when no positional question is given**. We
   passed the prompt as a positional *and* piped the report on stdin, so
   Kiro answered the positional instruction and ignored the report.
2. **EPIPE crash.** Kiro closed stdin without draining the ~800 KB
   report; the in-flight `proc.stdin.end(report)` write surfaced as an
   unhandled `'error'` event and aborted the process.

## Fix

- Add an `inputMode` to the `SummaryEngine` abstraction.
  - **Kiro** = `"stdin"`: `buildArgs` adds no positional; `spawnEngine`
    prepends the prompt to the piped payload so the model receives
    *instructions + report* as one message.
  - **Claude / Codex** = `"arg"` (default): prompt as positional, report
    on stdin, the CLI merges them (unchanged behavior).
- Attach an `error` handler to the child's stdin so an engine that
  closes its input early degrades gracefully — the summary still streams
  from stdout.

## Tests

- `summaryEngines`: Kiro `buildArgs` omits the positional; `inputMode`
  is `"stdin"` for Kiro and `"arg"` for Claude/Codex.
- `summaryRunner`: a stdin-mode engine receives **prompt + report** on
  stdin; the runner returns `0` instead of crashing when stdin emits
  EPIPE.
- Full suite: 722 passing. tsc + biome clean.

## Live verification

`summary --engine kiro --date 2026-06-10` now produces a real,
substantive summary from that day's activity and exits cleanly (no
"empty log", no EPIPE). Provenance marker + backlink block both land in
the cached file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for stdin-based prompt input mode in summary engines alongside traditional argument-based input.

* **Bug Fixes**
  * Improved error handling to prevent crashes when engines terminate input streams early.

* **Refactor**
  * Updated Kiro engine to use stdin for prompt delivery instead of command-line arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->