### PR TITLE
fix(ui): truncate sub-agent agentId to 6 chars (parent stays 4)

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,7 +29,7 @@ export interface SessionNode {
   status: SessionStatus;
   modelName: string | null; // e.g. "sonnet-4.6", null if not yet known
   subAgents: SessionNode[]; // direct sub-agents of this session
-  agentId?: string; // short agent ID from JSONL (sub-agents only)
+  agentId?: string; // agent ID from JSONL (sub-agents only); a long hex string, truncated for display
   taskDescription?: string; // extracted task summary from first message (sub-agents only)
   nonInteractive: boolean; // true when entrypoint === "sdk-cli"
   firstUserPrompt: string | null; // Display description: latest substantial (≥10 chars, non-slash) user message, falling back to the first natural-language one. Name kept for backwards compat.

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -178,12 +178,14 @@ function SessionRow({
   const model = session.modelName ?? "";
   const isNonInteractive = session.nonInteractive;
 
-  // Name: parent uses short ID (project name is shown on the project header), sub-agent uses agentId or short ID
+  // Name: parent uses a short 6-char ID (project name is shown on the
+  // project header); sub-agent uses its agentId, also truncated to 6 chars
+  // so both read consistently (Claude writes agentId as a long hex string).
   const rawName = isParent
     ? isNonInteractive
-      ? `(#${session.id.slice(0, 4)})`
-      : `#${session.id.slice(0, 4)}`
-    : (session.agentId ?? session.id.slice(0, 8));
+      ? `(#${session.id.slice(0, 6)})`
+      : `#${session.id.slice(0, 6)}`
+    : (session.agentId ?? session.id).slice(0, 6);
 
   // Short ID is now the name itself for parent sessions; no separate suffix needed
   const shortIdDisplay = "";

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -178,13 +178,13 @@ function SessionRow({
   const model = session.modelName ?? "";
   const isNonInteractive = session.nonInteractive;
 
-  // Name: parent uses a short 6-char ID (project name is shown on the
-  // project header); sub-agent uses its agentId, also truncated to 6 chars
-  // so both read consistently (Claude writes agentId as a long hex string).
+  // Name: parent uses a short 4-char ID (project name is shown on the
+  // project header); sub-agent uses its agentId truncated to 6 chars so it
+  // no longer prints the long hex string Claude writes verbatim.
   const rawName = isParent
     ? isNonInteractive
-      ? `(#${session.id.slice(0, 6)})`
-      : `#${session.id.slice(0, 6)}`
+      ? `(#${session.id.slice(0, 4)})`
+      : `#${session.id.slice(0, 4)}`
     : (session.agentId ?? session.id).slice(0, 6);
 
   // Short ID is now the name itself for parent sessions; no separate suffix needed

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -171,7 +171,7 @@ describe("SessionTreePanel", () => {
     expect(frame).toContain("2 cool");
   });
 
-  it("shows a 6-char short session ID for parent sessions with a project name", () => {
+  it("shows a 4-char short session ID for parent sessions with a project name", () => {
     const session = makeSession({ id: "abc12345", projectName: "myproject" });
     const project = makeProject("myproject", [session]);
     const { lastFrame } = render(
@@ -184,8 +184,8 @@ describe("SessionTreePanel", () => {
       />,
     );
     const frame = lastFrame() ?? "";
-    expect(frame).toContain("#abc123"); // 6 chars
-    expect(frame).not.toContain("#abc1234"); // not 7
+    expect(frame).toContain("#abc1"); // 4 chars
+    expect(frame).not.toContain("#abc12"); // not 5
   });
 
   it("shows project path on the project header row (not the session row)", () => {

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -171,7 +171,7 @@ describe("SessionTreePanel", () => {
     expect(frame).toContain("2 cool");
   });
 
-  it("shows short session ID for parent sessions with a project name", () => {
+  it("shows a 6-char short session ID for parent sessions with a project name", () => {
     const session = makeSession({ id: "abc12345", projectName: "myproject" });
     const project = makeProject("myproject", [session]);
     const { lastFrame } = render(
@@ -183,7 +183,9 @@ describe("SessionTreePanel", () => {
         width={80}
       />,
     );
-    expect(lastFrame()).toContain("#abc1");
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("#abc123"); // 6 chars
+    expect(frame).not.toContain("#abc1234"); // not 7
   });
 
   it("shows project path on the project header row (not the session row)", () => {
@@ -230,15 +232,15 @@ describe("SessionTreePanel", () => {
     expect(lastFrame()).not.toContain("#chil");
   });
 
-  it("shows agentId as name for sub-agents", () => {
+  it("shows a 6-char truncated agentId as name for sub-agents", () => {
     const session = makeSession({
       subAgents: [
         makeSession({
-          id: "agent-a26daaf",
+          id: "agent-abce044562ca241ed",
           projectName: "",
           status: "hot",
           subAgents: [],
-          agentId: "a26daaf",
+          agentId: "abce044562ca241ed", // 17-char hex, as Claude writes it
           taskDescription: "Task 3: Create .env.example",
         }),
       ],
@@ -254,7 +256,8 @@ describe("SessionTreePanel", () => {
       />,
     );
     const frame = lastFrame() ?? "";
-    expect(frame).toContain("a26daaf");
+    expect(frame).toContain("abce04"); // first 6 chars
+    expect(frame).not.toContain("abce044562ca241ed"); // not the full id
     expect(frame).toContain("Task 3: Create .env.example");
   });
 


### PR DESCRIPTION
## Problem

Sub-agent rows rendered their full `agentId` from the JSONL — which Claude Code now writes as a long 17-char hex string (e.g. `abce044562ca241ed`) — while parent rows showed a tidy 4-char ID (`#abc1`). The sub-agent ID read like an unbroken UUID.

## Fix

Truncate the sub-agent `agentId` to **6 chars** in `SessionRow` (`src/ui/SessionTreePanel.tsx`). Parent sessions keep their existing **4-char** short ID. Also refreshed the stale `agentId` type comment (`// short agent ID` — no longer short).

## Test

TDD: updated `SessionTreePanel` tests to assert parent = 4 chars and sub-agent = 6-char truncation (no full id). 743/743 tests pass, `tsc --noEmit` clean, `biome check` clean.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)