### PR TITLE
fix(discovery): bound the per-file caches (chronic over-hours leak)

### DIFF
--- a/src/data/providers/claude.ts
+++ b/src/data/providers/claude.ts
@@ -128,23 +128,35 @@ function extractTaskDescription(content: string): string {
 // up to one poll for a file that goes idle without any further
 // write (same mtime → cache hit). Acceptable: a ~2s delay on a
 // hot→cool transition, invisible in practice.
-const tailCache = new Map<
-  string,
-  {
-    modelName: string | null;
-    liveState: LiveState | null;
-    contextUsage: { used: number; total: number; percent: number } | null;
-  }
->();
-const promptCache = new Map<string, string | null>();
-const entrypointCache = new Map<string, string | null>();
-const subAgentInfoCache = new Map<
-  string,
-  { agentId: string | null; taskDescription: string | null }
->();
+// Per-file derived caches. Keyed by path (NOT by path+mtime) with the
+// mtime stored alongside the value, so a session that changes every poll
+// overwrites its one entry instead of accumulating a new key forever —
+// the long-run leak. One entry per file ⇒ bounded by the file count.
+type Memo<V> = Map<string, { mtimeMs: number; value: V }>;
 
-function mtimeKey(filePath: string, mtimeMs: number): string {
-  return `${filePath}:${mtimeMs}`;
+const tailCache: Memo<{
+  modelName: string | null;
+  liveState: LiveState | null;
+  contextUsage: { used: number; total: number; percent: number } | null;
+}> = new Map();
+const promptCache: Memo<string | null> = new Map();
+const entrypointCache: Memo<string | null> = new Map();
+const subAgentInfoCache: Memo<{
+  agentId: string | null;
+  taskDescription: string | null;
+}> = new Map();
+
+function memoByMtime<V>(
+  cache: Memo<V>,
+  filePath: string,
+  mtimeMs: number,
+  compute: () => V,
+): V {
+  const cached = cache.get(filePath);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.value;
+  const value = compute();
+  cache.set(filePath, { mtimeMs, value });
+  return value;
 }
 
 /** Test/maintenance hook: drop all per-file derived caches. */
@@ -155,6 +167,16 @@ export function clearClaudeFileCaches(): void {
   subAgentInfoCache.clear();
 }
 
+/** Test hook: total entries across the per-file caches (bound check). */
+export function claudeFileCacheEntryCount(): number {
+  return (
+    tailCache.size +
+    promptCache.size +
+    entrypointCache.size +
+    subAgentInfoCache.size
+  );
+}
+
 function readSubAgentInfo(
   filePath: string,
   mtimeMs: number,
@@ -162,12 +184,9 @@ function readSubAgentInfo(
   agentId: string | null;
   taskDescription: string | null;
 } {
-  const key = mtimeKey(filePath, mtimeMs);
-  const cached = subAgentInfoCache.get(key);
-  if (cached) return cached;
-  const value = computeSubAgentInfo(filePath);
-  subAgentInfoCache.set(key, value);
-  return value;
+  return memoByMtime(subAgentInfoCache, filePath, mtimeMs, () =>
+    computeSubAgentInfo(filePath),
+  );
 }
 
 // Discovery touches every session on every refresh. Reading whole files
@@ -287,14 +306,10 @@ function readSessionTail(
   contextUsage: { used: number; total: number; percent: number } | null;
 } {
   // `isSubAgent` is a fixed property of the file's location (the
-  // subagents/ dir), so it never varies for a given path — caching by
-  // (path, mtime) alone stays correct.
-  const key = mtimeKey(filePath, mtimeMs);
-  const cached = tailCache.get(key);
-  if (cached) return cached;
-  const value = computeSessionTail(filePath, mtimeMs, now, isSubAgent);
-  tailCache.set(key, value);
-  return value;
+  // subagents/ dir), so it never varies for a given path.
+  return memoByMtime(tailCache, filePath, mtimeMs, () =>
+    computeSessionTail(filePath, mtimeMs, now, isSubAgent),
+  );
 }
 
 function computeSessionTail(
@@ -400,12 +415,9 @@ function isSystemNoise(text: string): boolean {
  * `firstUserPrompt` in `SessionNode` for backwards compatibility.
  */
 function readFirstUserPrompt(filePath: string, mtimeMs: number): string | null {
-  const key = mtimeKey(filePath, mtimeMs);
-  const cached = promptCache.get(key);
-  if (cached !== undefined) return cached;
-  const value = computeFirstUserPrompt(filePath);
-  promptCache.set(key, value);
-  return value;
+  return memoByMtime(promptCache, filePath, mtimeMs, () =>
+    computeFirstUserPrompt(filePath),
+  );
 }
 
 function computeFirstUserPrompt(filePath: string): string | null {
@@ -466,12 +478,9 @@ function computeFirstUserPrompt(filePath: string): string | null {
 }
 
 function readEntrypoint(filePath: string, mtimeMs: number): string | null {
-  const key = mtimeKey(filePath, mtimeMs);
-  const cached = entrypointCache.get(key);
-  if (cached !== undefined) return cached;
-  const value = computeEntrypoint(filePath);
-  entrypointCache.set(key, value);
-  return value;
+  return memoByMtime(entrypointCache, filePath, mtimeMs, () =>
+    computeEntrypoint(filePath),
+  );
 }
 
 function computeEntrypoint(filePath: string): string | null {

--- a/tests/data/sessions.test.ts
+++ b/tests/data/sessions.test.ts
@@ -14,7 +14,7 @@ const { existsSync, readdirSync, statSync, readFileSync } = await import(
 const { discoverSessions, findContainingProject } = await import(
   "../../src/data/sessions.js"
 );
-const { clearClaudeFileCaches } = await import(
+const { clearClaudeFileCaches, claudeFileCacheEntryCount } = await import(
   "../../src/data/providers/claude.js"
 );
 
@@ -44,6 +44,54 @@ describe("discoverSessions", () => {
     expect(tree.projects).toHaveLength(0);
     expect(tree.coldProjects).toHaveLength(0);
     expect(tree.totalCount).toBe(0);
+  });
+
+  it("per-file caches stay bounded as a session's mtime changes each refresh", () => {
+    const projectsDir = join(
+      process.env.HOME ?? "/home/user",
+      ".claude",
+      "projects",
+    );
+    const projectDir = join(projectsDir, "-Users-neo-myproject");
+    vi.mocked(existsSync).mockImplementation(
+      (p) => String(p) === projectsDir || String(p).includes("myproject"),
+    );
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const path = String(p);
+      if (path === projectsDir)
+        return ["-Users-neo-myproject"] as unknown as ReturnType<
+          typeof readdirSync
+        >;
+      if (path === projectDir)
+        return ["s.jsonl"] as unknown as ReturnType<typeof readdirSync>;
+      return [] as unknown as ReturnType<typeof readdirSync>;
+    });
+    vi.mocked(readFileSync).mockReturnValue(
+      `${JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "hi" },
+        timestamp: new Date(NOW).toISOString(),
+      })}\n`,
+    );
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    // Each refresh the file's mtime advances (an active, appending
+    // session). The pre-fix caches keyed by (path, mtime) grew one entry
+    // per refresh forever; now it's one entry per file.
+    for (let i = 0; i < 20; i++) {
+      vi.mocked(statSync).mockImplementation((p) => {
+        const isDir = !String(p).endsWith(".jsonl");
+        return {
+          isDirectory: () => isDir,
+          mtimeMs: NOW - i,
+          size: 80,
+        } as ReturnType<typeof statSync>;
+      });
+      discoverSessions(mockConfig);
+    }
+
+    // 1 file × 4 caches = 4 entries, regardless of how many refreshes ran.
+    expect(claudeFileCacheEntryCount()).toBeLessThanOrEqual(4);
   });
 
   it("discovers a top-level session with no sub-agents", () => {


### PR DESCRIPTION
## Problem

After the acute whole-file-read freeze was fixed (#161/#162), live
monitoring of the running instances showed memory **plateau but with a
slow upward creep** on an actively-watched instance. One source: the
four per-file derived caches in `claude.ts` —

- `tailCache` (model / liveState / context),
- `promptCache` (row title),
- `entrypointCache`,
- `subAgentInfoCache`

— were keyed by `${path}:${mtime}` with **no eviction**, cleared only by
tests. An active session's mtime changes every ~2s poll, so each refresh
added a **new** key and never dropped the old one. The values are small,
so it's a slow leak, but over a multi-hour watch (the "leave it open and
it bloats" report) it accumulates without bound.

## Fix

Key by **path**, storing the mtime alongside the value (a `memoByMtime`
helper). A changed file overwrites its single entry instead of
accumulating a new one. **One entry per file** ⇒ bounded by the file
count, regardless of how long it runs.

## Tests

New case in `sessions.test.ts`: run `discoverSessions` 20× with the
session's mtime advancing each time; assert the total cache entry count
stays ≤ 4 (one file × four caches), not 80. Full suite green (743), tsc +
biome clean.

## Context

Third in the freeze series: #161 (viewer window) + #162 (discovery
bounded reads) killed the acute 700-900MB spikes; this removes the
chronic cache growth over long runs.