### PR TITLE
feat(ui): pin live PROJECTS as a sticky block (replaces the detached session band)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@
   and the activity timeline. Loaded through a guarded require so agenthud
   still runs on Node < 22 (the provider is simply unavailable there — no
   new dependency, no engine bump). Schema: `docs/schemas/opencode-session.md`.
-- **Pinned live sessions.** In a short Projects panel, sessions running
-  right now (working/waiting) are pinned above the scrollable tree so they
-  never scroll out of view, capped to half the panel with a `+N more
-  working` overflow line. Keyed on liveState, not the 30-min hot window,
-  so finished-but-recent sub-agents don't flood it.
+- **Sticky live projects.** In a short Projects panel, projects that are
+  running right now stay anchored as a sticky block at the top — header
+  plus their sessions/sub-agents, hierarchy intact — so the live monitor
+  never scrolls active work out of view; only the cold tail scrolls. A
+  project is "live" when it has a working/waiting session or a working
+  sub-agent (keyed on liveState, not the 30-min hot window, so a project
+  whose sub-agents just finished doesn't stay pinned). Live projects sort
+  first; the prefix is capped so it can't swallow the whole panel.
 
 ### Fixed
 - **Bound `widthCache`** to stop unbounded memory growth. `getDisplayWidth`

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -457,19 +457,21 @@ function flattenSessions(
   return result;
 }
 
-/** A flattened row for a session RUNNING right now: a top-level session
- * that is working or waiting, or a sub-agent that is working (sub-agents
- * never surface "waiting" — `detectLiveState` in sessionLiveness.ts forces
- * a sub-agent's state to working|null). Pins key on liveState, NOT the
- * 30-min hot window, so finished-but-recent sub-agents don't flood the
- * band. `isParent` mirrors SessionRow's own `prefix === "    "` test. */
-function isLiveSessionRow(
-  row: FlatRow,
-): row is Extract<FlatRow, { kind: "session" }> {
-  if (row.kind !== "session") return false;
-  const isParent = row.prefix === "    ";
-  const ls = row.session.liveState;
-  return isParent ? ls === "working" || ls === "waiting" : ls === "working";
+/** A project is "live" when something is RUNNING in it right now: a
+ * top-level session that is working or waiting, or a sub-agent that is
+ * working (sub-agents never surface "waiting" — `detectLiveState` in
+ * sessionLiveness.ts forces a sub-agent's state to working|null). Keyed on
+ * liveState, NOT the 30-min hot window, so a project whose sub-agents just
+ * finished doesn't stay pinned. Live projects are anchored as a sticky top
+ * block so the monitor never scrolls active work out of view. */
+function isProjectLive(project: ProjectNode): boolean {
+  for (const s of project.sessions) {
+    if (s.liveState === "working" || s.liveState === "waiting") return true;
+    for (const sa of s.subAgents) {
+      if (sa.liveState === "working") return true;
+    }
+  }
+  return false;
 }
 
 function ProjectRow({
@@ -988,7 +990,21 @@ export function SessionTreePanel({
     );
   }
 
-  const flatRows = flattenSessions(projects, coldProjects, expandedIds);
+  // Live projects sort first so the sticky top block (below) is a clean
+  // leading prefix of the flattened rows.
+  const liveProjectPaths = new Set<string>();
+  for (const p of projects) {
+    if (isProjectLive(p)) liveProjectPaths.add(p.projectPath);
+  }
+  const orderedActive =
+    liveProjectPaths.size > 0 && liveProjectPaths.size < projects.length
+      ? [...projects].sort(
+          (a, b) =>
+            (liveProjectPaths.has(a.projectPath) ? 0 : 1) -
+            (liveProjectPaths.has(b.projectPath) ? 0 : 1),
+        )
+      : projects;
+  const flatRows = flattenSessions(orderedActive, coldProjects, expandedIds);
   const totalRows = flatRows.length;
 
   // Census takes one row inside the panel content area when present, so
@@ -1000,44 +1016,33 @@ export function SessionTreePanel({
     effectiveMaxRows !== undefined && totalRows > effectiveMaxRows;
   const visibleCount = needsOverflow ? effectiveMaxRows - 1 : totalRows;
 
-  // Pinned "live" band: when the tree overflows, sessions that are running
-  // RIGHT NOW (working/waiting) must never scroll out of view — that's the
-  // point of a live monitor. Pin them above the scrollable tree, capped to
-  // half the budget so a burst of concurrent sub-agents can't eat the
-  // panel; the overflow collapses to a "+N more working" line. Pinned rows
-  // are removed from the tree below so a live row never renders twice.
-  const liveRows = needsOverflow ? flatRows.filter(isLiveSessionRow) : [];
-  const bandCap = Math.max(1, Math.floor(visibleCount / 2));
-  let pinnedRows: Extract<FlatRow, { kind: "session" }>[];
-  let pinnedOverflow: number;
-  if (liveRows.length <= bandCap) {
-    pinnedRows = liveRows;
-    pinnedOverflow = 0;
-  } else if (bandCap === 1) {
-    // No room for both a row and a summary — always show at least one live
-    // row (the band's whole purpose), and drop the count.
-    pinnedRows = liveRows.slice(0, 1);
-    pinnedOverflow = 0;
-  } else {
-    // Reserve one slot for the "+N more working" summary line.
-    pinnedRows = liveRows.slice(0, bandCap - 1);
-    pinnedOverflow = liveRows.length - pinnedRows.length;
+  // Sticky live-project prefix: keep whole live-project blocks (header +
+  // their sessions/sub-agents, hierarchy intact) anchored at the top; only
+  // the cold tail below scrolls. A session always stays under its own
+  // header (unlike a detached session band). The leading rows are the live
+  // projects (sorted first above); stop at the first non-live project
+  // header or the cold-projects summary.
+  let livePrefixCount = 0;
+  for (const row of flatRows) {
+    if (row.kind === "project") {
+      if (!liveProjectPaths.has(row.project.projectPath)) break;
+    } else if (row.kind === "cold-projects-summary") {
+      break;
+    }
+    livePrefixCount++;
   }
-  const bandHeight = pinnedRows.length + (pinnedOverflow > 0 ? 1 : 0);
+  // Cap the sticky prefix so it can't swallow the whole panel — always
+  // leave at least one row for the scrollable tail.
+  const pinnedCount = needsOverflow
+    ? Math.min(livePrefixCount, Math.max(0, visibleCount - 1))
+    : 0;
+  const pinnedRows = flatRows.slice(0, pinnedCount);
+  const restRows = flatRows.slice(pinnedCount);
+  const restTotal = restRows.length;
 
-  // The scrollable tree excludes pinned rows (no double render).
-  const pinnedIds = new Set(pinnedRows.map((r) => r.session.id));
-  const treeRows =
-    bandHeight > 0
-      ? flatRows.filter(
-          (r) => !(r.kind === "session" && pinnedIds.has(r.session.id)),
-        )
-      : flatRows;
-  const treeTotal = treeRows.length;
-
-  // Index of the selected row within the (de-pinned) tree. A selected row
-  // that is itself pinned won't be found here — it's shown in the band.
-  const selectedFlatIndex = treeRows.findIndex((row) => {
+  // Index of the selected row within the scrollable tail (pinned rows are
+  // always visible, so a selection there needs no scroll).
+  const selectedRestIndex = restRows.findIndex((row) => {
     if (row.kind === "project") return selectedId === row.sentinelId;
     if (row.kind === "session") return row.session.id === selectedId;
     if (row.kind === "subagent-summary")
@@ -1048,87 +1053,71 @@ export function SessionTreePanel({
     return false;
   });
 
-  // Compute scrollTop so the selected tree row stays visible.
-  const treeVisibleCount = Math.max(1, visibleCount - bandHeight);
+  // Compute scrollTop so the selected tail row stays visible.
+  const treeVisibleCount = Math.max(1, visibleCount - pinnedRows.length);
   let scrollTop = 0;
-  if (treeTotal > treeVisibleCount && selectedFlatIndex >= 0) {
-    scrollTop = Math.max(0, selectedFlatIndex - treeVisibleCount + 1);
-    scrollTop = Math.min(scrollTop, Math.max(0, treeTotal - treeVisibleCount));
+  if (restTotal > treeVisibleCount && selectedRestIndex >= 0) {
+    scrollTop = Math.max(0, selectedRestIndex - treeVisibleCount + 1);
+    scrollTop = Math.min(scrollTop, Math.max(0, restTotal - treeVisibleCount));
   }
 
-  const displayRows = treeRows.slice(scrollTop, scrollTop + treeVisibleCount);
-  const hiddenBelow = treeTotal - (scrollTop + displayRows.length);
+  const displayRows = restRows.slice(scrollTop, scrollTop + treeVisibleCount);
+  const hiddenBelow = restTotal - (scrollTop + displayRows.length);
 
-  const overflowLabel = `▸ +${pinnedOverflow} more working`;
+  // One row renderer for both the sticky prefix and the scrollable tail.
+  const renderRow = (row: FlatRow, key: string) =>
+    row.kind === "project" ? (
+      <ProjectRow
+        key={key}
+        project={row.project}
+        isSelected={selectedId === row.sentinelId}
+        hasFocus={hasFocus}
+        contentWidth={contentWidth}
+        census={census}
+      />
+    ) : row.kind === "session" ? (
+      <SessionRow
+        key={key}
+        session={row.session}
+        isSelected={row.session.id === selectedId}
+        hasFocus={hasFocus}
+        prefix={row.prefix}
+        contentWidth={contentWidth}
+      />
+    ) : row.kind === "subagent-summary" ? (
+      <SubagentSummaryRow
+        key={key}
+        coolCount={row.coolCount}
+        coldCount={row.coldCount}
+        contentWidth={contentWidth}
+        isSelected={selectedId === `__sub-${row.parentId}__`}
+        hasFocus={hasFocus}
+      />
+    ) : row.kind === "cold-projects-summary" ? (
+      <ColdProjectsSummaryRow
+        key={key}
+        count={row.count}
+        isSelected={selectedId === "__cold__"}
+        hasFocus={hasFocus}
+        width={width}
+      />
+    ) : (
+      <ColdSessionsSummaryRow
+        key={key}
+        count={row.count}
+        projectName={row.projectName}
+        isSelected={selectedId === `__cold-sessions-${row.projectName}__`}
+        hasFocus={hasFocus}
+        contentWidth={contentWidth}
+      />
+    );
 
   return (
     <Box flexDirection="column" width={width}>
       <Text>{titleLine}</Text>
       {renderCensusRow()}
-      {pinnedRows.map((row, idx) => (
-        <SessionRow
-          key={`pin-${row.session.id}-${idx}`}
-          session={row.session}
-          isSelected={row.session.id === selectedId}
-          hasFocus={hasFocus}
-          prefix={row.prefix}
-          contentWidth={contentWidth}
-        />
-      ))}
-      {pinnedOverflow > 0 && (
-        <Text>
-          {BOX.v} <Text color="green">{overflowLabel}</Text>
-          {" ".repeat(Math.max(0, contentWidth - overflowLabel.length - 1))}
-          {BOX.v}
-        </Text>
-      )}
-      {displayRows.map((row, idx) =>
-        row.kind === "project" ? (
-          <ProjectRow
-            key={`project-${row.project.name}-${idx}`}
-            project={row.project}
-            isSelected={selectedId === row.sentinelId}
-            hasFocus={hasFocus}
-            contentWidth={contentWidth}
-            census={census}
-          />
-        ) : row.kind === "session" ? (
-          <SessionRow
-            key={`${row.session.id}-${idx}`}
-            session={row.session}
-            isSelected={row.session.id === selectedId}
-            hasFocus={hasFocus}
-            prefix={row.prefix}
-            contentWidth={contentWidth}
-          />
-        ) : row.kind === "subagent-summary" ? (
-          <SubagentSummaryRow
-            key={`subagent-summary-${idx}`}
-            coolCount={row.coolCount}
-            coldCount={row.coldCount}
-            contentWidth={contentWidth}
-            isSelected={selectedId === `__sub-${row.parentId}__`}
-            hasFocus={hasFocus}
-          />
-        ) : row.kind === "cold-projects-summary" ? (
-          <ColdProjectsSummaryRow
-            key="cold-summary"
-            count={row.count}
-            isSelected={selectedId === "__cold__"}
-            hasFocus={hasFocus}
-            width={width}
-          />
-        ) : (
-          <ColdSessionsSummaryRow
-            key={`cold-sessions-${row.projectName}`}
-            count={row.count}
-            projectName={row.projectName}
-            isSelected={selectedId === `__cold-sessions-${row.projectName}__`}
-            hasFocus={hasFocus}
-            contentWidth={contentWidth}
-          />
-        ),
-      )}
+      {pinnedRows.map((row, idx) => renderRow(row, `pin-${idx}`))}
+      {displayRows.map((row, idx) => renderRow(row, `row-${idx}`))}
       {hiddenBelow > 0 && (
         <Text>
           {BOX.v} <Text dimColor>{`... ${hiddenBelow} more`}</Text>

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -1099,58 +1099,89 @@ describe("buildTitleSegments", () => {
   });
 });
 
-describe("SessionTreePanel — pinned live rows", () => {
+describe("SessionTreePanel — sticky live projects", () => {
   const coldFiller = (n: number) =>
     Array.from({ length: n }, (_, i) =>
       makeProject(
         `coldp${i}`,
         [makeSession({ id: `coldsess${i}`, status: "cold" })],
-        {
-          hotness: "cold",
-        },
+        { hotness: "cold" },
       ),
     );
+  const lineOf = (frame: string, needle: string) =>
+    frame.split("\n").findIndex((l) => l.includes(needle));
 
-  it("keeps a live session visible when the selection scrolls to the bottom (short panel)", () => {
-    // Several hot (but NOT live) sub-agents shown individually add rows, so
-    // that with the selection on the bottom cold sentinel the live session
-    // would otherwise scroll off the top.
-    const live = makeSession({
-      id: "live0001",
+  it("pins a live project as a sticky block — session stays UNDER its own header, not above it", () => {
+    // Input order puts the non-live (hot, but not working) project first;
+    // the live project must sort first AND stay pinned with the selection on
+    // the bottom cold sentinel — with the header above its session.
+    const liveSession = makeSession({
+      id: "liveAAAA",
       status: "hot",
       liveState: "working",
       firstUserPrompt: "active work",
-      subAgents: Array.from({ length: 6 }, (_, i) =>
-        makeSession({
-          id: `hs${i}`,
-          status: "hot",
-          liveState: null,
-          projectName: "",
-        }),
-      ),
     });
-    const active = makeProject("liveproj", [live]);
+    const liveProj = makeProject("liveproj", [liveSession]);
+    const idleProj = makeProject("idleproj", [
+      makeSession({ id: "idleBBBB", status: "hot", liveState: null }),
+    ]);
     const { lastFrame } = render(
       <SessionTreePanel
-        projects={[active]}
-        coldProjects={coldFiller(8)}
+        projects={[idleProj, liveProj]}
+        coldProjects={coldFiller(10)}
         selectedId="__cold__"
         hasFocus={true}
-        width={110}
+        width={120}
         maxRows={4}
       />,
     );
     const frame = lastFrame() ?? "";
-    expect(frame).toContain("#live"); // pinned, not scrolled off
+    const header = lineOf(frame, "> liveproj");
+    const session = lineOf(frame, "#live");
+    expect(header).toBeGreaterThanOrEqual(0); // live project header pinned
+    expect(session).toBeGreaterThan(header); // its session sits UNDER the header
+    // the non-live project is not pinned — it scrolled away
+    expect(frame).not.toContain("> idleproj");
   });
 
-  it("pins by liveState, not the 30-min hot window: finished sub-agents don't flood", () => {
-    // A live parent with one WORKING sub-agent and many recently-finished
-    // (status hot, liveState null) ones. Only the working one should pin.
+  it("treats liveState (not the 30-min hot window) as 'live'", () => {
+    // A project whose only session is hot but NOT working/waiting is not
+    // live, so it is NOT pinned and scrolls off under a bottom selection.
+    const idleProj = makeProject("idleproj", [
+      makeSession({
+        id: "idleAAAA",
+        status: "hot",
+        liveState: null,
+        subAgents: Array.from({ length: 6 }, (_, i) =>
+          makeSession({
+            id: `done${i}`,
+            status: "hot",
+            liveState: null,
+            projectName: "",
+          }),
+        ),
+      }),
+    ]);
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[idleProj]}
+        coldProjects={coldFiller(10)}
+        selectedId="__cold__"
+        hasFocus={true}
+        width={120}
+        maxRows={4}
+      />,
+    );
+    // selection is on the cold sentinel; nothing is live, so nothing is
+    // pinned and the cold tail is what shows.
+    expect(lastFrame() ?? "").toContain("cold");
+  });
+
+  it("a working sub-agent makes its project live (whole block pinned)", () => {
     const parent = makeSession({
-      id: "par00001",
+      id: "parAAAAA",
       status: "hot",
-      liveState: "working",
+      liveState: null, // parent idle, but a sub-agent is working
       subAgents: [
         makeSession({
           id: "subwork1",
@@ -1158,117 +1189,21 @@ describe("SessionTreePanel — pinned live rows", () => {
           liveState: "working",
           projectName: "",
         }),
-        ...Array.from({ length: 6 }, (_, i) =>
-          makeSession({
-            id: `subdone${i}`,
-            status: "hot",
-            liveState: null,
-            projectName: "",
-          }),
-        ),
       ],
     });
-    const active = makeProject("liveproj", [parent]);
+    const liveProj = makeProject("liveproj", [parent]);
     const { lastFrame } = render(
       <SessionTreePanel
-        projects={[active]}
-        coldProjects={coldFiller(8)}
+        projects={[liveProj]}
+        coldProjects={coldFiller(10)}
         selectedId="__cold__"
         hasFocus={true}
-        width={110}
-        maxRows={6}
-      />,
-    );
-    const frame = lastFrame() ?? "";
-    expect(frame).toContain("#par0"); // live parent pinned
-    expect(frame).toContain("subwor"); // working sub-agent pinned
-  });
-
-  it("does not render a pinned live row twice (band + tree)", () => {
-    const live = makeSession({
-      id: "live0001",
-      status: "hot",
-      liveState: "working",
-      subAgents: Array.from({ length: 6 }, (_, i) =>
-        makeSession({
-          id: `hs${i}`,
-          status: "hot",
-          liveState: null,
-          projectName: "",
-        }),
-      ),
-    });
-    const active = makeProject("liveproj", [live]);
-    const { lastFrame } = render(
-      <SessionTreePanel
-        projects={[active]}
-        coldProjects={coldFiller(8)}
-        selectedId="live0001" // selecting the live row would scroll the tree to it
-        hasFocus={true}
-        width={110}
-        maxRows={6}
-      />,
-    );
-    const frame = lastFrame() ?? "";
-    const occurrences = (frame.match(/#live/g) ?? []).length;
-    expect(occurrences).toBe(1); // pinned only, removed from the tree
-  });
-
-  it("caps the band and summarizes the overflow as '+N more working'", () => {
-    const live = Array.from({ length: 8 }, (_, i) =>
-      makeProject(`lp${i}`, [
-        makeSession({ id: `lv${i}aaaa`, status: "hot", liveState: "working" }),
-      ]),
-    );
-    const { lastFrame } = render(
-      <SessionTreePanel
-        projects={live}
-        coldProjects={coldFiller(4)}
-        selectedId="__cold__"
-        hasFocus={true}
-        width={110}
-        maxRows={8}
-      />,
-    );
-    expect(lastFrame() ?? "").toContain("more working"); // overflow summarized
-  });
-
-  it("shows at least one live row even in a tiny panel (bandCap === 1)", () => {
-    const live = Array.from({ length: 5 }, (_, i) =>
-      makeProject(`lp${i}`, [
-        makeSession({ id: `lv${i}aaaa`, status: "hot", liveState: "working" }),
-      ]),
-    );
-    const { lastFrame } = render(
-      <SessionTreePanel
-        projects={live}
-        coldProjects={coldFiller(4)}
-        selectedId="__cold__"
-        hasFocus={true}
-        width={110}
-        maxRows={3}
-      />,
-    );
-    expect(lastFrame() ?? "").toContain("[working]"); // a real live row, not just a count
-  });
-
-  it("does not pin anything when no session is live (no regression)", () => {
-    const hotButIdle = makeSession({
-      id: "idle0001",
-      status: "hot",
-      liveState: null,
-    });
-    const active = makeProject("liveproj", [hotButIdle]);
-    const { lastFrame } = render(
-      <SessionTreePanel
-        projects={[active]}
-        coldProjects={coldFiller(8)}
-        selectedId="__cold__"
-        hasFocus={true}
-        width={110}
+        width={120}
         maxRows={4}
       />,
     );
-    expect(lastFrame() ?? "").not.toContain("more working");
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("> liveproj"); // project pinned because a sub-agent is working
+    expect(frame).toContain("subwor"); // the working sub-agent stays visible
   });
 });

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -1206,4 +1206,92 @@ describe("SessionTreePanel — sticky live projects", () => {
     expect(frame).toContain("> liveproj"); // project pinned because a sub-agent is working
     expect(frame).toContain("subwor"); // the working sub-agent stays visible
   });
+
+  it("keeps the header when a single live block is taller than the panel", () => {
+    // One live project with many hot (non-live) sub-agents shown
+    // individually — the block alone exceeds the row budget.
+    const live = makeSession({
+      id: "liveAAAA",
+      status: "hot",
+      liveState: "working",
+      subAgents: Array.from({ length: 12 }, (_, i) =>
+        makeSession({
+          id: `hs${i}`,
+          status: "hot",
+          liveState: null,
+          projectName: "",
+        }),
+      ),
+    });
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[makeProject("liveproj", [live])]}
+        coldProjects={coldFiller(6)}
+        selectedId="__cold__"
+        hasFocus={true}
+        width={120}
+        maxRows={5}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("> liveproj"); // header always retained (block starts with it)
+    expect(frame).toContain("6 cold"); // the cold tail (selected) scrolled into view
+  });
+
+  it("scrolls a selected cold row into view while the live project stays pinned", () => {
+    const live = makeSession({
+      id: "liveAAAA",
+      status: "hot",
+      liveState: "working",
+    });
+    const liveProj = makeProject("liveproj", [live]);
+    const cold = coldFiller(10);
+    // expand the cold-projects group and select a deep cold session
+    const expanded = new Set<string>([
+      "__cold__",
+      "__expanded-__proj-coldp9__",
+    ]);
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[liveProj]}
+        coldProjects={cold}
+        selectedId="coldsess9"
+        hasFocus={true}
+        width={120}
+        maxRows={6}
+        expandedIds={expanded}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("> liveproj"); // live project still pinned at top
+    expect(frame).toContain("#cold"); // the selected deep cold session scrolled into view
+  });
+
+  it("does not pin a hot-but-idle project — it scrolls under a bottom selection", () => {
+    const idle = makeSession({
+      id: "idleAAAA",
+      status: "hot",
+      liveState: null,
+      subAgents: Array.from({ length: 6 }, (_, i) =>
+        makeSession({
+          id: `hs${i}`,
+          status: "hot",
+          liveState: null,
+          projectName: "",
+        }),
+      ),
+    });
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[makeProject("idleproj", [idle])]}
+        coldProjects={coldFiller(8)}
+        selectedId="__cold__"
+        hasFocus={true}
+        width={120}
+        maxRows={4}
+      />,
+    );
+    // nothing live → no sticky prefix → the idle session scrolls off
+    expect(lastFrame() ?? "").not.toContain("#idle");
+  });
 });


### PR DESCRIPTION
## Problem

The #173 pin pulled individual **live session rows** into a band at the very top, detached from their project header. A launcher session rendered *above* the `> launcher` header — looked like broken tree ordering. (Reported in use.)

## Fix (agreed direction: pin live *projects*, not sessions)

Keep the tree hierarchy intact. Whole **live-project blocks** (header + their sessions/sub-agents) anchor as a sticky prefix at the top; only the cold tail (cold-session summaries, cold projects) scrolls below. A session always stays **under its own header**.

- **"Live" project** = a session with `liveState` working|waiting, OR a sub-agent with `liveState` working. Not mtime hot/warm — a project whose sub-agents just finished isn't pinned (keeps the no-30-min-flood rule from #172).
- Live projects sort first; the sticky prefix is capped (always leaves ≥1 row for the scrollable tail); selection in the tail scrolls normally.
- Removes `isLiveSessionRow` + the band/overflow logic; a single `renderRow` now serves both the sticky prefix and the scrolled tail.

## Verified

Real-tree render at short heights: live projects (`> agenthud` / `> launcher`) stay pinned with their sessions **under** them; cold projects collapse/scroll at the bottom. The "session above its project header" confusion is gone.

## Tests

Replaced the band tests with sticky-project tests: live project pinned with header-above-session (and non-live project scrolls away), liveState-not-mtime, and a working sub-agent making its project live. Full suite + tsc + biome green.

## Note

Supersedes the band approach from #173 (merged into the unreleased 0.19.0). CHANGELOG's 0.19.0 entry updated to describe the project-level behavior.

Closes #174