### PR TITLE
fix(viewer): load only a recent window of a session (fixes giant-session freeze)

### DIFF
--- a/src/data/sessionHistory.ts
+++ b/src/data/sessionHistory.ts
@@ -101,6 +101,11 @@ function providerForPath(filePath: string): SessionProvider {
  */
 const TAIL_TARGET = 2 * 1024 * 1024; // aim to keep the tail this size
 const TAIL_MAX = 4 * 1024 * 1024; // advance the prefix past this
+// The viewer is a recent-activity window, not a full-history reader.
+// Never load more than this from a session file: a 100MB+ session read
+// in full spikes ~700MB and freezes the TUI. Older history lives in
+// `report` / `summary`, which truncate and stream.
+const MAX_VIEWER_BYTES = 8 * 1024 * 1024;
 
 interface HistoryCacheEntry {
   mtimeMs: number;
@@ -294,33 +299,45 @@ export function parseSessionHistory(filePath: string): ActivityEntry[] {
   }
 
   // Full (re)parse: first sight of this file, or it was rewritten.
-  // Read as a string; only large files pay a Buffer copy to locate
-  // the prefix/tail split on a byte boundary.
-  let content: string;
-  try {
-    content = readFileSync(filePath, "utf-8");
-  } catch {
-    return [];
+  // For a huge file, read only the last MAX_VIEWER_BYTES (snapped to a
+  // turn boundary) instead of the whole thing — loading a 100MB session
+  // in full is what spiked memory and froze the TUI.
+  let windowStart = 0;
+  let buf: Buffer;
+  if (size > MAX_VIEWER_BYTES) {
+    const rough = readRange(filePath, size - MAX_VIEWER_BYTES, size);
+    const snap = nextTurnBoundary(rough, 0, provider); // drop partial first record
+    buf = rough.subarray(snap);
+    windowStart = size - rough.length + snap;
+  } else {
+    try {
+      buf = Buffer.from(readFileSync(filePath, "utf-8"), "utf-8");
+    } catch {
+      return [];
+    }
   }
 
-  let prefixByteLen = 0;
+  // Within the loaded window, freeze everything but the last TAIL_TARGET
+  // as the prefix so later appends only re-parse the tail.
+  let prefixWithinBuf = 0;
   let prefixActivities: ActivityEntry[] = [];
-  let tailText = content;
-  if (Buffer.byteLength(content, "utf-8") > TAIL_TARGET) {
-    const buf = Buffer.from(content, "utf-8");
-    prefixByteLen = nextTurnBoundary(buf, buf.length - TAIL_TARGET, provider);
+  if (buf.length > TAIL_TARGET) {
+    prefixWithinBuf = nextTurnBoundary(buf, buf.length - TAIL_TARGET, provider);
     prefixActivities = parseChunk(
       provider,
-      buf.subarray(0, prefixByteLen).toString("utf-8"),
+      buf.subarray(0, prefixWithinBuf).toString("utf-8"),
       mtimeMs,
     );
-    tailText = buf.subarray(prefixByteLen).toString("utf-8");
   }
-  const tailActivities = parseChunk(provider, tailText, mtimeMs);
+  const tailActivities = parseChunk(
+    provider,
+    buf.subarray(prefixWithinBuf).toString("utf-8"),
+    mtimeMs,
+  );
   return storeEntry(filePath, {
     mtimeMs,
     size,
-    prefixByteLen,
+    prefixByteLen: windowStart + prefixWithinBuf,
     prefixActivities,
     tailActivities,
   });

--- a/tests/data/sessionHistory.window.test.ts
+++ b/tests/data/sessionHistory.window.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearSessionHistoryCache,
+  parseSessionHistory,
+} from "../../src/data/sessionHistory.js";
+
+// Real-filesystem integration (no node:fs mock): the live viewer must
+// NOT load the whole of a giant session — only a recent window — or it
+// bloats to hundreds of MB and freezes the TUI (a 104MB session spiked
+// ~700MB). Older history is served by report/summary instead.
+describe("parseSessionHistory viewer window", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agenthud-hist-"));
+  });
+  afterEach(() => {
+    clearSessionHistoryCache();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ~1 KB per line so byte-size and line-count track each other.
+  const line = (i: number) =>
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: `entry ${i} ${"x".repeat(900)}` }],
+      },
+      timestamp: new Date(1_700_000_000_000 + i * 1000).toISOString(),
+    });
+
+  const write = (name: string, count: number): string => {
+    const path = join(dir, name);
+    writeFileSync(
+      path,
+      Array.from({ length: count }, (_, i) => line(i)).join("\n"),
+    );
+    return path;
+  };
+
+  it("caps a huge session to a recent window (does not load the whole file)", () => {
+    const total = 12_000; // ~12 MB, well over the viewer window
+    const acts = parseSessionHistory(write("big.jsonl", total));
+
+    // Only the recent window is loaded — far fewer than the full file.
+    expect(acts.length).toBeGreaterThan(0);
+    expect(acts.length).toBeLessThan(total);
+    // ...and it is the MOST RECENT slice: newest present, oldest dropped.
+    expect(acts[acts.length - 1].detail).toContain("entry 11999");
+    expect(acts[0].detail).not.toContain("entry 0 ");
+  });
+
+  it("loads a small session in full", () => {
+    const acts = parseSessionHistory(write("small.jsonl", 50));
+    expect(acts.length).toBe(50);
+    expect(acts[0].detail).toContain("entry 0 ");
+    expect(acts[49].detail).toContain("entry 49 ");
+  });
+});


### PR DESCRIPTION
## Problem

The "leave it open for hours → 600MB+ → frozen, no Ctrl+C/q" freeze.
Root cause: the live viewer **fully read + parsed the selected session**.
Sessions are now huge — the launcher session here is **104MB** — and
reading one whole spiked **~700MB RSS** (~7× the file size) and retained
~200MB, *on every selection*. That swaps / GC-thrashes the process and
starves the event loop.

v0.18.5 (LRU cache + stable refs) stopped unbounded **multi-session**
accumulation, but a **single giant session** still bombed — so it kept
freezing. Confirmed live: both running 0.18.5 instances sat at ~500MB.

## Fix

`parseSessionHistory` now reads **at most the last `MAX_VIEWER_BYTES`
(8MB)** of a session file (snapped to a turn boundary) instead of the
whole thing. The viewer is a recent-activity window with bounded
scrollback; full history is what `report` / `summary` are for (they
truncate + stream). Files **within** the window are untouched, so the
`incremental == full` invariant still holds.

### Measured on the real 104MB session

| | before | after |
|---|---|---|
| transient peak | ~700MB | **40MB** |
| retained | ~200MB | **17MB** |
| activities loaded | ~18,000 | **833** |

(36MB session: 255MB→30MB transient, 69MB→5MB retained.)

## Tests

TDD, new `tests/data/sessionHistory.window.test.ts` (real fs): a huge
session loads only a bounded recent slice (newest present, oldest
dropped); a small session loads in full. Full suite green (741), tsc +
biome clean.

## Follow-up

A session that appends many MB *while selected* can still regrow the
frozen prefix over a very long watch. Bounding that without breaking
`incremental == full` is a separate change (a prefix-activity cap broke
the invariant, so it's deferred).