### PR TITLE
fix(viewer): bound history cache + stable refs (fixes long-run freeze)

### DIFF
--- a/src/data/sessionHistory.ts
+++ b/src/data/sessionHistory.ts
@@ -108,12 +108,41 @@ interface HistoryCacheEntry {
   prefixByteLen: number; // [0, prefixByteLen) is the frozen prefix
   prefixActivities: ActivityEntry[];
   tailActivities: ActivityEntry[];
+  // Memoized prefix ++ tail. Returned (by reference) on every cache hit
+  // so a re-parse of an unchanged file yields the SAME array — letting
+  // `setActivities` bail out of re-rendering the viewer.
+  activities: ActivityEntry[];
 }
+
+// Bound the cache so a long-lived watch process doesn't hoard the full
+// parsed activity array of every session ever selected. Without this the
+// map grew unboundedly (600MB+ RSS over hours → GC thrash → the whole
+// TUI freezes, unresponsive to Ctrl+C/q). LRU: keep the N most-recently
+// read sessions; the viewer only shows one at a time.
+export const HISTORY_CACHE_MAX = 8;
+
 const historyCache = new Map<string, HistoryCacheEntry>();
 
 /** Test/maintenance hook: drop the parsed-history cache. */
 export function clearSessionHistoryCache(): void {
   historyCache.clear();
+}
+
+// Insert/refresh an entry at the most-recently-used end, memoizing the
+// concatenated activities once, and evict the oldest beyond the cap.
+function storeEntry(
+  filePath: string,
+  fields: Omit<HistoryCacheEntry, "activities">,
+): ActivityEntry[] {
+  const activities = fields.prefixActivities.concat(fields.tailActivities);
+  historyCache.delete(filePath); // re-insert at the end (LRU recency)
+  historyCache.set(filePath, { ...fields, activities });
+  while (historyCache.size > HISTORY_CACHE_MAX) {
+    const oldest = historyCache.keys().next().value;
+    if (oldest === undefined) break;
+    historyCache.delete(oldest);
+  }
+  return activities;
 }
 
 // Byte offset of the first byte AFTER the first '\n' at index >=
@@ -190,7 +219,9 @@ export function parseSessionHistory(filePath: string): ActivityEntry[] {
 
   const cached = historyCache.get(filePath);
   if (cached && cached.mtimeMs === mtimeMs) {
-    return cached.prefixActivities.concat(cached.tailActivities);
+    historyCache.delete(filePath); // bump LRU recency
+    historyCache.set(filePath, cached);
+    return cached.activities; // stable reference — no re-render churn
   }
 
   const provider = providerForPath(filePath);
@@ -205,14 +236,13 @@ export function parseSessionHistory(filePath: string): ActivityEntry[] {
     }
     const lines = content.trim().split("\n").filter(Boolean);
     const activities = provider.parseActivities(lines, { mtimeMs }).activities;
-    historyCache.set(filePath, {
+    return storeEntry(filePath, {
       mtimeMs,
       size,
       prefixByteLen: size,
       prefixActivities: activities,
       tailActivities: [],
     });
-    return activities;
   }
 
   // Incremental append: file grew and the frozen prefix is intact.
@@ -221,7 +251,7 @@ export function parseSessionHistory(filePath: string): ActivityEntry[] {
   // appended tail bytes, never the whole file.
   if (cached && size > cached.size) {
     const tailBytes = readRange(filePath, cached.prefixByteLen, size);
-    let entry: HistoryCacheEntry;
+    let entry: Omit<HistoryCacheEntry, "activities">;
     if (tailBytes.length <= TAIL_MAX) {
       entry = {
         mtimeMs,
@@ -260,8 +290,7 @@ export function parseSessionHistory(filePath: string): ActivityEntry[] {
         ),
       };
     }
-    historyCache.set(filePath, entry);
-    return entry.prefixActivities.concat(entry.tailActivities);
+    return storeEntry(filePath, entry);
   }
 
   // Full (re)parse: first sight of this file, or it was rewritten.
@@ -288,12 +317,11 @@ export function parseSessionHistory(filePath: string): ActivityEntry[] {
     tailText = buf.subarray(prefixByteLen).toString("utf-8");
   }
   const tailActivities = parseChunk(provider, tailText, mtimeMs);
-  historyCache.set(filePath, {
+  return storeEntry(filePath, {
     mtimeMs,
     size,
     prefixByteLen,
     prefixActivities,
     tailActivities,
   });
-  return prefixActivities.concat(tailActivities);
 }

--- a/tests/data/sessionHistory.test.ts
+++ b/tests/data/sessionHistory.test.ts
@@ -10,9 +10,8 @@ vi.mock("node:fs", () => ({
 }));
 
 const { existsSync, readFileSync, statSync } = await import("node:fs");
-const { parseSessionHistory, clearSessionHistoryCache } = await import(
-  "../../src/data/sessionHistory.js"
-);
+const { parseSessionHistory, clearSessionHistoryCache, HISTORY_CACHE_MAX } =
+  await import("../../src/data/sessionHistory.js");
 
 // Each test sets readFileSync's return; mirror its byte size into
 // statSync so the (mtime, size)-gated incremental cache treats the
@@ -140,5 +139,42 @@ describe("parseSessionHistory", () => {
       "/Users/x/.claude/projects/-foo/bar.jsonl",
     );
     expect(result).toHaveLength(0);
+  });
+});
+
+// The watch process is long-lived and re-parses the selected session on
+// every 2s refresh. Two memory/CPU hazards this guards against (the
+// "agenthud froze after hours, 680MB, no Ctrl+C" report):
+//   1. the cache must return a STABLE reference on a hit, so setActivities
+//      bails out of re-rendering when nothing changed.
+//   2. the cache must be BOUNDED, so it doesn't accumulate every session's
+//      full activity array forever.
+describe("parseSessionHistory cache (memory/CPU safety)", () => {
+  it("returns the same array reference on a cache hit (no churn)", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(makeLines(20));
+    stubStat(makeLines(20));
+    const a = parseSessionHistory("/s.jsonl");
+    const b = parseSessionHistory("/s.jsonl");
+    expect(b).toBe(a);
+  });
+
+  it("bounds the cache with LRU eviction (oldest dropped past the cap)", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(makeLines(5));
+    stubStat(makeLines(5));
+
+    const first = parseSessionHistory("/f0.jsonl");
+    // Fill past the cap with distinct paths → f0 becomes least-recent.
+    for (let i = 1; i <= HISTORY_CACHE_MAX; i++) {
+      parseSessionHistory(`/f${i}.jsonl`);
+    }
+    // f0 was evicted → re-parsing yields a NEW reference.
+    expect(parseSessionHistory("/f0.jsonl")).not.toBe(first);
+  });
+
+  it("keeps a small fixed cap regardless of how many sessions are read", () => {
+    expect(HISTORY_CACHE_MAX).toBeGreaterThan(0);
+    expect(HISTORY_CACHE_MAX).toBeLessThanOrEqual(16);
   });
 });


