### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: [20, 22]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
       # the typecheck's job (CI runs tsc against @types/node@^20),
       # not the publish build's — so publish stays on Node 24.
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -102,7 +102,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: release_notes.md
           generate_release_notes: false

--- a/.github/workflows/smoke-windows.yml
+++ b/.github/workflows/smoke-windows.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'npm'


### PR DESCRIPTION
Closes #153.

## Why

Both v0.18.0 and v0.18.1 publish runs warned:

> Node.js 20 actions are deprecated … `actions/checkout@v4`,
> `actions/setup-node@v4`, `softprops/action-gh-release@v2` … forced to
> Node.js 24 by default starting **June 16th, 2026**.

After that date the Node 20 pins risk breaking CI and the publish flow.

## Change

Bump to the Node 24 majors (each verified `using: node24` in its
`action.yml`):

| Action | From | To |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `softprops/action-gh-release` | `@v2` | `@v3` |

`codecov/codecov-action@v5` is a composite action (no Node 20 runtime) —
left as-is.

`action-gh-release@v3` is, per its release notes, a pure Node 20→24
runtime move with no input changes; our release step uses only
`body_path` + `generate_release_notes`, both unchanged.

## Verification

CI on this PR exercises the bumped `checkout` + `setup-node` across the
full matrix (the publish-only `gh-release@v3` can't run until the next
tag, but the input surface is unchanged).