### PR TITLE
fix(ui): keep the tree selection on a visible row (never dangles)

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -541,6 +541,53 @@ export function findParentTarget(
   return flat[idx - 1]?.id ?? currentId;
 }
 
+/**
+ * Keep the tree selection on a row that is actually visible. The
+ * `selectedId` is a stable id, but the flattened view it points into
+ * changes underneath it — a refresh that cools the selected session into
+ * a `... N cold` fold, an expand/collapse, a show-hidden toggle. When the
+ * id falls out of `flat` the cursor vanishes and j/k go silent
+ * (selectedIndex = -1).
+ *
+ * Returns a still-visible id by walking UP from the missing selection
+ * (sub-agent → its session → that session's project header) until it
+ * lands on a row that's in `flat`; failing that, the first visible row
+ * (or null when nothing is visible).
+ */
+export function reconcileSelectedId(
+  selectedId: string | null,
+  flat: SessionNode[],
+  tree: SessionTree,
+): string | null {
+  const inFlat = (id: string | null | undefined): boolean =>
+    id != null && flat.some((row) => row.id === id);
+
+  if (inFlat(selectedId)) return selectedId;
+
+  if (selectedId != null) {
+    const allProjects = [...tree.projects, ...tree.coldProjects];
+    const allSessions = allProjects.flatMap((p) => p.sessions);
+
+    // sub-agent → its containing session
+    const owningSession = allSessions.find((s) =>
+      s.subAgents.some((sa) => sa.id === selectedId),
+    );
+    if (inFlat(owningSession?.id)) return owningSession?.id ?? null;
+
+    // the selected session (or the sub-agent's session) → project header
+    const sessionId = owningSession?.id ?? selectedId;
+    const owningProject = allProjects.find((p) =>
+      p.sessions.some((s) => s.id === sessionId),
+    );
+    const projectSentinel = owningProject
+      ? `__proj-${owningProject.name}__`
+      : null;
+    if (inFlat(projectSentinel)) return projectSentinel;
+  }
+
+  return flat[0]?.id ?? null;
+}
+
 export function initialSelectedId(tree: SessionTree): string | null {
   const firstProject = tree.projects[0];
   if (firstProject) return `__proj-${firstProject.name}__`;
@@ -642,6 +689,17 @@ export function App({
   useEffect(() => {
     allFlatRef.current = allFlat;
   }, [allFlat]);
+
+  // Selection must always point to a visible row. Whenever the flattened
+  // view changes (refresh cooling a session into "... N cold", an
+  // expand/collapse, a show-hidden toggle) and the selected id drops out
+  // of it, snap to the nearest visible ancestor so the cursor never
+  // vanishes and j/k don't go silent (selectedIndex = -1). Converges in
+  // one extra render: the reconciled id is always in `allFlat`.
+  useEffect(() => {
+    const next = reconcileSelectedId(selectedId, allFlat, displayTree);
+    if (next !== selectedId) setSelectedId(next);
+  }, [allFlat, selectedId, displayTree]);
 
   const activitiesRef = useRef<ActivityEntry[]>(activities);
   useEffect(() => {

--- a/tests/ui/reconcileSelectedId.test.ts
+++ b/tests/ui/reconcileSelectedId.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ProjectNode,
+  SessionNode,
+  SessionTree,
+} from "../../src/types/index.js";
+import { reconcileSelectedId } from "../../src/ui/App.js";
+
+const node = (id: string, subAgents: SessionNode[] = []): SessionNode => ({
+  id,
+  hideKey: "",
+  filePath: `/tmp/${id}.jsonl`,
+  projectPath: "/p",
+  projectName: "p",
+  lastModifiedMs: 0,
+  status: "cold",
+  modelName: null,
+  subAgents,
+  nonInteractive: false,
+  firstUserPrompt: null,
+  liveState: null,
+});
+
+const project = (name: string, sessions: SessionNode[]): ProjectNode => ({
+  name,
+  projectPath: `/${name}`,
+  sessions,
+  hotness: "warm",
+});
+
+const tree = (
+  projects: ProjectNode[],
+  coldProjects: ProjectNode[] = [],
+): SessionTree => ({
+  projects,
+  coldProjects,
+  totalCount: 0,
+  timestamp: "",
+  hiddenStats: { total: 0, active: 0 },
+});
+
+// A flattened "visible rows" list — reconcile only checks id membership.
+const flatOf = (...ids: string[]): SessionNode[] => ids.map((id) => node(id));
+
+describe("reconcileSelectedId", () => {
+  it("keeps a selection that is still visible", () => {
+    const t = tree([project("agenthud", [node("s1")])]);
+    const flat = flatOf("__proj-agenthud__", "s1");
+    expect(reconcileSelectedId("s1", flat, t)).toBe("s1");
+  });
+
+  it("falls back to the project header when the selected session cooled out of view", () => {
+    // s1 still exists in the tree but folded under "... N cold"; its
+    // project header is still visible.
+    const t = tree([project("agenthud", [node("s1")])]);
+    const flat = flatOf("__proj-agenthud__", "__cold-sessions-agenthud__");
+    expect(reconcileSelectedId("s1", flat, t)).toBe("__proj-agenthud__");
+  });
+
+  it("falls back to the parent session when a sub-agent disappears", () => {
+    const s = node("s1", [node("a1")]);
+    const t = tree([project("p", [s])]);
+    const flat = flatOf("__proj-p__", "s1"); // sub-agent row gone
+    expect(reconcileSelectedId("a1", flat, t)).toBe("s1");
+  });
+
+  it("walks up to the project when both the sub-agent and its session are hidden", () => {
+    const s = node("s1", [node("a1")]);
+    const t = tree([project("p", [s])]);
+    const flat = flatOf("__proj-p__", "__cold-sessions-p__");
+    expect(reconcileSelectedId("a1", flat, t)).toBe("__proj-p__");
+  });
+
+  it("falls back to the first visible row when the whole branch is gone", () => {
+    // project "p" went fully cold and collapsed under "__cold__".
+    const t = tree([project("active", [node("x")])], [project("p", [node("s1")])]);
+    const flat = flatOf("__proj-active__", "x", "__cold__");
+    expect(reconcileSelectedId("s1", flat, t)).toBe("__proj-active__");
+  });
+
+  it("returns null when the tree is empty", () => {
+    expect(reconcileSelectedId("s1", [], tree([]))).toBeNull();
+  });
+
+  it("leaves a null selection null when nothing is visible", () => {
+    expect(reconcileSelectedId(null, [], tree([]))).toBeNull();
+  });
+});

--- a/tests/ui/reconcileSelectedId.test.ts
+++ b/tests/ui/reconcileSelectedId.test.ts
@@ -73,7 +73,10 @@ describe("reconcileSelectedId", () => {
 
   it("falls back to the first visible row when the whole branch is gone", () => {
     // project "p" went fully cold and collapsed under "__cold__".
-    const t = tree([project("active", [node("x")])], [project("p", [node("s1")])]);
+    const t = tree(
+      [project("active", [node("x")])],
+      [project("p", [node("s1")])],
+    );
     const flat = flatOf("__proj-active__", "x", "__cold__");
     expect(reconcileSelectedId("s1", flat, t)).toBe("__proj-active__");
   });


### PR DESCRIPTION
## Problem

In the live view the selection row could vanish — the tree showed no
highlighted row and the viewer read **"No session selected"**, with j/k
navigation frozen.

### Root cause

A session that cools to `cold` is folded under the `... N cold` sentinel
and **drops out of the flattened nav list** (`flattenSessions`).
Selection is tracked by a stable `selectedId`, but the only recovery in
`refresh()` handled a vanished **sub-agent** (→ its parent session). A
vanished **session** (or its whole project collapsing) left `selectedId`
pointing at a row no longer in `allFlat`, so `selectedIndex` became `-1`:
the cursor disappeared and `j`/`k` went silent.

## Fix

- `reconcileSelectedId(selectedId, flat, tree)` — a pure helper that
  walks **up** from a missing selection (sub-agent → its session →
  that session's project header) to the nearest row still present in
  the flattened view, falling back to the first visible row (or `null`
  when nothing is visible).
- A clamp `useEffect` runs it on every `allFlat` change, so the
  selection self-heals after a refresh (a cooling session), an
  expand/collapse, or a show-hidden toggle. Converges in one extra
  render — the reconciled id is always in `allFlat`.

## Tests

TDD: 7 cases in `tests/ui/reconcileSelectedId.test.ts` (still-visible,
session→project, sub-agent→session, sub-agent→project, whole-branch-gone
→ first row, empty tree). Full suite green (736), tsc + biome clean; the
existing `App.test.tsx` render tests confirm no render loop.