### PR TITLE
feat(providers): add opencode provider (read-only SQLite)

### DIFF
--- a/docs/schemas/opencode-session.md
+++ b/docs/schemas/opencode-session.md
@@ -68,8 +68,11 @@ scope for the SQLite-first implementation — document, don't build.
   concern as a reader, but a reason never to open read-write).
 - **Schema is migration-versioned** (`migration` / `data_migration`
   tables). Column set WILL drift across opencode releases (note how many
-  `session` columns below are `ALTER TABLE` add-ons). Treat columns as
-  optional and feature-detect; pin behavior to the verification queries.
+  `session` columns below are `ALTER TABLE` add-ons). The current provider
+  pins the column set it selects and **fails soft to an empty tree** if a
+  query can't bind (older/newer schema) — it never crashes the refresh. A
+  `PRAGMA table_info`-based feature-detect is a future hardening; until
+  then, the verification queries below are the contract.
 
 ## Tables that matter
 
@@ -280,8 +283,10 @@ If any output surprises you, this doc is wrong — open an issue.
 - `session.model` and `message.data` / `part.data` are JSON encoded as
   TEXT — `json_extract` in SQL or parse in JS.
 - The schema is migration-versioned and several `session` columns are
-  late `ALTER TABLE` additions — feature-detect columns; expect drift
-  between opencode releases.
+  late `ALTER TABLE` additions — expect drift between opencode releases.
+  The provider pins its selected columns and degrades to an empty tree on
+  a binding mismatch (never crashes); column feature-detection is a
+  future hardening.
 - Context-window size is NOT in the DB; it comes from the models catalog
   (`~/.cache/opencode/models.json`) keyed by `modelID`.
 - Sample install was small (2 sessions, 43 parts); a larger corpus may

--- a/docs/schemas/opencode-session.md
+++ b/docs/schemas/opencode-session.md
@@ -27,15 +27,45 @@ ${XDG_DATA_HOME:-~/.local/share}/opencode/opencode.db   (+ -wal, -shm)
 - Per-model context-window sizes live in `~/.cache/opencode/models.json`
   (a mirror of models.dev) — needed to turn token counts into a gauge.
 
+## Legacy storage (pre-SQLite) — file-per-entity JSON
+
+Before the SQLite store, opencode persisted to **many small JSON files**
+(one JSON object per file, NOT line-delimited JSONL), under
+`${XDG_DATA_HOME:-~/.local/share}/opencode/storage/`:
+
+```
+storage/
+  project/{projectID}.json              # one object per project
+  session/{projectID}/{sessionID}.json  # one object per session
+  message/{sessionID}/{messageID}.json  # one file PER message
+  part/{messageID}/{partID}.json        # one file PER part (tool call, text…)
+  session_diff/{sessionID}.json
+  share/{sessionID}.json
+  migration                             # migration version marker
+```
+
+A file per message and per part is why a short session could leave
+thousands of files on disk — the churn that motivated the move to
+SQLite. A migration engine bulk-inserts these into the DB (tracked by
+the `migration` / `data_migration` tables), so on a current install the
+DB is authoritative and `storage/` is usually absent or stale. A
+provider targeting **un-migrated older installs** could fall back to
+walking `storage/{session,message,part}/**.json`, but that is out of
+scope for the SQLite-first implementation — document, don't build.
+
 ## Access model (read this first)
 
 - Open **read-only**, e.g. `sqlite3 "file:<path>?mode=ro"`, or in Node
   `new DatabaseSync(path, { readOnly: true })` (`node:sqlite`, Node 22+)
   / `new Database(path, { readonly: true, fileMustExist: true })`
   (`better-sqlite3`). Never open read-write — opencode owns the file.
-- WAL mode: a read-only connection sees the last committed state; an
-  in-flight (uncommitted) opencode write is simply invisible until it
-  commits. That's fine — agenthud polls.
+- WAL mode (`journal_mode=WAL`, `synchronous=NORMAL`, `busy_timeout=5000`,
+  single writer / many readers): a read-only connection sees the last
+  committed state; an in-flight (uncommitted) opencode write is simply
+  invisible until it commits. That's fine — agenthud polls. Multiple
+  opencode instances share this one DB, so read-only is the only safe
+  posture (concurrent writers have caused corruption reports — not our
+  concern as a reader, but a reason never to open read-write).
 - **Schema is migration-versioned** (`migration` / `data_migration`
   tables). Column set WILL drift across opencode releases (note how many
   `session` columns below are `ALTER TABLE` add-ons). Treat columns as
@@ -256,3 +286,8 @@ If any output surprises you, this doc is wrong — open an issue.
   (`~/.cache/opencode/models.json`) keyed by `modelID`.
 - Sample install was small (2 sessions, 43 parts); a larger corpus may
   surface more `part.type` / `tool` values and a populated `parent_id`.
+- **No auto-pruning:** opencode never prunes, size-caps, or cleans up old
+  sessions, so the DB (and the session count) grows unbounded over time.
+  A discovery pass should expect an ever-growing `session` table and lean
+  on recency (`time_updated`) ordering / hot-cold status rather than
+  assuming a small set.

