### PR TITLE
feat(ui): pin live sessions so they never scroll out of a short panel

### DIFF
--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -443,6 +443,20 @@ function flattenSessions(
   return result;
 }
 
+/** A flattened row for a session RUNNING right now: a top-level session
+ * that is working or waiting, or a sub-agent that is working (sub-agents
+ * never surface "waiting" — see App's liveness rule). Pins key on
+ * liveState, NOT the 30-min hot window, so finished-but-recent sub-agents
+ * don't flood the pinned band. */
+function isLiveSessionRow(
+  row: FlatRow,
+): row is Extract<FlatRow, { kind: "session" }> {
+  if (row.kind !== "session") return false;
+  const isParent = row.prefix === "    ";
+  const ls = row.session.liveState;
+  return isParent ? ls === "working" || ls === "waiting" : ls === "working";
+}
+
 function ProjectRow({
   project,
   isSelected,
@@ -983,19 +997,55 @@ export function SessionTreePanel({
   const needsOverflow =
     effectiveMaxRows !== undefined && totalRows > effectiveMaxRows;
   const visibleCount = needsOverflow ? effectiveMaxRows - 1 : totalRows;
+
+  // Pinned "live" band: when the tree overflows, sessions that are running
+  // RIGHT NOW (working/waiting) must never scroll out of view — that's the
+  // point of a live monitor. Pin them above the scrollable tree, capped to
+  // half the budget so a burst of concurrent sub-agents can't eat the
+  // panel; the overflow collapses to a "+N working" line.
+  const liveRows = needsOverflow ? flatRows.filter(isLiveSessionRow) : [];
+  const bandCap = Math.max(1, Math.floor(visibleCount / 2));
+  let pinnedRows = liveRows.slice(0, bandCap);
+  let pinnedOverflow = liveRows.length - pinnedRows.length;
+  if (pinnedOverflow > 0) {
+    pinnedRows = liveRows.slice(0, Math.max(0, bandCap - 1));
+    pinnedOverflow = liveRows.length - pinnedRows.length;
+  }
+  const bandHeight = pinnedRows.length + (pinnedOverflow > 0 ? 1 : 0);
+  const treeVisibleCount = Math.max(1, visibleCount - bandHeight);
+
   let scrollTop = 0;
   if (needsOverflow && selectedFlatIndex >= 0) {
-    scrollTop = Math.max(0, selectedFlatIndex - visibleCount + 1);
-    scrollTop = Math.min(scrollTop, Math.max(0, totalRows - visibleCount));
+    scrollTop = Math.max(0, selectedFlatIndex - treeVisibleCount + 1);
+    scrollTop = Math.min(scrollTop, Math.max(0, totalRows - treeVisibleCount));
   }
 
-  const displayRows = flatRows.slice(scrollTop, scrollTop + visibleCount);
+  const displayRows = flatRows.slice(scrollTop, scrollTop + treeVisibleCount);
   const hiddenBelow = totalRows - (scrollTop + displayRows.length);
+
+  const overflowLabel = `▸ +${pinnedOverflow} more working`;
 
   return (
     <Box flexDirection="column" width={width}>
       <Text>{titleLine}</Text>
       {renderCensusRow()}
+      {pinnedRows.map((row, idx) => (
+        <SessionRow
+          key={`pin-${row.session.id}-${idx}`}
+          session={row.session}
+          isSelected={row.session.id === selectedId}
+          hasFocus={hasFocus}
+          prefix={row.prefix}
+          contentWidth={contentWidth}
+        />
+      ))}
+      {pinnedOverflow > 0 && (
+        <Text>
+          {BOX.v} <Text color="green">{overflowLabel}</Text>
+          {" ".repeat(Math.max(0, contentWidth - overflowLabel.length - 1))}
+          {BOX.v}
+        </Text>
+      )}
       {displayRows.map((row, idx) =>
         row.kind === "project" ? (
           <ProjectRow

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -445,9 +445,10 @@ function flattenSessions(
 
 /** A flattened row for a session RUNNING right now: a top-level session
  * that is working or waiting, or a sub-agent that is working (sub-agents
- * never surface "waiting" — see App's liveness rule). Pins key on
- * liveState, NOT the 30-min hot window, so finished-but-recent sub-agents
- * don't flood the pinned band. */
+ * never surface "waiting" — `detectLiveState` in sessionLiveness.ts forces
+ * a sub-agent's state to working|null). Pins key on liveState, NOT the
+ * 30-min hot window, so finished-but-recent sub-agents don't flood the
+ * band. `isParent` mirrors SessionRow's own `prefix === "    "` test. */
 function isLiveSessionRow(
   row: FlatRow,
 ): row is Extract<FlatRow, { kind: "session" }> {
@@ -976,20 +977,7 @@ export function SessionTreePanel({
   const flatRows = flattenSessions(projects, coldProjects, expandedIds);
   const totalRows = flatRows.length;
 
-  // Find the index of the currently selected row
-  const selectedFlatIndex = flatRows.findIndex((row) => {
-    if (row.kind === "project") return selectedId === row.sentinelId;
-    if (row.kind === "session") return row.session.id === selectedId;
-    if (row.kind === "subagent-summary")
-      return selectedId === `__sub-${row.parentId}__`;
-    if (row.kind === "cold-projects-summary") return selectedId === "__cold__";
-    if (row.kind === "cold-sessions-summary")
-      return selectedId === `__cold-sessions-${row.projectName}__`;
-    return false;
-  });
-
-  // Compute scrollTop so the selected row stays visible. Census
-  // takes one row inside the panel content area when present, so
+  // Census takes one row inside the panel content area when present, so
   // the effective row budget shrinks by 1 in that case.
   const censusRowCost = censusSegments ? 1 : 0;
   const effectiveMaxRows =
@@ -1002,26 +990,60 @@ export function SessionTreePanel({
   // RIGHT NOW (working/waiting) must never scroll out of view — that's the
   // point of a live monitor. Pin them above the scrollable tree, capped to
   // half the budget so a burst of concurrent sub-agents can't eat the
-  // panel; the overflow collapses to a "+N working" line.
+  // panel; the overflow collapses to a "+N more working" line. Pinned rows
+  // are removed from the tree below so a live row never renders twice.
   const liveRows = needsOverflow ? flatRows.filter(isLiveSessionRow) : [];
   const bandCap = Math.max(1, Math.floor(visibleCount / 2));
-  let pinnedRows = liveRows.slice(0, bandCap);
-  let pinnedOverflow = liveRows.length - pinnedRows.length;
-  if (pinnedOverflow > 0) {
-    pinnedRows = liveRows.slice(0, Math.max(0, bandCap - 1));
+  let pinnedRows: Extract<FlatRow, { kind: "session" }>[];
+  let pinnedOverflow: number;
+  if (liveRows.length <= bandCap) {
+    pinnedRows = liveRows;
+    pinnedOverflow = 0;
+  } else if (bandCap === 1) {
+    // No room for both a row and a summary — always show at least one live
+    // row (the band's whole purpose), and drop the count.
+    pinnedRows = liveRows.slice(0, 1);
+    pinnedOverflow = 0;
+  } else {
+    // Reserve one slot for the "+N more working" summary line.
+    pinnedRows = liveRows.slice(0, bandCap - 1);
     pinnedOverflow = liveRows.length - pinnedRows.length;
   }
   const bandHeight = pinnedRows.length + (pinnedOverflow > 0 ? 1 : 0);
-  const treeVisibleCount = Math.max(1, visibleCount - bandHeight);
 
+  // The scrollable tree excludes pinned rows (no double render).
+  const pinnedIds = new Set(pinnedRows.map((r) => r.session.id));
+  const treeRows =
+    bandHeight > 0
+      ? flatRows.filter(
+          (r) => !(r.kind === "session" && pinnedIds.has(r.session.id)),
+        )
+      : flatRows;
+  const treeTotal = treeRows.length;
+
+  // Index of the selected row within the (de-pinned) tree. A selected row
+  // that is itself pinned won't be found here — it's shown in the band.
+  const selectedFlatIndex = treeRows.findIndex((row) => {
+    if (row.kind === "project") return selectedId === row.sentinelId;
+    if (row.kind === "session") return row.session.id === selectedId;
+    if (row.kind === "subagent-summary")
+      return selectedId === `__sub-${row.parentId}__`;
+    if (row.kind === "cold-projects-summary") return selectedId === "__cold__";
+    if (row.kind === "cold-sessions-summary")
+      return selectedId === `__cold-sessions-${row.projectName}__`;
+    return false;
+  });
+
+  // Compute scrollTop so the selected tree row stays visible.
+  const treeVisibleCount = Math.max(1, visibleCount - bandHeight);
   let scrollTop = 0;
-  if (needsOverflow && selectedFlatIndex >= 0) {
+  if (treeTotal > treeVisibleCount && selectedFlatIndex >= 0) {
     scrollTop = Math.max(0, selectedFlatIndex - treeVisibleCount + 1);
-    scrollTop = Math.min(scrollTop, Math.max(0, totalRows - treeVisibleCount));
+    scrollTop = Math.min(scrollTop, Math.max(0, treeTotal - treeVisibleCount));
   }
 
-  const displayRows = flatRows.slice(scrollTop, scrollTop + treeVisibleCount);
-  const hiddenBelow = totalRows - (scrollTop + displayRows.length);
+  const displayRows = treeRows.slice(scrollTop, scrollTop + treeVisibleCount);
+  const hiddenBelow = treeTotal - (scrollTop + displayRows.length);
 
   const overflowLabel = `▸ +${pinnedOverflow} more working`;
 

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -1074,3 +1074,89 @@ describe("buildTitleSegments", () => {
     expect(concat(segs)).not.toContain("⊘");
   });
 });
+
+describe("SessionTreePanel — pinned live rows", () => {
+  const coldFiller = (n: number) =>
+    Array.from({ length: n }, (_, i) =>
+      makeProject(
+        `coldp${i}`,
+        [makeSession({ id: `coldsess${i}`, status: "cold" })],
+        {
+          hotness: "cold",
+        },
+      ),
+    );
+
+  it("keeps a live session visible when the selection scrolls to the bottom (short panel)", () => {
+    // Several hot (but NOT live) sub-agents shown individually add rows, so
+    // that with the selection on the bottom cold sentinel the live session
+    // would otherwise scroll off the top.
+    const live = makeSession({
+      id: "live0001",
+      status: "hot",
+      liveState: "working",
+      firstUserPrompt: "active work",
+      subAgents: Array.from({ length: 6 }, (_, i) =>
+        makeSession({
+          id: `hs${i}`,
+          status: "hot",
+          liveState: null,
+          projectName: "",
+        }),
+      ),
+    });
+    const active = makeProject("liveproj", [live]);
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[active]}
+        coldProjects={coldFiller(8)}
+        selectedId="__cold__"
+        hasFocus={true}
+        width={110}
+        maxRows={4}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("#live"); // pinned, not scrolled off
+  });
+
+  it("pins by liveState, not the 30-min hot window: finished sub-agents don't flood", () => {
+    // A live parent with one WORKING sub-agent and many recently-finished
+    // (status hot, liveState null) ones. Only the working one should pin.
+    const parent = makeSession({
+      id: "par00001",
+      status: "hot",
+      liveState: "working",
+      subAgents: [
+        makeSession({
+          id: "subwork1",
+          status: "hot",
+          liveState: "working",
+          projectName: "",
+        }),
+        ...Array.from({ length: 6 }, (_, i) =>
+          makeSession({
+            id: `subdone${i}`,
+            status: "hot",
+            liveState: null,
+            projectName: "",
+          }),
+        ),
+      ],
+    });
+    const active = makeProject("liveproj", [parent]);
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[active]}
+        coldProjects={coldFiller(8)}
+        selectedId="__cold__"
+        hasFocus={true}
+        width={110}
+        maxRows={6}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("#par0"); // live parent pinned
+    expect(frame).toContain("subwor"); // working sub-agent pinned
+  });
+});

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -1159,4 +1159,92 @@ describe("SessionTreePanel — pinned live rows", () => {
     expect(frame).toContain("#par0"); // live parent pinned
     expect(frame).toContain("subwor"); // working sub-agent pinned
   });
+
+  it("does not render a pinned live row twice (band + tree)", () => {
+    const live = makeSession({
+      id: "live0001",
+      status: "hot",
+      liveState: "working",
+      subAgents: Array.from({ length: 6 }, (_, i) =>
+        makeSession({
+          id: `hs${i}`,
+          status: "hot",
+          liveState: null,
+          projectName: "",
+        }),
+      ),
+    });
+    const active = makeProject("liveproj", [live]);
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[active]}
+        coldProjects={coldFiller(8)}
+        selectedId="live0001" // selecting the live row would scroll the tree to it
+        hasFocus={true}
+        width={110}
+        maxRows={6}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    const occurrences = (frame.match(/#live/g) ?? []).length;
+    expect(occurrences).toBe(1); // pinned only, removed from the tree
+  });
+
+  it("caps the band and summarizes the overflow as '+N more working'", () => {
+    const live = Array.from({ length: 8 }, (_, i) =>
+      makeProject(`lp${i}`, [
+        makeSession({ id: `lv${i}aaaa`, status: "hot", liveState: "working" }),
+      ]),
+    );
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={live}
+        coldProjects={coldFiller(4)}
+        selectedId="__cold__"
+        hasFocus={true}
+        width={110}
+        maxRows={8}
+      />,
+    );
+    expect(lastFrame() ?? "").toContain("more working"); // overflow summarized
+  });
+
+  it("shows at least one live row even in a tiny panel (bandCap === 1)", () => {
+    const live = Array.from({ length: 5 }, (_, i) =>
+      makeProject(`lp${i}`, [
+        makeSession({ id: `lv${i}aaaa`, status: "hot", liveState: "working" }),
+      ]),
+    );
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={live}
+        coldProjects={coldFiller(4)}
+        selectedId="__cold__"
+        hasFocus={true}
+        width={110}
+        maxRows={3}
+      />,
+    );
+    expect(lastFrame() ?? "").toContain("[working]"); // a real live row, not just a count
+  });
+
+  it("does not pin anything when no session is live (no regression)", () => {
+    const hotButIdle = makeSession({
+      id: "idle0001",
+      status: "hot",
+      liveState: null,
+    });
+    const active = makeProject("liveproj", [hotButIdle]);
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[active]}
+        coldProjects={coldFiller(8)}
+        selectedId="__cold__"
+        hasFocus={true}
+        width={110}
+        maxRows={4}
+      />,
+    );
+    expect(lastFrame() ?? "").not.toContain("more working");
+  });
 });


### PR DESCRIPTION
## Problem

In a short Projects panel, active sessions scrolled off the top when the selection moved to a lower row (e.g. a cold sentinel). The census reported N active but you couldn't see them — defeating the live-monitor purpose. Reproduced in v0.18.9 and current main.

## Fix

Pin **live** rows above the scrollable tree (`src/ui/SessionTreePanel.tsx`):
- **Live = liveState**, not mtime: top-level session working|waiting, or sub-agent working. A finished-but-recent sub-agent (liveState null, still <30min "hot") is NOT pinned, so short-lived discarded sub-agents can't flood the band.
- **Capped** at half the row budget; overflow collapses to `▸ +N more working`. A tiny panel (bandCap===1) still shows at least one live row.
- Pinned rows are **removed from the tree** below, so a live session never renders twice.
- Only engages on overflow; otherwise behaviour is unchanged.

## Verified

Real-tree render at short heights confirms both active sessions stay pinned with the selection on a bottom cold sentinel, no duplication. Independently reviewed — both must-fix findings (duplication, bandCap===1 degenerate) addressed in the second commit.

## Tests (TDD)

6 new cases: live visible despite bottom selection; pin-by-liveState (no flood); no double render; capped overflow line; tiny-panel guarantees a row; no band when nothing live. Full suite + tsc + biome green.

## Known follow-up (not blocking)

Pinned rows don't show their project header (only `#id [working] title`). Title usually disambiguates; project context could be added later.

Closes #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session panel now pins active/working sessions to the top, keeping them visible while scrolling through the tree. Displays an overflow indicator when capacity is exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->