### PR TITLE
fix(activity): parse AskUserQuestion question + options into detail

### DIFF
--- a/src/data/toolDetails.ts
+++ b/src/data/toolDetails.ts
@@ -35,6 +35,13 @@
 
 import { basename } from "node:path";
 
+export interface AskQuestion {
+  question?: string;
+  header?: string;
+  multiSelect?: boolean;
+  options?: { label?: string; description?: string }[];
+}
+
 export interface ToolInput {
   command?: string;
   file_path?: string;
@@ -47,6 +54,8 @@ export interface ToolInput {
   subject?: string;
   taskId?: string;
   status?: string;
+  // AskUserQuestion: one or more questions, each with selectable options.
+  questions?: AskQuestion[];
 }
 
 interface PatchHunk {
@@ -168,6 +177,21 @@ export function summarizeToolDetail(
     return input?.subject ?? "";
   }
 
+  if (name === "AskUserQuestion") {
+    const qs = input?.questions;
+    if (!qs || qs.length === 0) return "";
+    if (qs.length === 1) return qs[0].question ?? qs[0].header ?? "";
+    // Multiple questions: a count plus each question's compact header
+    // (falling back to its full text when no header was provided).
+    // Drop blank labels so a malformed question can't leave a dangling
+    // " · " separator.
+    const labels = qs
+      .map((q) => q.header ?? q.question ?? "")
+      .filter(Boolean)
+      .join(" · ");
+    return `${qs.length} questions: ${labels}`;
+  }
+
   return getToolDetail(name, input);
 }
 
@@ -207,11 +231,36 @@ function formatBashBody(
   return sections.join("\n\n");
 }
 
+/**
+ * Render AskUserQuestion's questions + options for the TUI detail view:
+ *   Q: <question> (multi-select)
+ *     ○ <label> — <description>
+ * Questions are separated by a blank line. Returns null when there is
+ * nothing to show so the caller falls back to the one-liner only.
+ */
+function formatAskBody(questions: AskQuestion[] | undefined): string | null {
+  if (!questions || questions.length === 0) return null;
+  const blocks = questions.map((q) => {
+    const head = `Q: ${q.question ?? q.header ?? ""}${q.multiSelect ? " (multi-select)" : ""}`;
+    const opts = (q.options ?? []).map(
+      (o) =>
+        `  ○ ${o.label ?? ""}${o.description ? ` — ${o.description}` : ""}`,
+    );
+    return [head, ...opts].join("\n");
+  });
+  return blocks.join("\n\n");
+}
+
 export function buildToolDetailBody(
   name: string,
   input: ToolInput | undefined,
   result: ToolUseResult | undefined,
 ): { text: string; kind: "diff" | "code"; numbered?: boolean } | null {
+  if (name === "AskUserQuestion") {
+    const text = formatAskBody(input?.questions);
+    if (text) return { text, kind: "code" };
+    return null;
+  }
   // Write intentionally shows the written file content (more useful to read
   // than an all-additions diff); the row summary still uses patch stats.
   if (name === "Write") {

--- a/tests/data/toolDetails.test.ts
+++ b/tests/data/toolDetails.test.ts
@@ -157,6 +157,78 @@ describe("summarizeToolDetail", () => {
       "foo",
     );
   });
+
+  it("AskUserQuestion: single question shows the question text", () => {
+    expect(
+      summarizeToolDetail(
+        "AskUserQuestion",
+        {
+          questions: [
+            {
+              question: "Which library should we use?",
+              header: "Library",
+              options: [{ label: "A" }, { label: "B" }],
+            },
+          ],
+        },
+        undefined,
+      ),
+    ).toBe("Which library should we use?");
+  });
+
+  it("AskUserQuestion: multiple questions show count + headers", () => {
+    expect(
+      summarizeToolDetail(
+        "AskUserQuestion",
+        {
+          questions: [
+            { question: "Q1?", header: "Auth" },
+            { question: "Q2?", header: "Storage" },
+          ],
+        },
+        undefined,
+      ),
+    ).toBe("2 questions: Auth · Storage");
+  });
+
+  it("AskUserQuestion: multi falls back to question when a header is missing", () => {
+    expect(
+      summarizeToolDetail(
+        "AskUserQuestion",
+        {
+          questions: [{ question: "First?" }, { header: "Second" }],
+        },
+        undefined,
+      ),
+    ).toBe("2 questions: First? · Second");
+  });
+
+  it("AskUserQuestion: single question with only a header uses the header", () => {
+    expect(
+      summarizeToolDetail(
+        "AskUserQuestion",
+        { questions: [{ header: "Approach" }] },
+        undefined,
+      ),
+    ).toBe("Approach");
+  });
+
+  it("AskUserQuestion: multi drops blank labels (no dangling separator)", () => {
+    expect(
+      summarizeToolDetail(
+        "AskUserQuestion",
+        { questions: [{ header: "Auth" }, {}] },
+        undefined,
+      ),
+    ).toBe("2 questions: Auth");
+  });
+
+  it("AskUserQuestion: no questions yields empty detail", () => {
+    expect(
+      summarizeToolDetail("AskUserQuestion", { questions: [] }, undefined),
+    ).toBe("");
+    expect(summarizeToolDetail("AskUserQuestion", {}, undefined)).toBe("");
+  });
 });
 
 describe("buildToolDetailBody", () => {
@@ -408,5 +480,55 @@ describe("buildToolDetailBody", () => {
         stdout: "should not be used",
       } as unknown as never),
     ).toBeNull();
+  });
+
+  it("AskUserQuestion: renders each question with its options", () => {
+    const body = buildToolDetailBody(
+      "AskUserQuestion",
+      {
+        questions: [
+          {
+            question: "Which library?",
+            header: "Library",
+            options: [
+              { label: "A", description: "the first" },
+              { label: "B", description: "the second" },
+            ],
+          },
+        ],
+      },
+      undefined,
+    );
+    expect(body?.kind).toBe("code");
+    expect(body?.text).toBe(
+      "Q: Which library?\n  ○ A — the first\n  ○ B — the second",
+    );
+  });
+
+  it("AskUserQuestion: marks multi-select and separates questions", () => {
+    const body = buildToolDetailBody(
+      "AskUserQuestion",
+      {
+        questions: [
+          {
+            question: "Pick features",
+            multiSelect: true,
+            options: [{ label: "X" }],
+          },
+          { question: "Pick one", options: [{ label: "Y" }] },
+        ],
+      },
+      undefined,
+    );
+    expect(body?.text).toBe(
+      "Q: Pick features (multi-select)\n  ○ X\n\nQ: Pick one\n  ○ Y",
+    );
+  });
+
+  it("AskUserQuestion: no questions returns null", () => {
+    expect(
+      buildToolDetailBody("AskUserQuestion", { questions: [] }, undefined),
+    ).toBeNull();
+    expect(buildToolDetailBody("AskUserQuestion", {}, undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

`AskUserQuestion` activity rows rendered as a bare `? AskUserQuestion` with an
**empty detail** — the question text and options were never parsed.

## Root cause

`src/data/toolDetails.ts` had no `AskUserQuestion` branch, so:
- `summarizeToolDetail` fell through to `getToolDetail` (which only reads
  `command/file_path/pattern/query/description`) → empty one-liner.
- `buildToolDetailBody` returned `null` → no detail body.

Verified the real input shape against session JSONL:
`questions[]: { question, header, multiSelect, options[]: { label, description } }`.
The user's answer is **not** reliably structured (often `"Error: Answer questions?"`),
so the fix intentionally parses only the questions + options.

## Fix

- One-liner: question text (single) or `"N questions: <header> · ..."` (multi,
  blank labels filtered so a malformed question can't leave a dangling ` · `).
- Detail body: each question + its options for the TUI detail view, e.g.

  ```
  Q: Which library? (multi-select)
    ○ A — the first
    ○ B — the second
  ```

## Testing

- TDD: failing tests first (reproduced empty detail), then implementation.
- 44 toolDetails tests + full suite (848) green; `tsc --noEmit` clean; biome clean.
- Independent review (code-reviewer subagent): SHIP-WITH-NITS → both nits
  (`.filter(Boolean)` hardening + single-question header-only test) applied.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for user question prompts as a new tool type with dedicated formatting and rendering
  * Questions support optional headers, descriptions, and multi-select options
  * Comprehensive test coverage added for question display handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->