### PR DESCRIPTION
## Problem

Running agenthud for hours with a busy session selected, it grew to
**~680MB RSS** and **~28% idle CPU**, then **froze** — unresponsive to
Ctrl+C / q (the event loop was starved by memory pressure + render
churn). Reproduced live on a current build (idle process holding 682MB).

### Root cause (`src/data/sessionHistory.ts`)

The watch loop re-parses the selected session every 2s. Two hazards:

1. **Unbounded cache.** `historyCache` cached the full parsed activity
   array of **every session ever selected**, with **no eviction**. Over
   a long session it accumulated hundreds of MB → GC thrash → swap →
   freeze.
2. **New reference on every cache hit.** `parseSessionHistory` returned
   `prefix.concat(tail)` — a fresh array each call. So `setActivities`
   saw a "new" value every 2s and re-rendered the viewer + re-ran the
   full-array filter/merge memos **even when nothing changed** → the
   sustained idle CPU.

## Fix

- **LRU bound** (`HISTORY_CACHE_MAX = 8`): keep only the most-recently
  read sessions (the viewer shows one at a time), evicting the oldest.
- **Stable reference**: memoize `prefix ++ tail` in the cache entry and
  return it by reference on a hit, so an unchanged re-parse yields the
  **same** array and React/`setActivities` bails out of re-rendering.

The viewer already renders only a viewport slice, so per-frame render
cost was bounded; the churn came from the array-reference identity and
the unbounded memory.

## Tests

TDD, added to `tests/data/sessionHistory.test.ts`: cache hit returns the
**same array reference**; the cache is **LRU-bounded** (oldest evicted
past the cap). Full suite green (739), tsc + biome clean.

## Follow-ups (separate, smaller)

- `App.tsx` calls `setActivities` from two effects per refresh — now
  cheap with stable refs, but could be deduped.
- The 30s git `execSync` (gitCommits) could get a timeout / go async.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Session history caching has been optimized to reduce memory consumption and improve performance when accessing the same session history files repeatedly.

* **Tests**
  * New test suite added to validate session history cache behavior, including memory safety verification, reference consistency checks, and cache capacity limit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->