### PR TITLE
fix(summary): show the file path after the summary, with read/write wording

### DIFF
--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -535,12 +535,15 @@ async function generateDailySummary(
       // model now being requested; otherwise fall through to regenerate
       // so a switched engine/model doesn't serve another's stale text.
       if (cacheMatchesEngine(content, opts.engine.name, opts.model)) {
-        if (opts.announce) {
-          process.stderr.write(`cached summary from ${cached}\n`);
-        }
         if (opts.streamToStdout) {
           process.stdout.write(content);
           if (!content.endsWith("\n")) process.stdout.write("\n");
+        }
+        // Report the path AFTER the content so it's the last thing the
+        // user sees — otherwise a long summary scrolls it off the top
+        // and they can't tell which file to open.
+        if (opts.announce) {
+          process.stderr.write(`\nsummary read from cache: ${cached}\n`);
         }
         return {
           code: 0,
@@ -689,7 +692,7 @@ async function generateDailySummary(
 
   if (opts.announce && result.code === 0) {
     process.stderr.write("\n");
-    process.stderr.write(`saved to ${cached}\n`);
+    process.stderr.write(`summary written to ${cached}\n`);
     if (result.usage) {
       process.stderr.write(`${formatUsage(result.usage)}\n`);
     }
@@ -789,11 +792,12 @@ export async function runRangeSummary(
       // Reuse only when the same engine/model produced it; a switched
       // engine/model falls through to regenerate.
       if (cacheMatchesEngine(content, engine.name, options.model)) {
-        process.stderr.write(`cached range summary from ${rangeCache}\n`);
         if (!options.open) {
           process.stdout.write(content);
           if (!content.endsWith("\n")) process.stdout.write("\n");
         }
+        // Path last, so it survives a long summary scrolling by.
+        process.stderr.write(`\nrange summary read from cache: ${rangeCache}\n`);
         try {
           regenerateIndex(summariesDir());
         } catch {
@@ -940,7 +944,7 @@ export async function runRangeSummary(
   }
 
   process.stderr.write("\n");
-  process.stderr.write(`saved to ${rangeCache}\n`);
+  process.stderr.write(`range summary written to ${rangeCache}\n`);
   if (metaResult.usage) {
     process.stderr.write(`${formatUsage(metaResult.usage)}\n`);
   }

--- a/src/data/summaryRunner.ts
+++ b/src/data/summaryRunner.ts
@@ -797,7 +797,9 @@ export async function runRangeSummary(
           if (!content.endsWith("\n")) process.stdout.write("\n");
         }
         // Path last, so it survives a long summary scrolling by.
-        process.stderr.write(`\nrange summary read from cache: ${rangeCache}\n`);
+        process.stderr.write(
+          `\nrange summary read from cache: ${rangeCache}\n`,
+        );
         try {
           regenerateIndex(summariesDir());
         } catch {

--- a/tests/data/summaryRunner.test.ts
+++ b/tests/data/summaryRunner.test.ts
@@ -179,6 +179,76 @@ describe("runSummary cache behavior", () => {
     expect(vi.mocked(spawn)).not.toHaveBeenCalled();
   });
 
+  it("on a cache hit, reports the file path with cache wording (not 'saved to')", async () => {
+    vi.mocked(existsSync).mockImplementation((p) =>
+      String(p).endsWith("2026-05-14.md"),
+    );
+    vi.mocked(readFileSync).mockReturnValue("cached summary text");
+
+    const origOut = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    const stderrChunks: string[] = [];
+    const origErr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((c: string | Uint8Array) => {
+      stderrChunks.push(String(c));
+      return true;
+    }) as typeof process.stderr.write;
+
+    await runSummary({
+      date: new Date(2026, 4, 14),
+      force: false,
+      today: new Date(2026, 4, 15),
+    });
+
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+    const allErr = stderrChunks.join("");
+    // The path must be reported so the user can open the file, and the
+    // wording must reflect a cache read — nothing was "saved".
+    expect(allErr).toContain("2026-05-14.md");
+    expect(allErr).toMatch(/from cache/i);
+    expect(allErr).not.toContain("saved to");
+  });
+
+  it("on a fresh generation, reports the file path with write wording", async () => {
+    vi.mocked(existsSync).mockReturnValue(false); // no cache → generate
+    const mockStream = {
+      write: vi.fn(),
+      end: vi.fn((cb?: () => void) => {
+        if (cb) cb();
+      }),
+      on: vi.fn().mockReturnThis(),
+    };
+    vi.mocked(createWriteStream).mockReturnValue(
+      mockStream as unknown as ReturnType<typeof createWriteStream>,
+    );
+    vi.mocked(spawn).mockReturnValue(
+      mockClaudeProcess() as unknown as ReturnType<typeof spawn>,
+    );
+
+    const origOut = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    const stderrChunks: string[] = [];
+    const origErr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((c: string | Uint8Array) => {
+      stderrChunks.push(String(c));
+      return true;
+    }) as typeof process.stderr.write;
+
+    await runSummary({
+      date: new Date(2026, 4, 14),
+      force: false,
+      today: new Date(2026, 4, 15),
+    });
+
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+    const allErr = stderrChunks.join("");
+    expect(allErr).toContain("2026-05-14.md");
+    expect(allErr).toMatch(/written to/i);
+    expect(allErr).not.toContain("saved to");
+  });
+
   it("bypasses cache when force is true", async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readFileSync).mockReturnValue("ignored");


### PR DESCRIPTION
## Problem

On a cache hit, `agenthud summary` printed the file path **before** the
summary content. A long summary then scrolled it off the top, so the
user couldn't tell which file was shown or where to open it. The
generation path used "saved to", which is also wrong for a cache read
(nothing was saved).

## Fix

Move the path to the **end** of the output (after the content) for both
daily and range summaries, and use wording that distinguishes a fresh
write from a cache read:

| | before | after |
|---|---|---|
| daily fresh | `saved to <path>` | `summary written to <path>` |
| daily cache | `cached summary from <path>` (at top) | `summary read from cache: <path>` (at end) |
| range fresh | `saved to <path>` | `range summary written to <path>` |
| range cache | `cached range summary from <path>` (at top) | `range summary read from cache: <path>` (at end) |

## Tests

TDD: added two cases in `summaryRunner.test.ts` — a cache hit reports the
path with cache wording (not "saved to"), and a fresh generation reports
it with write wording. Full suite green (727), tsc + biome clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cache hit messaging to display "read from cache" instead of previous wording and to emit streamed content before status messages.
  * Updated successful generation messaging from "saved to" to "written to" for clarity.
  * Fixed output ordering to consistently show file content before status messages for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->