### PR TITLE
docs(readme): note opencode sessions need Node 22+ (node:sqlite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It's organized as **three layers, by who's reading** — a human at a glance, a 
 
 → **See [FEATURES.md](./FEATURES.md) for the full surface** — every flag, keybinding, config key, file path, and env var. Per-agent session schemas: [Claude Code](./docs/schemas/claude-session.md) · [Codex CLI](./docs/schemas/codex-session.md) · [Kiro IDE](./docs/schemas/kiro-ide-session.md) · [Kiro CLI](./docs/schemas/kiro-session.md) · [opencode](./docs/schemas/opencode-session.md) (or browse [docs/schemas/](./docs/schemas/)).
 
-Requires Node.js 20+. Open agenthud in a separate terminal while you work; press `?` inside the TUI for in-app help.
+Requires Node.js 20+ (opencode sessions need Node 22+ — they're read via the built-in `node:sqlite`; on older Node, opencode is simply skipped and everything else works). Open agenthud in a separate terminal while you work; press `?` inside the TUI for in-app help.
 
 ## Try without installing
 


### PR DESCRIPTION
Core app stays Node 20+ (engines unchanged). The opencode provider reads via the built-in `node:sqlite` (Node 22+); on Node 20-21 opencode is silently skipped and everything else works. Added that caveat to the requirements line.

Docs only. Closes #181