--- a/src/data/providers/opencode.ts
+++ b/src/data/providers/opencode.ts
@@ -1,0 +1,482 @@
+/**
+ * opencode provider — sessions from opencode's SQLite store.
+ *
+ * Design decisions:
+ * - Unlike every other provider (per-session JSON/JSONL files), opencode
+ *   keeps all sessions in one SQLite DB. We open it READ-ONLY and query;
+ *   there is no file to scan. See docs/schemas/opencode-session.md.
+ * - `node:sqlite` is loaded through a guarded require so agenthud still
+ *   runs on Node < 22 (where the module is absent): the provider simply
+ *   reports `isAvailable() === false` instead of crashing the app. No new
+ *   dependency, no forced engine bump.
+ * - Sessions have no real path, so each `SessionNode.filePath` is a
+ *   synthetic `opencode:<sessionId>` token. `sessionHistory` routes that
+ *   prefix to `parseOpenCodeSessionActivities` (a DB query) instead of a
+ *   file read.
+ *
+ * Gotcha:
+ * - `node:sqlite` emits a one-time ExperimentalWarning on first use; we
+ *   filter exactly that warning so it can't corrupt the TUI's stderr.
+ */
+
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import type {
+  ActivityEntry,
+  GlobalConfig,
+  ProjectNode,
+  SessionNode,
+  SessionStatus,
+  SessionTree,
+} from "../../types/index.js";
+import { ICONS } from "../../types/index.js";
+import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
+import type { DiscoverOptions, ParseResult, SessionProvider } from "./types.js";
+
+export const OPENCODE_PATH_PREFIX = "opencode:";
+
+/** Synthetic filePath for an opencode session (no real file exists). */
+export function opencodeFilePath(sessionId: string): string {
+  return OPENCODE_PATH_PREFIX + sessionId;
+}
+
+/** Recover the session id from a synthetic opencode filePath. */
+export function sessionIdFromPath(filePath: string): string | null {
+  return filePath.startsWith(OPENCODE_PATH_PREFIX)
+    ? filePath.slice(OPENCODE_PATH_PREFIX.length)
+    : null;
+}
+
+export function getOpenCodeDbPath(): string {
+  if (process.env.OPENCODE_DB) return process.env.OPENCODE_DB;
+  const dataHome =
+    process.env.XDG_DATA_HOME ?? join(homedir(), ".local", "share");
+  return join(dataHome, "opencode", "opencode.db");
+}
+
+// --- node:sqlite guarded loader -------------------------------------------
+// node:sqlite's types vary by Node version (and are absent < 22), so the
+// DB handle is loosely typed.
+type SqliteDb = any;
+let sqliteMod:
+  | { DatabaseSync: new (path: string, opts?: object) => SqliteDb }
+  | null
+  | undefined;
+
+function loadSqlite() {
+  if (sqliteMod !== undefined) return sqliteMod;
+  // Filter only the SQLite ExperimentalWarning so it can't reach the TUI.
+  const originalEmit = process.emitWarning;
+  const filtered: typeof process.emitWarning = (warning, ...rest) => {
+    const opts = rest[0];
+    const type =
+      typeof opts === "string"
+        ? opts
+        : opts && typeof opts === "object" && "type" in opts
+          ? (opts as { type?: string }).type
+          : undefined;
+    if (type === "ExperimentalWarning" && String(warning).includes("SQLite")) {
+      return;
+    }
+    return (originalEmit as (...a: unknown[]) => void)(warning, ...rest);
+  };
+  process.emitWarning = filtered;
+  try {
+    // Use require so a missing built-in (Node < 22) throws here, caught below,
+    // instead of failing the ESM module graph at import time.
+    const req = createRequire(import.meta.url);
+    sqliteMod = req("node:sqlite") as typeof sqliteMod;
+  } catch {
+    sqliteMod = null;
+  }
+  return sqliteMod;
+}
+
+/** Open the opencode DB read-only, or null if unavailable. Caller closes. */
+function openDb(): SqliteDb | null {
+  const mod = loadSqlite();
+  if (!mod) return null;
+  const path = getOpenCodeDbPath();
+  if (!existsSync(path)) return null;
+  try {
+    return new mod.DatabaseSync(path, { readOnly: true });
+  } catch {
+    return null;
+  }
+}
+
+// --- status / context helpers ---------------------------------------------
+
+function getSessionStatus(mtimeMs: number): SessionStatus {
+  const now = Date.now();
+  const age = now - mtimeMs;
+  if (age < THIRTY_MINUTES_MS) return "hot";
+  if (age < ONE_HOUR_MS) return "warm";
+  const mtime = new Date(mtimeMs);
+  const nowDate = new Date(now);
+  if (
+    mtime.getUTCFullYear() === nowDate.getUTCFullYear() &&
+    mtime.getUTCMonth() === nowDate.getUTCMonth() &&
+    mtime.getUTCDate() === nowDate.getUTCDate()
+  ) {
+    return "cool";
+  }
+  return "cold";
+}
+
+// opencode's models.json (XDG cache) carries true context windows, but its
+// shape varies; until that lookup lands, assume a conservative window so the
+// gauge is directional. Tracked in docs/schemas/opencode-session.md.
+const ASSUMED_WINDOW = 200_000;
+
+interface LatestAssistant {
+  used: number;
+  modelID: string | null;
+  working: boolean;
+}
+
+function readModelId(modelJson: string | null): string | null {
+  if (!modelJson) return null;
+  try {
+    return (JSON.parse(modelJson) as { id?: string }).id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function parseLatestAssistant(dataJson: string): LatestAssistant | null {
+  try {
+    const d = JSON.parse(dataJson) as {
+      role?: string;
+      modelID?: string;
+      tokens?: { input?: number; cache?: { read?: number } };
+      time?: { completed?: number };
+    };
+    if (d.role !== "assistant") return null;
+    const used = (d.tokens?.input ?? 0) + (d.tokens?.cache?.read ?? 0);
+    return {
+      used,
+      modelID: d.modelID ?? null,
+      working: d.time?.completed == null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// --- discovery -------------------------------------------------------------
+
+interface SessionRow {
+  id: string;
+  parent_id: string | null;
+  directory: string;
+  title: string;
+  model: string | null;
+  time_updated: number;
+}
+
+function makeNode(
+  row: SessionRow,
+  latest: LatestAssistant | undefined,
+  hidden: boolean,
+): SessionNode {
+  const projectName = basename(row.directory);
+  const model = readModelId(row.model) ?? latest?.modelID ?? null;
+  const node: SessionNode = {
+    id: row.id,
+    hideKey: `${projectName}/${row.id}`,
+    filePath: opencodeFilePath(row.id),
+    projectPath: row.directory,
+    projectName,
+    lastModifiedMs: row.time_updated,
+    status: getSessionStatus(row.time_updated),
+    modelName: model,
+    subAgents: [],
+    nonInteractive: false,
+    firstUserPrompt: row.title || null,
+    liveState: latest?.working ? "working" : null,
+    provider: "opencode",
+  };
+  if (latest && latest.used > 0) {
+    node.contextUsage = {
+      used: latest.used,
+      total: ASSUMED_WINDOW,
+      percent: Math.min(100, Math.round((latest.used / ASSUMED_WINDOW) * 100)),
+    };
+  }
+  if (hidden) node.hidden = true;
+  return node;
+}
+
+function emptyTree(): SessionTree {
+  return {
+    projects: [],
+    coldProjects: [],
+    totalCount: 0,
+    timestamp: new Date().toISOString(),
+    hiddenStats: { total: 0, active: 0 },
+  };
+}
+
+function discoverSessions(
+  config: GlobalConfig,
+  options?: DiscoverOptions,
+): SessionTree {
+  const db = openDb();
+  if (!db) return emptyTree();
+
+  try {
+    const rows = db
+      .prepare(
+        `SELECT id, parent_id, directory, title, model, time_updated
+         FROM session WHERE time_archived IS NULL
+         ORDER BY time_updated DESC`,
+      )
+      .all() as SessionRow[];
+
+    // Latest assistant message per session → context + liveness + model.
+    const latestById = new Map<string, LatestAssistant>();
+    const msgRows = db
+      .prepare(
+        `SELECT m.session_id AS sid, m.data AS data FROM message m
+         JOIN (SELECT session_id, MAX(time_created) mt FROM message
+               WHERE json_extract(data,'$.role')='assistant'
+               GROUP BY session_id) x
+         ON m.session_id = x.session_id AND m.time_created = x.mt`,
+      )
+      .all() as Array<{ sid: string; data: string }>;
+    for (const r of msgRows) {
+      const la = parseLatestAssistant(r.data);
+      if (la) latestById.set(r.sid, la);
+    }
+
+    const byId = new Map<string, SessionRow>();
+    for (const r of rows) byId.set(r.id, r);
+
+    const nodesById = new Map<string, SessionNode>();
+    const byProject = new Map<string, SessionNode[]>();
+    let hiddenTotal = 0;
+    let hiddenActive = 0;
+
+    // Top-level sessions first.
+    for (const row of rows) {
+      if (row.parent_id && byId.has(row.parent_id)) continue; // child
+      if (options?.scopeToProject && row.directory !== options.scopeToProject) {
+        continue;
+      }
+      const projectName = basename(row.directory);
+      const hidden =
+        config.hiddenProjects.includes(projectName) ||
+        config.hiddenSessions.includes(`${projectName}/${row.id}`);
+      const node = makeNode(row, latestById.get(row.id), hidden);
+      nodesById.set(row.id, node);
+      if (hidden) {
+        hiddenTotal++;
+        if (node.status === "hot" || node.status === "warm") hiddenActive++;
+      }
+      const arr = byProject.get(row.directory) ?? [];
+      arr.push(node);
+      byProject.set(row.directory, arr);
+    }
+
+    // Child sessions → sub-agents.
+    for (const row of rows) {
+      if (!row.parent_id || !byId.has(row.parent_id)) continue;
+      const parent = nodesById.get(row.parent_id);
+      if (!parent) continue; // parent scoped/hidden out
+      const projectName = parent.projectName;
+      const hidden =
+        config.hiddenProjects.includes(projectName) ||
+        config.hiddenSubAgents.includes(`${projectName}/${row.id}`);
+      const node = makeNode(row, latestById.get(row.id), hidden);
+      node.agentId = row.id;
+      node.taskDescription = row.title || undefined;
+      if (hidden) {
+        hiddenTotal++;
+        if (node.status === "hot" || node.status === "warm") hiddenActive++;
+      }
+      parent.subAgents.push(node);
+    }
+
+    const statusOrder: Record<SessionStatus, number> = {
+      hot: 0,
+      warm: 1,
+      cool: 2,
+      cold: 3,
+    };
+    const allProjects: ProjectNode[] = [];
+    for (const [projectPath, sessions] of byProject) {
+      if (sessions.length === 0) continue;
+      const projectName = sessions[0].projectName;
+      sessions.sort((a, b) => {
+        const d = statusOrder[a.status] - statusOrder[b.status];
+        return d !== 0 ? d : b.lastModifiedMs - a.lastModifiedMs;
+      });
+      allProjects.push({
+        name: projectName,
+        projectPath,
+        sessions,
+        hotness: sessions[0].status,
+        hidden: config.hiddenProjects.includes(projectName) || undefined,
+      });
+    }
+
+    const activeProjects = allProjects.filter((p) => p.hotness !== "cold");
+    const coldProjects = allProjects.filter((p) => p.hotness === "cold");
+    activeProjects.sort((a, b) => {
+      const d = statusOrder[a.hotness] - statusOrder[b.hotness];
+      return d !== 0
+        ? d
+        : b.sessions[0].lastModifiedMs - a.sessions[0].lastModifiedMs;
+    });
+
+    const count = (projects: ProjectNode[]) =>
+      projects.reduce(
+        (sum, p) =>
+          sum +
+          p.sessions.length +
+          p.sessions.reduce((s, sn) => s + sn.subAgents.length, 0),
+        0,
+      );
+
+    return {
+      projects: activeProjects,
+      coldProjects,
+      totalCount: count(activeProjects) + count(coldProjects),
+      timestamp: new Date().toISOString(),
+      hiddenStats: { total: hiddenTotal, active: hiddenActive },
+    };
+  } catch {
+    return emptyTree();
+  } finally {
+    db.close();
+  }
+}
+
+// --- activities ------------------------------------------------------------
+
+/** One line = a JSON envelope `{ role, t, part }` (part = a `part.data`
+ * object). Kept line-shaped so the mapper is unit-testable with synthetic
+ * input, mirroring the other providers' `parseXActivities(lines)`. */
+interface PartEnvelope {
+  role?: string;
+  t?: number;
+  part?: {
+    type?: string;
+    tool?: string;
+    text?: string;
+    state?: { title?: string; status?: string };
+  };
+}
+
+export function parseActivities(lines: string[]): ParseResult {
+  const activities: ActivityEntry[] = [];
+  let sessionStartTime: Date | null = null;
+
+  for (const line of lines) {
+    let env: PartEnvelope;
+    try {
+      env = JSON.parse(line) as PartEnvelope;
+    } catch {
+      continue;
+    }
+    const part = env.part;
+    if (!part) continue;
+    const ts = new Date(env.t ?? 0);
+    if (!sessionStartTime) sessionStartTime = ts;
+
+    switch (part.type) {
+      case "text": {
+        const text = (part.text ?? "").trim();
+        if (!text) continue;
+        if (env.role === "user") {
+          activities.push({
+            timestamp: ts,
+            type: "user",
+            icon: ICONS.User,
+            label: "User",
+            detail: text.split("\n")[0] ?? "",
+            detailBody: text.includes("\n") ? text : undefined,
+          });
+        } else {
+          activities.push({
+            timestamp: ts,
+            type: "response",
+            icon: ICONS.Response,
+            label: "Response",
+            detail: text.split("\n")[0] ?? "",
+            detailBody: text.includes("\n") ? text : undefined,
+          });
+        }
+        break;
+      }
+      case "reasoning": {
+        const text = (part.text ?? "").trim();
+        if (!text) continue;
+        activities.push({
+          timestamp: ts,
+          type: "thinking",
+          icon: ICONS.Thinking,
+          label: "Thinking",
+          detail: text.split("\n")[0] ?? "",
+        });
+        break;
+      }
+      case "tool": {
+        const tool = part.tool ?? "tool";
+        activities.push({
+          timestamp: ts,
+          type: "tool",
+          icon: ICONS.Default,
+          label: tool,
+          detail: part.state?.title ?? "",
+        });
+        break;
+      }
+      // step-start / step-finish are turn boundaries — skipped.
+    }
+  }
+
+  return { activities, tokenCount: 0, modelName: null, sessionStartTime };
+}
+
+/** Build the full activity history for one opencode session via the DB. */
+export function parseOpenCodeSessionActivities(
+  sessionId: string,
+): ActivityEntry[] {
+  const db = openDb();
+  if (!db) return [];
+  try {
+    const rows = db
+      .prepare(
+        `SELECT p.data AS pdata, p.time_created AS t,
+                json_extract(m.data,'$.role') AS role
+         FROM part p JOIN message m ON p.message_id = m.id
+         WHERE p.session_id = ?
+         ORDER BY p.time_created ASC`,
+      )
+      .all(sessionId) as Array<{ pdata: string; t: number; role: string }>;
+    const lines = rows.map((r) =>
+      JSON.stringify({ role: r.role, t: r.t, part: JSON.parse(r.pdata) }),
+    );
+    return parseActivities(lines).activities;
+  } catch {
+    return [];
+  } finally {
+    db.close();
+  }
+}
+
+function isAvailable(): boolean {
+  return loadSqlite() != null && existsSync(getOpenCodeDbPath());
+}
+
+export const opencodeProvider: SessionProvider = {
+  name: "opencode",
+  lineDelimited: false,
+  isAvailable,
+  discoverSessions,
+  parseActivities,
+};

--- a/src/data/providers/opencode.ts
+++ b/src/data/providers/opencode.ts
@@ -88,7 +88,12 @@ function loadSqlite() {
     // instead of failing the ESM module graph at import time.
     const req = createRequire(import.meta.url);
     sqliteMod = req("node:sqlite") as typeof sqliteMod;
+    // Keep the filter installed on success: the warning fires on first DB
+    // use (later), not necessarily here.
   } catch {
+    // Unavailable (Node < 22): restore the original handler — nothing in
+    // this process will emit the SQLite warning, so leave no global trace.
+    process.emitWarning = originalEmit;
     sqliteMod = null;
   }
   return sqliteMod;
@@ -458,9 +463,19 @@ export function parseOpenCodeSessionActivities(
          ORDER BY p.time_created ASC`,
       )
       .all(sessionId) as Array<{ pdata: string; t: number; role: string }>;
-    const lines = rows.map((r) =>
-      JSON.stringify({ role: r.role, t: r.t, part: JSON.parse(r.pdata) }),
-    );
+    // Per-row guard: one malformed part.data must not blank the whole
+    // timeline (parseActivities guards each line too, but the pre-parse
+    // here would otherwise throw for the entire session).
+    const lines: string[] = [];
+    for (const r of rows) {
+      try {
+        lines.push(
+          JSON.stringify({ role: r.role, t: r.t, part: JSON.parse(r.pdata) }),
+        );
+      } catch {
+        // skip this malformed part
+      }
+    }
     return parseActivities(lines).activities;
   } catch {
     return [];

--- a/src/data/providers/types.ts
+++ b/src/data/providers/types.ts
@@ -28,7 +28,12 @@ import type {
   SessionTree,
 } from "../../types/index.js";
 
-export type ProviderName = "claude" | "kiro" | "kiro-ide" | "codex";
+export type ProviderName =
+  | "claude"
+  | "kiro"
+  | "kiro-ide"
+  | "codex"
+  | "opencode";
 
 export interface DiscoverOptions {
   // When set, drop every project whose decoded path is not exactly this

--- a/src/data/sessionHistory.ts
+++ b/src/data/sessionHistory.ts
@@ -30,6 +30,12 @@ import {
   getKiroIdeSessionsDir,
   kiroIdeProvider,
 } from "./providers/kiro-ide.js";
+import {
+  OPENCODE_PATH_PREFIX,
+  opencodeProvider,
+  parseOpenCodeSessionActivities,
+  sessionIdFromPath,
+} from "./providers/opencode.js";
 import type { SessionProvider } from "./providers/types.js";
 
 const norm = (p: string) => p.replace(/\\/g, "/");
@@ -41,6 +47,7 @@ const norm = (p: string) => p.replace(/\\/g, "/");
 // the Claude parser). The well-known segments stay as fallbacks for
 // nodes constructed before an env change. Claude is the default.
 function providerForPath(filePath: string): SessionProvider {
+  if (filePath.startsWith(OPENCODE_PATH_PREFIX)) return opencodeProvider;
   const p = norm(filePath);
   if (
     p.startsWith(`${norm(getKiroSessionsDir())}/`) ||
@@ -210,6 +217,11 @@ function readRange(filePath: string, start: number, end: number): Buffer {
 // Parse the full, untruncated activity history from a session file.
 // Returns entries in chronological order (oldest first).
 export function parseSessionHistory(filePath: string): ActivityEntry[] {
+  // opencode sessions have no file — their synthetic `opencode:<id>` path
+  // resolves to a read-only DB query, bypassing the file-tail machinery.
+  const opencodeId = sessionIdFromPath(filePath);
+  if (opencodeId !== null) return parseOpenCodeSessionActivities(opencodeId);
+
   if (!existsSync(filePath)) return [];
 
   let mtimeMs: number;

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -36,6 +36,7 @@ import { claudeProvider } from "./providers/claude.js";
 import { codexProvider } from "./providers/codex.js";
 import { kiroProvider } from "./providers/kiro.js";
 import { kiroIdeProvider } from "./providers/kiro-ide.js";
+import { opencodeProvider } from "./providers/opencode.js";
 import type { DiscoverOptions, SessionProvider } from "./providers/types.js";
 
 export {
@@ -50,6 +51,7 @@ const PROVIDERS: SessionProvider[] = [
   kiroProvider,
   kiroIdeProvider,
   codexProvider,
+  opencodeProvider,
 ];
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,7 +35,7 @@ export interface SessionNode {
   firstUserPrompt: string | null; // Display description: latest substantial (≥10 chars, non-slash) user message, falling back to the first natural-language one. Name kept for backwards compat.
   liveState: LiveState | null; // working/waiting from JSONL tail; null = fall back to time-based status
   hidden?: boolean; // true when matched by hiddenSessions/hiddenSubAgents, or descendant of a hidden project
-  provider?: "claude" | "kiro" | "kiro-ide" | "codex"; // origin source of this node. Renderer uses it for a small per-row label so users can tell at a glance which CLI created the session.
+  provider?: "claude" | "kiro" | "kiro-ide" | "codex" | "opencode"; // origin source of this node. Renderer uses it for a small per-row label so users can tell at a glance which CLI created the session.
   /**
    * Most-recent context-window usage observed for this session.
    * `percent` is the fraction-of-window (0..100) the renderer shows

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -181,11 +181,22 @@ function SessionRow({
   // Name: parent uses a short 4-char ID (project name is shown on the
   // project header); sub-agent uses its agentId truncated to 6 chars so it
   // no longer prints the long hex string Claude writes verbatim.
+  // opencode prefixes every id with a constant `ses_` that carries no
+  // identity — strip it for display so the distinguishing hex shows
+  // (the underlying id/filePath/DB key keep the prefix).
+  const shortIdSource =
+    session.provider === "opencode"
+      ? (session.agentId ?? session.id).replace(/^ses_/, "")
+      : (session.agentId ?? session.id);
+  const parentIdSource =
+    session.provider === "opencode"
+      ? session.id.replace(/^ses_/, "")
+      : session.id;
   const rawName = isParent
     ? isNonInteractive
-      ? `(#${session.id.slice(0, 4)})`
-      : `#${session.id.slice(0, 4)}`
-    : (session.agentId ?? session.id).slice(0, 6);
+      ? `(#${parentIdSource.slice(0, 4)})`
+      : `#${parentIdSource.slice(0, 4)}`
+    : shortIdSource.slice(0, 6);
 
   // Short ID is now the name itself for parent sessions; no separate suffix needed
   const shortIdDisplay = "";

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -181,22 +181,25 @@ function SessionRow({
   // Name: parent uses a short 4-char ID (project name is shown on the
   // project header); sub-agent uses its agentId truncated to 6 chars so it
   // no longer prints the long hex string Claude writes verbatim.
-  // opencode prefixes every id with a constant `ses_` that carries no
-  // identity — strip it for display so the distinguishing hex shows
-  // (the underlying id/filePath/DB key keep the prefix).
-  const shortIdSource =
-    session.provider === "opencode"
-      ? (session.agentId ?? session.id).replace(/^ses_/, "")
-      : (session.agentId ?? session.id);
-  const parentIdSource =
-    session.provider === "opencode"
-      ? session.id.replace(/^ses_/, "")
-      : session.id;
+  //
+  // Most providers' ids start with their distinguishing bits AND map to a
+  // session FILE, so the leading chars help locate the file. opencode is
+  // different: it has no file, and its ids are time-ordered
+  // (`ses_<descending-timestamp><random>`), so close-in-time sessions share
+  // a long prefix. The distinguishing entropy is the random TAIL — show
+  // that instead (the title alongside is the primary identity).
+  const isOpencode = session.provider === "opencode";
+  const parentShort = isOpencode
+    ? session.id.slice(-4)
+    : session.id.slice(0, 4);
+  const subShort = isOpencode
+    ? (session.agentId ?? session.id).slice(-6)
+    : (session.agentId ?? session.id).slice(0, 6);
   const rawName = isParent
     ? isNonInteractive
-      ? `(#${parentIdSource.slice(0, 4)})`
-      : `#${parentIdSource.slice(0, 4)}`
-    : shortIdSource.slice(0, 6);
+      ? `(#${parentShort})`
+      : `#${parentShort}`
+    : subShort;
 
   // Short ID is now the name itself for parent sessions; no separate suffix needed
   const shortIdDisplay = "";

--- a/tests/data/providers/opencode.test.ts
+++ b/tests/data/providers/opencode.test.ts
@@ -214,6 +214,26 @@ describe.skipIf(!sqliteAvailable)("opencodeProvider", () => {
     expect(acts[1].detail).toBe("file.ts");
     expect(acts[3].detail).toBe("Here is the answer");
   });
+
+  it("skips a single malformed part instead of blanking the timeline", () => {
+    const db = new DatabaseSync(dbPath);
+    db.prepare("INSERT INTO part VALUES (?,?,?,?,?)").run(
+      "p_bad",
+      "m_asst",
+      "ses_top",
+      NOW - 2200,
+      "{not valid json",
+    );
+    db.close();
+    const acts = parseOpenCodeSessionActivities("ses_top");
+    // The 4 good parts still come through; the malformed one is dropped.
+    expect(acts.map((a) => a.type)).toEqual([
+      "user",
+      "tool",
+      "thinking",
+      "response",
+    ]);
+  });
 });
 
 // parseActivities is pure (line-based) and testable without SQLite.

--- a/tests/data/providers/opencode.test.ts
+++ b/tests/data/providers/opencode.test.ts
@@ -1,0 +1,249 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  opencodeProvider,
+  parseActivities,
+  parseOpenCodeSessionActivities,
+} from "../../../src/data/providers/opencode.js";
+import type { GlobalConfig } from "../../../src/types/index.js";
+
+// node:sqlite is Node 22+. Skip the whole suite where it's missing (CI Node
+// 20) — the provider degrades to isAvailable() === false there, by design.
+let DatabaseSync:
+  | {
+      new (
+        path: string,
+      ): {
+        exec(s: string): void;
+        prepare(s: string): { run(...a: unknown[]): void };
+        close(): void;
+      };
+    }
+  | undefined;
+let sqliteAvailable = false;
+try {
+  DatabaseSync = createRequire(import.meta.url)("node:sqlite").DatabaseSync;
+  sqliteAvailable = true;
+} catch {
+  // node:sqlite unavailable
+}
+
+const NOW = Date.now();
+
+const config: GlobalConfig = {
+  refreshIntervalMs: 2000,
+  hiddenSessions: [],
+  hiddenSubAgents: [],
+  filterPresets: [[]],
+  hiddenProjects: [],
+  report: { include: [], detailLimit: 0, withGit: false, format: "markdown" },
+  summary: {},
+};
+
+let dir: string;
+let dbPath: string;
+
+function buildDb(): void {
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, project_id TEXT,
+      directory TEXT, title TEXT, model TEXT, time_created INTEGER,
+      time_updated INTEGER, time_archived INTEGER);
+    CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT,
+      time_created INTEGER, data TEXT);
+    CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+      time_created INTEGER, data TEXT);
+  `);
+
+  const ins = db.prepare("INSERT INTO session VALUES (?,?,?,?,?,?,?,?,?)");
+  ins.run(
+    "ses_top",
+    null,
+    "prj",
+    "/Users/neo/ocproj",
+    "Top",
+    '{"id":"gpt-5.5"}',
+    NOW - 5000,
+    NOW - 1000,
+    null,
+  );
+  ins.run(
+    "ses_child",
+    "ses_top",
+    "prj",
+    "/Users/neo/ocproj",
+    "Child task",
+    '{"id":"gpt-5.5"}',
+    NOW - 4000,
+    NOW - 2000,
+    null,
+  );
+  ins.run(
+    "ses_arch",
+    null,
+    "prj",
+    "/Users/neo/ocproj",
+    "Archived",
+    '{"id":"gpt-5.5"}',
+    NOW - 9000,
+    NOW - 9000,
+    NOW - 8000,
+  );
+
+  const msg = db.prepare("INSERT INTO message VALUES (?,?,?,?)");
+  msg.run("m_user", "ses_top", NOW - 4000, JSON.stringify({ role: "user" }));
+  msg.run(
+    "m_asst",
+    "ses_top",
+    NOW - 1000,
+    JSON.stringify({
+      role: "assistant",
+      modelID: "gpt-5.5",
+      tokens: { input: 1000, cache: { read: 4000 } },
+      time: { created: NOW - 2000, completed: NOW - 1000 },
+    }),
+  );
+
+  const part = db.prepare("INSERT INTO part VALUES (?,?,?,?,?)");
+  part.run(
+    "p1",
+    "m_user",
+    "ses_top",
+    NOW - 4000,
+    JSON.stringify({ type: "text", text: "Explain repo" }),
+  );
+  part.run(
+    "p2",
+    "m_asst",
+    "ses_top",
+    NOW - 3000,
+    JSON.stringify({
+      type: "tool",
+      tool: "read",
+      state: { title: "file.ts", status: "completed" },
+    }),
+  );
+  part.run(
+    "p3",
+    "m_asst",
+    "ses_top",
+    NOW - 2500,
+    JSON.stringify({ type: "reasoning", text: "thinking hard" }),
+  );
+  part.run(
+    "p4",
+    "m_asst",
+    "ses_top",
+    NOW - 2000,
+    JSON.stringify({ type: "text", text: "Here is the answer" }),
+  );
+  db.close();
+}
+
+beforeEach(() => {
+  if (!sqliteAvailable) return;
+  dir = mkdtempSync(join(tmpdir(), "agenthud-oc-"));
+  dbPath = join(dir, "opencode.db");
+  buildDb();
+  process.env.OPENCODE_DB = dbPath;
+});
+
+afterEach(() => {
+  delete process.env.OPENCODE_DB;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe.skipIf(!sqliteAvailable)("opencodeProvider", () => {
+  it("isAvailable is true when the DB exists", () => {
+    expect(opencodeProvider.isAvailable()).toBe(true);
+  });
+
+  it("isAvailable is false when the DB is missing", () => {
+    process.env.OPENCODE_DB = join(dir, "nope.db");
+    expect(opencodeProvider.isAvailable()).toBe(false);
+  });
+
+  it("discovers a top-level session with model, title, and project", () => {
+    const tree = opencodeProvider.discoverSessions(config);
+    expect(tree.projects).toHaveLength(1);
+    const project = tree.projects[0];
+    expect(project.name).toBe("ocproj");
+    const top = project.sessions.find((s) => s.id === "ses_top");
+    expect(top).toBeDefined();
+    expect(top?.modelName).toBe("gpt-5.5");
+    expect(top?.firstUserPrompt).toBe("Top");
+    expect(top?.provider).toBe("opencode");
+    expect(top?.filePath).toBe("opencode:ses_top");
+  });
+
+  it("nests a child session as a sub-agent via parent_id", () => {
+    const tree = opencodeProvider.discoverSessions(config);
+    const top = tree.projects[0].sessions.find((s) => s.id === "ses_top");
+    expect(top?.subAgents).toHaveLength(1);
+    expect(top?.subAgents[0].id).toBe("ses_child");
+    expect(top?.subAgents[0].taskDescription).toBe("Child task");
+  });
+
+  it("computes a context-usage gauge from the latest assistant tokens", () => {
+    const tree = opencodeProvider.discoverSessions(config);
+    const top = tree.projects[0].sessions.find((s) => s.id === "ses_top");
+    // used = input(1000) + cache.read(4000) = 5000
+    expect(top?.contextUsage?.used).toBe(5000);
+    expect(top?.contextUsage?.percent).toBe(3); // 5000 / 200000
+  });
+
+  it("excludes archived sessions", () => {
+    const tree = opencodeProvider.discoverSessions(config);
+    const ids = tree.projects.flatMap((p) => p.sessions.map((s) => s.id));
+    expect(ids).not.toContain("ses_arch");
+  });
+
+  it("builds the activity timeline for a session in chronological order", () => {
+    const acts = parseOpenCodeSessionActivities("ses_top");
+    expect(acts.map((a) => a.type)).toEqual([
+      "user",
+      "tool",
+      "thinking",
+      "response",
+    ]);
+    expect(acts[0].detail).toBe("Explain repo");
+    expect(acts[1].label).toBe("read");
+    expect(acts[1].detail).toBe("file.ts");
+    expect(acts[3].detail).toBe("Here is the answer");
+  });
+});
+
+// parseActivities is pure (line-based) and testable without SQLite.
+describe("opencode parseActivities (pure)", () => {
+  it("maps part envelopes to activity entries", () => {
+    const lines = [
+      JSON.stringify({
+        role: "user",
+        t: 1000,
+        part: { type: "text", text: "hi" },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        t: 2000,
+        part: { type: "reasoning", text: "hmm" },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        t: 3000,
+        part: { type: "tool", tool: "bash", state: { title: "ls" } },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        t: 4000,
+        part: { type: "step-start" },
+      }),
+    ];
+    const { activities } = parseActivities(lines);
+    expect(activities.map((a) => a.type)).toEqual(["user", "thinking", "tool"]); // step-start skipped
+    expect(activities[2].label).toBe("bash");
+    expect(activities[2].detail).toBe("ls");
+  });
+});

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -188,9 +188,11 @@ describe("SessionTreePanel", () => {
     expect(frame).not.toContain("#abc12"); // not 5
   });
 
-  it("strips the constant `ses_` prefix from opencode session IDs", () => {
+  it("uses the random tail of an opencode session ID (ids are time-prefixed)", () => {
+    // opencode ids are `ses_<descending-timestamp><random>`; the leading
+    // chars are a shared timestamp, so the distinguishing part is the tail.
     const session = makeSession({
-      id: "ses_abcdef12",
+      id: "ses_12fad7a2vNo2G",
       projectName: "myproject",
       provider: "opencode",
     });
@@ -205,8 +207,9 @@ describe("SessionTreePanel", () => {
       />,
     );
     const frame = lastFrame() ?? "";
-    expect(frame).toContain("#abcd"); // meaningful hex after ses_
-    expect(frame).not.toContain("#ses_"); // the constant prefix is gone
+    expect(frame).toContain("#No2G"); // distinguishing random tail
+    expect(frame).not.toContain("#ses_"); // not the constant prefix
+    expect(frame).not.toContain("#12fa"); // not the shared time prefix
   });
 
   it("shows project path on the project header row (not the session row)", () => {

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -188,6 +188,27 @@ describe("SessionTreePanel", () => {
     expect(frame).not.toContain("#abc12"); // not 5
   });
 
+  it("strips the constant `ses_` prefix from opencode session IDs", () => {
+    const session = makeSession({
+      id: "ses_abcdef12",
+      projectName: "myproject",
+      provider: "opencode",
+    });
+    const project = makeProject("myproject", [session]);
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[project]}
+        coldProjects={[]}
+        selectedId={null}
+        hasFocus={false}
+        width={80}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("#abcd"); // meaningful hex after ses_
+    expect(frame).not.toContain("#ses_"); // the constant prefix is gone
+  });
+
   it("shows project path on the project header row (not the session row)", () => {
     const session = makeSession({ projectPath: "/test/path/myproject" });
     const project = makeProject("myproject", [session], {

--- a/tests/utils/binGate.test.ts
+++ b/tests/utils/binGate.test.ts
@@ -1,0 +1,51 @@
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Guards the Node-version gate in the built bin (`dist/index.js`).
+ *
+ * The gate only works if it runs BEFORE any project/dependency code loads —
+ * which requires `dist/index.js` to carry NO static imports (those hoist to
+ * the top of an ESM module and evaluate first) and to pull the app in via a
+ * dynamic `import()` instead. tsup keeps `main` as a deferred chunk today; a
+ * future build-config change (e.g. disabling splitting / inlining) would
+ * silently hoist deps above the gate and break it on old Node. This test
+ * fails loudly if that ever happens.
+ */
+
+const distIndex = join(process.cwd(), "dist", "index.js");
+
+describe("bin Node-version gate (built dist/index.js)", () => {
+  beforeAll(() => {
+    // CI builds before testing; locally, build on demand if dist is absent.
+    if (!existsSync(distIndex)) {
+      execSync("npm run build", { cwd: process.cwd(), stdio: "ignore" });
+    }
+  }, 120_000);
+
+  it("the built bin exists", () => {
+    expect(existsSync(distIndex)).toBe(true);
+  });
+
+  it("has NO static imports — only a dynamic import of the main chunk", () => {
+    const src = readFileSync(distIndex, "utf-8");
+    // A static import statement starts a line with `import` NOT immediately
+    // followed by `(`. The deferred `import("./main-…")` is dynamic and must
+    // be the only `import` in the file.
+    const staticImport = /^\s*import\b(?!\s*\()/m;
+    expect(staticImport.test(src)).toBe(false);
+    expect(/import\s*\(/.test(src)).toBe(true);
+  });
+
+  it("runs the version gate before importing the main chunk", () => {
+    const src = readFileSync(distIndex, "utf-8");
+    const exitIdx = src.indexOf("process.exit(1)");
+    const dynImportIdx = src.search(/import\s*\(/);
+    expect(exitIdx).toBeGreaterThanOrEqual(0); // the gate exits
+    expect(dynImportIdx).toBeGreaterThan(exitIdx); // ...before loading main
+    expect(src).toContain("process.version");
+    expect(src).toMatch(/MIN_NODE_VERSION\s*=\s*20/);
+  });
+});


### PR DESCRIPTION
## What

Adds an **opencode** session provider. Unlike the 4 existing providers (claude/codex/kiro/kiro-ide) that scan per-session files, opencode keeps everything in one SQLite DB, so this provider opens it **read-only** via Node's built-in `node:sqlite` and queries it.

- **Discovery** from the `session` table: `parent_id` → sub-agents, `directory` → project, `model` JSON → model, `time_updated` → status. Context gauge + liveness from the latest assistant `message`; activity timeline from `part` rows (`text`→response/user, `tool`→tool, `reasoning`→thinking).
- **Activity viewer** via a synthetic `opencode:<id>` filePath that `sessionHistory.parseSessionHistory` routes to a DB query (bypassing the file-tail machinery).
- **Graceful on Node < 22:** `node:sqlite` is loaded through a guarded `require`; where it's absent the provider reports `isAvailable() === false` instead of crashing — **no new dependency, no engine bump**. The one-time SQLite ExperimentalWarning is filtered so it can't corrupt the TUI.

## Tests (TDD)

`tests/data/providers/opencode.test.ts` builds a temp DB with `node:sqlite` (suite `skipIf`-skipped where unavailable, e.g. CI Node 20) and covers discovery, parent/child nesting, context gauge, archived exclusion, chronological activity order, and **single-malformed-part resilience**. The pure line mapper is tested without SQLite. 755 tests pass, `tsc` + `biome` clean. Verified end-to-end against a real opencode install (2 sessions, 55 activities, context gauge, no warning leak).

## Reviewed

Independently reviewed; verdict ship-after-small-fixes — all addressed in the last commit (per-part parse resilience, `emitWarning` restore on the degraded path, doc/behavior reconciliation).

## Known follow-ups (documented, not blocking)

- Context-window size is an **assumed 200k** (a `models.json` lookup is the real fix) — the gauge numerator is real, denominator is a placeholder.
- opencode history is re-queried each ~2s poll (no LRU cache yet).
- Column **feature-detection** (`PRAGMA table_info`) vs the current pinned-columns / fail-soft-to-empty behavior.

Closes #169
Docs: `docs/schemas/opencode-session.md` (landed earlier via #170; extended here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenCode sessions—sessions from OpenCode databases are now discovered and displayed alongside other session sources.

* **Documentation**
  * Updated documentation for OpenCode's on-disk storage model and database access expectations.

* **Tests**
  * Added comprehensive test coverage for OpenCode session discovery, activity parsing, and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->