### PR TITLE
fix(summary): silence Kiro's benign empty---trust-tools warning

### DIFF
--- a/src/data/summaryEngines.ts
+++ b/src/data/summaryEngines.ts
@@ -66,6 +66,10 @@ export interface SummaryEngine {
   readonly inputMode?: "arg" | "stdin";
   /** Human label for the "CLI not found" hint. */
   readonly installHint: string;
+  /** Optional: a benign, known stderr line this engine always prints
+   *  that should be stripped from the passed-through diagnostics. Real
+   *  errors (auth, crashes) are NOT matched and still surface. */
+  readonly stderrFilter?: RegExp;
   buildArgs(ctx: BuildArgsCtx): string[];
   makeParser(): EngineParser;
   isAvailable(): boolean;
@@ -219,6 +223,12 @@ export const kiroEngine: SummaryEngine = {
   // the prompt rides on stdin (see buildArgs — it adds no positional).
   inputMode: "stdin",
   installHint: "see https://kiro.dev for the Kiro CLI",
+  // Kiro itself documents `--trust-tools=` as "trust no tools", yet
+  // still prints a warning that parses the empty value as a custom MCP
+  // tool name. It's harmless noise; strip just that line (ANSI and all)
+  // so real diagnostics stay visible. Matches the whole line by its
+  // stable phrase.
+  stderrFilter: /^.*--trust-tools arg for custom tool.*\r?\n?/m,
   buildArgs: ({ model }) => {
     const args = ["chat", "--no-interactive", "--trust-tools="];
     if (model) args.push("--model", model);

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -387,8 +387,15 @@ function spawnEngine(opts: SpawnEngineOpts): Promise<SpawnEngineResult> {
     });
 
     proc.stderr.on("data", (chunk: Buffer) => {
-      stderrBuf += chunk.toString();
-      process.stderr.write(chunk);
+      const text = chunk.toString();
+      // Keep the raw text for auth-hint detection on close, but strip a
+      // known-benign line (e.g. Kiro's empty-`--trust-tools` warning)
+      // from what the user sees. Real errors aren't matched.
+      stderrBuf += text;
+      const shown = engine.stderrFilter
+        ? text.replace(engine.stderrFilter, "")
+        : text;
+      if (shown) process.stderr.write(shown);
     });
 
     proc.on("close", (code) => {

--- a/tests/data/summaryEngines.test.ts
+++ b/tests/data/summaryEngines.test.ts
@@ -95,6 +95,25 @@ describe("engine inputMode", () => {
   });
 });
 
+describe("engine stderrFilter", () => {
+  it("kiro drops its benign empty-`--trust-tools` warning, nothing else", () => {
+    const f = kiroEngine.stderrFilter;
+    expect(f).toBeInstanceOf(RegExp);
+    const esc = "\u001b";
+    // The real warning is ANSI-wrapped; the stable token is the phrase.
+    const warning = `${esc}[38;5;11mWARNING: ${esc}[0m--trust-tools arg for custom tool ${esc}[0m needs to be prepended with @{MCPSERVERNAME}/\n`;
+    expect(warning.replace(f as RegExp, "")).toBe("");
+    // A real diagnostic (e.g. an auth error) must pass through untouched.
+    const real = "Error: not logged in. Please run /login\n";
+    expect(real.replace(f as RegExp, "")).toBe(real);
+  });
+
+  it("claude and codex do not filter stderr", () => {
+    expect(claudeEngine.stderrFilter).toBeUndefined();
+    expect(codexEngine.stderrFilter).toBeUndefined();
+  });
+});
+
 describe("resolveSummaryEngine", () => {
   it("explicit config name wins and must be available", () => {
     onlyAvailable("codex");

--- a/tests/data/summaryRunner.test.ts
+++ b/tests/data/summaryRunner.test.ts
@@ -118,6 +118,7 @@ function mockKiroProcess(
     onStdin?: (chunk: string) => void;
     failStdin?: boolean;
     exitCode?: number;
+    stderrText?: string;
   } = {},
 ) {
   const proc = new EventEmitter() as EventEmitter & {
@@ -139,7 +140,7 @@ function mockKiroProcess(
     }) as typeof proc.stdin.end;
   }
   proc.stdout = Readable.from(["kiro summary text"]);
-  proc.stderr = Readable.from([""]);
+  proc.stderr = Readable.from([opts.stderrText ?? ""]);
   setImmediate(() => proc.emit("close", opts.exitCode ?? 0));
   return proc;
 }
@@ -387,6 +388,47 @@ describe("runSummary stdin-input engine (Kiro)", () => {
     expect(stdin).toContain("SUMMARIZE THIS");
     // ...followed by the generated report payload (the mocked report).
     expect(stdin).toContain("## test");
+  });
+
+  it("suppresses Kiro's benign --trust-tools warning but keeps real stderr", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(resolveSummaryEngine).mockReturnValueOnce(kiroEngine);
+
+    const mockStream = {
+      write: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
+      on: vi.fn().mockReturnThis(),
+    };
+    vi.mocked(createWriteStream).mockReturnValue(
+      mockStream as unknown as ReturnType<typeof createWriteStream>,
+    );
+    vi.mocked(spawn).mockReturnValue(
+      mockKiroProcess({
+        stderrText:
+          "WARNING: --trust-tools arg for custom tool  needs to be prepended with @{MCPSERVERNAME}/\nreal diagnostic line\n",
+      }) as unknown as ReturnType<typeof spawn>,
+    );
+
+    const stderrChunks: string[] = [];
+    const origErr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((c: string | Uint8Array) => {
+      stderrChunks.push(String(c));
+      return true;
+    }) as typeof process.stderr.write;
+
+    await runSummary({
+      date: new Date(2026, 4, 15),
+      force: false,
+      today: new Date(2026, 4, 15),
+      prompt: "p",
+    });
+
+    process.stderr.write = origErr;
+    const allErr = stderrChunks.join("");
+    expect(allErr).not.toContain("--trust-tools arg for custom tool");
+    expect(allErr).toContain("real diagnostic line");
   });
 
   it("does not crash when the engine closes stdin early (EPIPE)", async () => {


### PR DESCRIPTION
## Problem

Every `agenthud summary --engine kiro` run prints:

```
WARNING: --trust-tools arg for custom tool  needs to be prepended with @{MCPSERVERNAME}/
```

We pass `--trust-tools=` to mean "trust no tools" — which is exactly how
`kiro-cli chat --help` documents it — but Kiro then parses the empty
value as a custom MCP tool name and warns. It's harmless noise on
**stderr** (it never reaches the summary body), but it's confusing.

## Fix

Add an optional per-engine `stderrFilter: RegExp`. In the spawn loop,
the raw stderr is still accumulated for auth-hint detection, but matching
lines are stripped from what's written through to the user. Only Kiro
sets a filter (matching the line by its stable phrase, ANSI and all);
Claude and Codex are untouched.

## Tests

- `summaryEngines`: Kiro's `stderrFilter` removes the ANSI-wrapped
  warning and leaves a real auth-error line intact; Claude/Codex have no
  filter.
- `summaryRunner`: a Kiro run whose child emits the warning + a real
  diagnostic passes only the diagnostic through to `process.stderr`.
- Full suite: 725 passing. tsc + biome clean.

## Live verification

`summary --engine kiro` no longer prints the warning; the progress
ticker, credits line, and `saved to …` all still show.