### PR TITLE
fix(discovery): bounded head/tail reads, not whole-file (completes freeze fix)

### DIFF
--- a/src/data/providers/claude.ts
+++ b/src/data/providers/claude.ts
@@ -32,7 +32,15 @@
  *   `sessionLiveness.ts`.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  statSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import type {
@@ -162,13 +170,77 @@ function readSubAgentInfo(
   return value;
 }
 
+// Discovery touches every session on every refresh. Reading whole files
+// just to peek at the first or last lines slurps 100MB+ sessions
+// repeatedly (the freeze). These read a bounded slice instead.
+const HEAD_READ_BYTES = 16 * 1024; // first line: entrypoint / sub-agent header
+const TAIL_READ_BYTES = 256 * 1024; // recent lines: model / liveState / context
+const PROMPT_TAIL_BYTES = 1024 * 1024; // latest substantial user prompt (title)
+
+// Files at or under the cap are read whole (cheap, and the common case);
+// only an oversized session pays the bounded positioned read. This also
+// keeps the unit tests — which use small in-memory fixtures — on the
+// plain readFileSync path.
+function readHeadText(filePath: string, maxBytes: number): string {
+  let size: number;
+  try {
+    size = statSync(filePath).size;
+  } catch {
+    return "";
+  }
+  if (size <= maxBytes) {
+    try {
+      return readFileSync(filePath, "utf-8");
+    } catch {
+      return "";
+    }
+  }
+  const fd = openSync(filePath, "r");
+  try {
+    const buf = Buffer.alloc(maxBytes);
+    const n = readSync(fd, buf, 0, maxBytes, 0);
+    return buf.toString("utf-8", 0, n);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// Read at most `maxBytes` from the END of the file, dropping a leading
+// partial line when the file is larger than the slice.
+function readTailText(filePath: string, maxBytes: number): string {
+  let size: number;
+  try {
+    size = statSync(filePath).size;
+  } catch {
+    return "";
+  }
+  if (size <= maxBytes) {
+    try {
+      return readFileSync(filePath, "utf-8");
+    } catch {
+      return "";
+    }
+  }
+  const fd = openSync(filePath, "r");
+  try {
+    const buf = Buffer.alloc(maxBytes);
+    const n = readSync(fd, buf, 0, maxBytes, size - maxBytes);
+    let text = buf.toString("utf-8", 0, n);
+    const nl = text.indexOf("\n");
+    if (nl >= 0) text = text.slice(nl + 1); // drop partial first line
+    return text;
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function computeSubAgentInfo(filePath: string): {
   agentId: string | null;
   taskDescription: string | null;
 } {
   if (!existsSync(filePath)) return { agentId: null, taskDescription: null };
   try {
-    const firstLine = readFileSync(filePath, "utf-8").split("\n")[0];
+    const firstLine = readHeadText(filePath, HEAD_READ_BYTES).split("\n")[0];
     if (!firstLine) return { agentId: null, taskDescription: null };
     const entry = JSON.parse(firstLine);
     const agentId = typeof entry.agentId === "string" ? entry.agentId : null;
@@ -238,7 +310,7 @@ function computeSessionTail(
   if (!existsSync(filePath))
     return { modelName: null, liveState: null, contextUsage: null };
   try {
-    const content = readFileSync(filePath, "utf-8");
+    const content = readTailText(filePath, TAIL_READ_BYTES);
     const tail = content.trim().split("\n").filter(Boolean).slice(-50);
 
     let modelName: string | null = null;
@@ -338,9 +410,11 @@ function readFirstUserPrompt(filePath: string, mtimeMs: number): string | null {
 
 function computeFirstUserPrompt(filePath: string): string | null {
   if (!existsSync(filePath)) return null;
+  // The row title is the LATEST substantial user message — always recent,
+  // so a bounded tail read finds it without slurping a huge session.
   let content: string;
   try {
-    content = readFileSync(filePath, "utf-8");
+    content = readTailText(filePath, PROMPT_TAIL_BYTES);
   } catch {
     return null;
   }
@@ -403,7 +477,7 @@ function readEntrypoint(filePath: string, mtimeMs: number): string | null {
 function computeEntrypoint(filePath: string): string | null {
   if (!existsSync(filePath)) return null;
   try {
-    const firstLine = readFileSync(filePath, "utf-8").split("\n")[0];
+    const firstLine = readHeadText(filePath, HEAD_READ_BYTES).split("\n")[0];
     if (!firstLine) return null;
     const entry = JSON.parse(firstLine);
     return typeof entry.entrypoint === "string" ? entry.entrypoint : null;

--- a/tests/data/sessions.largefile.test.ts
+++ b/tests/data/sessions.largefile.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearClaudeFileCaches } from "../../src/data/providers/claude.js";
+import { discoverSessions } from "../../src/data/sessions.js";
+
+// Real-fs integration: discovery reads every session on every refresh.
+// For a huge session it must read only bounded head/tail slices (not the
+// whole file) — slurping 100MB+ files is what bloated RSS and froze the
+// TUI. This locks in that the bounded reads still yield correct model /
+// liveState / title for an oversized file (> the 1MB prompt-tail cap).
+describe("discoverSessions on an oversized session file", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agenthud-big-"));
+    process.env.CLAUDE_PROJECTS_DIR = dir;
+    clearClaudeFileCaches();
+  });
+  afterEach(() => {
+    delete process.env.CLAUDE_PROJECTS_DIR;
+    clearClaudeFileCaches();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("derives model + latest user prompt from a >1MB session via bounded reads", () => {
+    const now = Date.now();
+    const proj = join(dir, "-Users-x-proj");
+    mkdirSync(proj, { recursive: true });
+
+    const pad = "y".repeat(1500);
+    const lines: string[] = [];
+    // Bulk filler to push the file well past the 1MB prompt-tail cap.
+    for (let i = 0; i < 1200; i++) {
+      lines.push(
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: `filler ${i} ${pad}` }] },
+          timestamp: new Date(now - 100_000 + i).toISOString(),
+        }),
+      );
+    }
+    // A recent user message (the row title) and a final assistant turn
+    // carrying the model — both must be found from the file's tail.
+    lines.push(
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "the most recent question" },
+        timestamp: new Date(now - 2000).toISOString(),
+      }),
+    );
+    lines.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          model: "claude-opus-4-20250101",
+          content: [{ type: "text", text: "answer" }],
+          usage: { input_tokens: 5, output_tokens: 5 },
+        },
+        timestamp: new Date(now - 1000).toISOString(),
+      }),
+    );
+    writeFileSync(join(proj, "big-session.jsonl"), `${lines.join("\n")}\n`);
+
+    const tree = discoverSessions({
+      refreshIntervalMs: 2000,
+      hiddenSessions: [],
+      hiddenSubAgents: [],
+      filterPresets: [[]],
+      hiddenProjects: [],
+    });
+
+    const session = tree.projects.flatMap((p) => p.sessions)[0];
+    expect(session).toBeDefined();
+    expect(session.modelName).toContain("opus");
+    expect(session.firstUserPrompt).toContain("the most recent question");
+  });
+});


