### PR TITLE
fix(ui): align right border of '... N more' / 'No activity yet' lines (off-by-one)

### DIFF
--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -319,7 +319,7 @@ export function ActivityViewerPanel({
 
   if (visibleActivities.length === 0) {
     const emptyText = "No activity yet";
-    const emptyPadding = Math.max(0, contentWidth - emptyText.length - 1);
+    const emptyPadding = Math.max(0, contentWidth - emptyText.length);
     lines.push(
       <Text key="empty">
         {BOX.v} <Text dimColor>{emptyText}</Text>

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -1122,7 +1122,7 @@ export function SessionTreePanel({
         <Text>
           {BOX.v} <Text dimColor>{`... ${hiddenBelow} more`}</Text>
           {" ".repeat(
-            Math.max(0, contentWidth - `... ${hiddenBelow} more`.length - 1),
+            Math.max(0, contentWidth - `... ${hiddenBelow} more`.length),
           )}
           {BOX.v}
         </Text>

--- a/tests/ui/ActivityViewerPanel.test.tsx
+++ b/tests/ui/ActivityViewerPanel.test.tsx
@@ -266,3 +266,15 @@ describe("ActivityViewerPanel", () => {
     expect(frame).not.toMatch(/Paragraph one\.\s*\n\s*Paragraph two\./);
   });
 });
+
+describe("ActivityViewerPanel — row width alignment", () => {
+  it("pads the empty-state line to the full panel width (right border aligned)", () => {
+    const W = 80;
+    const { lastFrame } = render(
+      <ActivityViewerPanel {...baseProps} activities={[]} width={W} />,
+    );
+    const lines = (lastFrame() ?? "").split("\n").filter(Boolean);
+    expect(lines.some((l) => l.includes("No activity yet"))).toBe(true);
+    for (const l of lines) expect([...l].length).toBe(W);
+  });
+});

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -1295,3 +1295,37 @@ describe("SessionTreePanel — sticky live projects", () => {
     expect(lastFrame() ?? "").not.toContain("#idle");
   });
 });
+
+describe("SessionTreePanel — row width alignment", () => {
+  it("pads the '... N more' line to the full panel width (right border aligned)", () => {
+    const live = makeSession({ id: "live0001", liveState: "working" });
+    const liveProj = makeProject("livep", [live]);
+    const qsess = makeSession({
+      id: "qsess001",
+      status: "hot",
+      subAgents: Array.from({ length: 8 }, (_, i) =>
+        makeSession({ id: `qs${i}`, status: "hot", projectName: "" }),
+      ),
+    });
+    const qProj = makeProject("qqq", [qsess]);
+    const cold = Array.from({ length: 4 }, (_, i) =>
+      makeProject(`c${i}`, [makeSession({ id: `cold${i}`, status: "cold" })], {
+        hotness: "cold",
+      }),
+    );
+    const W = 80;
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[liveProj, qProj]}
+        coldProjects={cold}
+        selectedId="live0001"
+        hasFocus={true}
+        width={W}
+        maxRows={7}
+      />,
+    );
+    const lines = (lastFrame() ?? "").split("\n").filter(Boolean);
+    expect(lines.some((l) => l.includes("more"))).toBe(true); // the indicator is present
+    for (const l of lines) expect([...l].length).toBe(W); // every line is full width
+  });
+});


### PR DESCRIPTION
## Bug

The Projects `... N more` line and the viewer `No activity yet` line rendered **one cell narrower** than every other row — right `│` one column left.

## Cause / Fix

Both render `│ ⟨space⟩ text ⟨pad⟩ │`, but `pad` had an extra `- 1` (double-counting the leading space). Correctly-aligned rows use the same leading space with `repeat(contentWidth - width(text))` and no `-1`. Dropped the spurious `-1` in `SessionTreePanel` (hidden-below) and `ActivityViewerPanel:322` (empty state). 79 → 80 cells at width 80.

## Test (TDD)

Render-and-measure tests assert **every** line is the full panel width — for the `... N more` indicator and the viewer empty state. Failed before (79), pass after. Full suite + tsc + biome green.

Closes #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected horizontal spacing of the empty state message in the Activity Viewer Panel for better border alignment
  * Fixed padding calculation for overflow indicators in the Session Tree Panel

* **Tests**
  * Added test suites to verify row-width alignment in Activity Viewer Panel and Session Tree Panel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->