### PR TITLE
fix(liveness): a finished sub-agent reads as done, not [waiting]

### DIFF
--- a/src/data/providers/claude.ts
+++ b/src/data/providers/claude.ts
@@ -208,15 +208,19 @@ function readSessionTail(
   filePath: string,
   mtimeMs: number,
   now: number,
+  isSubAgent = false,
 ): {
   modelName: string | null;
   liveState: LiveState | null;
   contextUsage: { used: number; total: number; percent: number } | null;
 } {
+  // `isSubAgent` is a fixed property of the file's location (the
+  // subagents/ dir), so it never varies for a given path — caching by
+  // (path, mtime) alone stays correct.
   const key = mtimeKey(filePath, mtimeMs);
   const cached = tailCache.get(key);
   if (cached) return cached;
-  const value = computeSessionTail(filePath, mtimeMs, now);
+  const value = computeSessionTail(filePath, mtimeMs, now, isSubAgent);
   tailCache.set(key, value);
   return value;
 }
@@ -225,6 +229,7 @@ function computeSessionTail(
   filePath: string,
   mtimeMs: number,
   now: number,
+  isSubAgent = false,
 ): {
   modelName: string | null;
   liveState: LiveState | null;
@@ -278,7 +283,7 @@ function computeSessionTail(
 
     return {
       modelName,
-      liveState: detectLiveState(tail, mtimeMs, now),
+      liveState: detectLiveState(tail, mtimeMs, now, isSubAgent),
       contextUsage,
     };
   } catch {
@@ -441,6 +446,7 @@ function buildSubAgents(
             filePath,
             stat.mtimeMs,
             Date.now(),
+            true, // sub-agent: a yielded turn means done, not waiting
           );
           return {
             id,

--- a/src/data/sessionLiveness.ts
+++ b/src/data/sessionLiveness.ts
@@ -14,6 +14,11 @@
  * - `AskUserQuestion` is treated as `waiting`. Even though it's
  *   technically a pending tool_use, the ball is in the user's
  *   court — they need to answer before Claude can continue.
+ * - `isSubAgent` suppresses every `waiting` verdict. A sub-agent is
+ *   one-shot: it produces a result and terminates, never pausing for
+ *   user input. A yielded turn (text-only assistant) therefore means
+ *   DONE, not waiting — so it returns `null` (→ time-based badge)
+ *   instead. A pending tool_use still reads as `working` (mid-task).
  * - Returns `null` outside the 30-minute recency window;
  *   upstream falls back to the time-based `[hot/warm/cool/cold]`
  *   ladder.
@@ -46,8 +51,13 @@ export function detectLiveState(
   tailLines: string[],
   mtimeMs: number,
   now: number,
+  isSubAgent = false,
 ): LiveState | null {
   if (now - mtimeMs > THIRTY_MINUTES_MS) return null;
+
+  // A sub-agent never waits on a user, so a yielded turn means it's done,
+  // not waiting → fall back to the time-based badge (null) instead.
+  const yielded: LiveState | null = isSubAgent ? null : "waiting";
 
   for (let i = tailLines.length - 1; i >= 0; i--) {
     const line = tailLines[i];
@@ -64,8 +74,8 @@ export function detectLiveState(
       const content = entry.message?.content;
       const blocks: ContentBlock[] = Array.isArray(content) ? content : [];
       const toolUses = blocks.filter((b) => b && b.type === "tool_use");
-      if (toolUses.length === 0) return "waiting"; // turn yielded (text only)
-      if (toolUses.some((b) => b.name === "AskUserQuestion")) return "waiting";
+      if (toolUses.length === 0) return yielded; // turn yielded (text only)
+      if (toolUses.some((b) => b.name === "AskUserQuestion")) return yielded;
       return "working"; // pending tool_use
     }
 

--- a/tests/data/sessionLiveness.test.ts
+++ b/tests/data/sessionLiveness.test.ts
@@ -137,4 +137,40 @@ describe("detectLiveState", () => {
     ];
     expect(detectLiveState(lines, STALE, NOW)).toBeNull();
   });
+
+  // Sub-agents are one-shot: they produce a result and terminate, never
+  // pausing for user input. So a yielded turn (text-only assistant, or an
+  // AskUserQuestion it can't actually get answered) means DONE, not
+  // "waiting". `isSubAgent` suppresses the waiting verdict; a pending
+  // tool_use still reads as working (the sub-agent is mid-task).
+  describe("isSubAgent", () => {
+    it("a finished sub-agent (text-only end_turn) is null, not 'waiting'", () => {
+      const lines = [
+        j({ type: "user", message: { role: "user", content: "Explore X" } }),
+        j({
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Here is the result." }],
+            stop_reason: "end_turn",
+          },
+        }),
+      ];
+      expect(detectLiveState(lines, RECENT, NOW)).toBe("waiting");
+      expect(detectLiveState(lines, RECENT, NOW, true)).toBeNull();
+    });
+
+    it("a sub-agent with a pending tool_use still reads as 'working'", () => {
+      const lines = [
+        j({
+          type: "assistant",
+          message: {
+            content: [
+              { type: "tool_use", name: "Grep", input: { pattern: "foo" } },
+            ],
+          },
+        }),
+      ];
+      expect(detectLiveState(lines, RECENT, NOW, true)).toBe("working");
+    });
+  });
 });


### PR DESCRIPTION
## Problem

In the live view, a finished sub-agent (e.g. `agent-a014c13e…`, an
Explore agent that produced its result and terminated) showed a
`[waiting]` badge even though it had already returned.

### Root cause

A sub-agent's session tail ends with a **text-only assistant turn**
(`stop_reason: "end_turn"`) once it delivers its result. `detectLiveState`
maps "last assistant is text-only" → `waiting`, which is correct for an
**interactive top-level session** ("Claude yielded, your turn") but wrong
for a **sub-agent**: sub-agents are one-shot and never pause for user
input, so a yielded turn means *done*, not waiting. `buildSubAgents` fed
the sub-agent tail straight through `detectLiveState` with no such
distinction.

## Fix

Add an `isSubAgent` flag to `detectLiveState`. When set, every "waiting"
verdict becomes `null` (so the time-based `[hot/warm/cool/cold]` badge
shows instead); a **pending tool_use still reads as `working`** (the
sub-agent is genuinely mid-task). Threaded through `readSessionTail` so
`buildSubAgents` passes `true`; top-level sessions are unchanged.

## Tests

TDD: two cases in `sessionLiveness.test.ts` — a finished sub-agent
(text-only `end_turn`) is `null` not `waiting`, and a sub-agent with a
pending tool_use still reads `working`. Full suite green (729), tsc +
biome clean.

Verified live against the reported file: `waiting` → `null` after the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session status detection for nested agents to correctly determine live state indicators.

* **Tests**
  * Added test coverage for nested agent status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->