### PR DESCRIPTION
## Problem

v0.18.6 bounded the **viewer** (selected session), but the freeze
persisted — confirmed live, both 0.18.6 instances still sat at
**~500-890MB**. Root cause #2: the **discovery walk** still read whole
files. `claude.ts` slurped each session fully, on every 2s refresh, just
to peek at:
- the **first line** (`computeEntrypoint`, `computeSubAgentInfo`),
- the **last ~50 lines** (`computeSessionTail` → model / liveState /
  context),
- the **latest user prompt** (`computeFirstUserPrompt` → row title).

With 100MB+ sessions on disk that re-read hundreds of MB per refresh —
so it bloated and froze **even when the giant session wasn't selected**.

## Fix

`readHeadText` / `readTailText` read a bounded slice — first 16KB (head)
or last 256KB / 1MB (tail) — of **oversized** files via a positioned
`readSync`. Files at/under the cap stay on the plain `readFileSync` path
(the common case, and what the small in-memory unit-test fixtures hit, so
no mock churn).

### Measured

`discoverSessions` over the real `~/.claude` (incl. the 104MB session)
× 3 refreshes: hundreds of MB → **25MB transient / 24MB retained** for 33
sessions.

## Tests

New `tests/data/sessions.largefile.test.ts` (real fs): a >1MB session
still yields the correct model + latest-user-prompt title via the
bounded reads. Full suite green (742), tsc + biome clean.

## Together with #161

- #161 (v0.18.6): viewer windowed parse — the **selected** session.
- this: discovery bounded reads — **every** session.

Both whole-file-read paths are now bounded; steady-state memory is flat
regardless of session size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance and memory efficiency when loading large session files by implementing bounded read operations instead of loading entire files into memory.
  * Enhanced reliability of session metadata discovery for oversized session files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->