### PR TITLE
fix(ui): bound widthCache to stop unbounded memory growth

### DIFF
--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -9,9 +9,13 @@
  * - `getDisplayWidth` is memoized across calls. Without
  *   memoization, repeated `stringWidth` invocations on the same
  *   string across renders cost ~17% CPU on a 60-row tree
- *   (measured in v0.9.0). The cache survives renders and is
- *   stable across the process lifetime — no invalidation needed
- *   since string display width is a pure function.
+ *   (measured in v0.9.0). The cache is bounded (`WIDTH_CACHE_MAX`,
+ *   FIFO eviction) because some callers pass per-render dynamic
+ *   strings (elapsed time, context %, timestamps) that never recur,
+ *   so an unbounded map grew without limit over long watch sessions.
+ *   No staleness invalidation is needed since display width is a
+ *   pure function; eviction only caps memory, and an evicted hot
+ *   string recomputes on its next miss.
  *
  * Gotcha:
  * - `THIRTY_MINUTES_MS` and `ONE_HOUR_MS` are imported by

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -171,11 +171,29 @@ export function truncateByWidth(text: string, maxWidth: number): string {
 // second during re-renders. CPU profiling showed it at ~17% of total runtime.
 import stringWidth from "string-width";
 
+// Bounded so a long-running watch session can't accumulate one entry per
+// dynamic string forever — several callers pass per-render strings (elapsed
+// time, context %, timestamps) that never produce a cache hit, so an
+// unbounded map grows without limit. Cap evicts the oldest insertion; hot
+// recurring strings (icons, single chars, stable line parts) re-insert on
+// the rare miss, so the CPU win is preserved at a ~0.5 MB ceiling.
+export const WIDTH_CACHE_MAX = 2000;
 const widthCache = new Map<string, number>();
 export function getDisplayWidth(s: string): number {
   const cached = widthCache.get(s);
   if (cached !== undefined) return cached;
   const w = stringWidth(s);
+  if (widthCache.size >= WIDTH_CACHE_MAX) {
+    // Evict the oldest insertion (Map preserves insertion order). Hot
+    // recurring strings simply re-insert on their next miss.
+    const oldest = widthCache.keys().next().value;
+    if (oldest !== undefined) widthCache.delete(oldest);
+  }
   widthCache.set(s, w);
   return w;
+}
+
+/** Test hook: current number of cached entries. */
+export function widthCacheSize(): number {
+  return widthCache.size;
 }

--- a/tests/ui/constants.test.ts
+++ b/tests/ui/constants.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_FALLBACK_WIDTH,
+  getDisplayWidth,
   getTerminalWidth,
   MAX_TERMINAL_WIDTH,
   MIN_TERMINAL_WIDTH,
+  WIDTH_CACHE_MAX,
+  widthCacheSize,
 } from "../../src/ui/constants.js";
 
 describe("getTerminalWidth", () => {
@@ -114,5 +117,30 @@ describe("getTerminalWidth", () => {
 
       expect(width).toBe(80);
     });
+  });
+});
+
+describe("getDisplayWidth width cache", () => {
+  it("returns accurate display widths (ASCII, empty, emoji, CJK)", () => {
+    expect(getDisplayWidth("abc")).toBe(3);
+    expect(getDisplayWidth("")).toBe(0);
+    expect(getDisplayWidth("👍")).toBe(2);
+    expect(getDisplayWidth("한글")).toBe(4); // wide CJK = 2 cells each
+  });
+
+  it("bounds the cache so a long-running session can't grow it without limit", () => {
+    // Simulate per-render dynamic strings (elapsed/context%) that never recur.
+    for (let i = 0; i < WIDTH_CACHE_MAX * 3; i++) {
+      getDisplayWidth(
+        `row-${i} feat/branch 4m${i}s ctx ${i % 100}% claude-opus`,
+      );
+    }
+    expect(widthCacheSize()).toBeLessThanOrEqual(WIDTH_CACHE_MAX);
+  });
+
+  it("still computes correctly for strings evicted by a flood", () => {
+    for (let i = 0; i < WIDTH_CACHE_MAX * 2; i++) getDisplayWidth(`flood-${i}`);
+    expect(getDisplayWidth("hello")).toBe(5);
+    expect(getDisplayWidth("한글")).toBe(4);
   });
 });


### PR DESCRIPTION
## Problem

`getDisplayWidth` (`src/ui/constants.ts`) memoized `string-width` results in a module-level `Map` that was **never evicted**. It exists for CPU (`string-width` runs Unicode regex, ~17% of runtime), assuming icons/labels recur every render. But several callers pass **per-render dynamic strings** that never produce a cache hit:

- `SessionTreePanel.tsx` — `rightSide` / `fullLine` (elapsed time, context %, model)
- `ActivityViewerPanel.tsx` — `labelContent` (activity timestamps)

These accumulated forever — ~282 bytes/entry, tens of MB over hours, scaling with activity (matches the workload-dependent RSS creep seen after the v0.18.5–0.18.9 work). Direct measurement showed the parsed session data is only **~22MB at worst**, so this cache — not the data, not file size — was the unbounded contributor.

## Fix

Cap at `WIDTH_CACHE_MAX = 2000` with FIFO eviction (evict the oldest insertion on a miss when full). Hot recurring strings re-insert on their rare miss, so the CPU win is preserved at a **~0.5MB ceiling** regardless of uptime. Per-frame working set (~hundreds of distinct strings) is far below the cap, so no thrashing.

## Test (TDD)

Added 3 tests in `tests/ui/constants.test.ts` — width correctness (ASCII/empty/emoji/CJK), bound holds after flooding 3× cap distinct strings (saw it fail at 6004 first), correctness survives eviction. 746/746 pass, `tsc` clean, `biome` clean. Independently reviewed (verdict: ship).

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)