### PR TITLE
feat(follow): --once one-shot mode and --since <N>s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 - **agenthud follow**: a live merged event stream (activity + state +
   lifecycle) across all sessions and sub-agents, emitted chronologically as
   human lines or, with `--json`, NDJSON. The read-only substrate a
-  higher-level supervisor can consume. `--since now|<N>h|<N>m` controls
+  higher-level supervisor can consume. `--since now|<N>h|<N>m|<N>s` controls
   backfill; `--include TYPES` narrows the activity firehose (state/lifecycle
-  always pass). See [FEATURES.md](./FEATURES.md#follow).
+  always pass); `--once` emits the backfill and exits instead of streaming
+  (like `tail` vs `tail -f`). See [FEATURES.md](./FEATURES.md#follow).
 
 ## [0.19.0] - 2026-06-17
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -316,14 +316,15 @@ machine-readable substrate a higher-level supervisor can consume.
 It is read-only: it observes, never acts.
 
 ```bash
-agenthud follow [--since SPEC] [--json] [--include TYPES]
+agenthud follow [--since SPEC] [--json] [--include TYPES] [--once]
 ```
 
 **Flags:**
 
-- `--since now|<N>h|<N>m` — where the stream starts (default `now`,
-  i.e. pure tail). `<N>h` / `<N>m` backfill the last N hours/minutes,
-  then follow live. (`HH:MM` / ISO / `last` are deferred.)
+- `--since now|<N>h|<N>m|<N>s` — where the stream starts (default `now`,
+  i.e. pure tail). `<N>h` / `<N>m` / `<N>s` backfill the last N
+  hours/minutes/seconds, then follow live. (`HH:MM` / ISO / `last` are
+  deferred.)
 - `--json` — emit NDJSON (one JSON object per line, the stable
   supervisor contract) instead of human lines.
 - `--include TYPES` — comma list filtering **activity** event
@@ -331,6 +332,10 @@ agenthud follow [--since SPEC] [--json] [--include TYPES]
   `response,bash,edit,thinking,read,glob,user,task`). `state` and
   `lifecycle` events always pass — they are the supervisor's trigger
   signal; `--include` only narrows the activity firehose.
+- `--once` — emit the backfill since `--since` and exit, instead of
+  streaming (the `tail` to the default's `tail -f`). Handy for scripts
+  and quick "what happened in the last N" checks. Pair with a non-`now`
+  `--since` (e.g. `--since 5m --once`); `--since now --once` emits nothing.
 
 **Event model (the NDJSON contract).** One JSON object per line,
 additive-only:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,7 @@ export interface CliOptions {
   followSince?: string; // raw --since spec
   followJson?: boolean;
   followInclude?: string[];
+  followOnce?: boolean; // emit the backfill and exit (no streaming)
   followError?: string;
 }
 
@@ -119,7 +120,12 @@ const KNOWN_SUMMARY_FLAGS = new Set([
   "-I",
   "--open-index",
 ]);
-const KNOWN_FOLLOW_FLAGS = new Set(["--since", "--json", "--include"]);
+const KNOWN_FOLLOW_FLAGS = new Set([
+  "--since",
+  "--json",
+  "--include",
+  "--once",
+]);
 const KNOWN_SUBCOMMANDS = new Set(["watch", "report", "summary", "follow"]);
 
 export function getHelp(): string {
@@ -189,10 +195,12 @@ Commands:
                                 Stream live agent events (activity +
                                 state + lifecycle) across all sessions
                                 and sub-agents, merged chronologically.
-    --since now|<N>h|<N>m       Where to start (default: now)
+    --since now|<N>h|<N>m|<N>s  Where to start (default: now)
     --json                      Emit NDJSON instead of human lines
     --include TYPES             Filter activity types (comma list; same
                                 vocabulary as report's --include)
+    --once                      Emit events since --since and exit, instead
+                                of streaming (like tail vs tail -f)
 
   Defaults for report and summary live under \`report:\` and \`summary:\`
   in ~/.agenthud/config.yaml. Flags override config values per-run; the
@@ -318,7 +326,11 @@ export function parseArgs(args: string[], config?: GlobalConfig): CliOptions {
   if (args.includes("--version") || args.includes("-V")) {
     return { mode: "watch", command: "version" };
   }
-  if (args.includes("--once")) {
+  // `follow` owns `--once` as its own one-shot flag (handled in its block
+  // below), so exempt it here. Every other entry point keeps the existing
+  // behavior: bare/`watch --once` is the watch one-shot, and report/summary
+  // (which don't define `--once`) continue to be absorbed here as before.
+  if (args[0] !== "follow" && args.includes("--once")) {
     return args.includes("--cwd")
       ? { mode: "once", scopeToCwd: true }
       : { mode: "once" };
@@ -678,6 +690,7 @@ export function parseArgs(args: string[], config?: GlobalConfig): CliOptions {
     let followSince: string | undefined;
     let followJson: boolean | undefined;
     let followInclude: string[] | undefined;
+    let followOnce: boolean | undefined;
     let followError: string | undefined;
 
     const FLAGS_WITH_VALUE = new Set(["--since", "--include"]);
@@ -702,6 +715,7 @@ export function parseArgs(args: string[], config?: GlobalConfig): CliOptions {
     }
 
     if (rest.includes("--json")) followJson = true;
+    if (rest.includes("--once")) followOnce = true;
 
     const includeIdx = rest.indexOf("--include");
     if (includeIdx !== -1) {
@@ -733,6 +747,7 @@ export function parseArgs(args: string[], config?: GlobalConfig): CliOptions {
       followSince,
       followJson,
       followInclude,
+      followOnce,
       followError,
     };
   }

--- a/src/data/followRunner.ts
+++ b/src/data/followRunner.ts
@@ -71,6 +71,8 @@ export interface RunFollowOptions {
   intervalMs?: number;
   now?: () => number;
   write?: (line: string) => void;
+  /** One-shot: emit the seed backfill and return without streaming. */
+  once?: boolean;
 }
 
 /** The loop. Seeds cursors from `sinceMs`, then diffs every interval. */
@@ -100,6 +102,11 @@ export function runFollow(opts: RunFollowOptions): { stop: () => void } {
       write(fmt(e));
     }
   }
+
+  // One-shot: the seed is the whole output. Don't schedule the loop so the
+  // process exits naturally once stdout flushes (no `process.exit` that could
+  // truncate buffered output).
+  if (opts.once) return { stop: () => {} };
 
   const tick = () => {
     const snaps = buildSnapshots(discoverSessions(opts.config));

--- a/src/data/followSince.ts
+++ b/src/data/followSince.ts
@@ -1,17 +1,20 @@
 /**
  * `--since` parsing for `agenthud follow` (Phase 1): `now` (default)
- * and relative `<N>h` / `<N>m`. HH:MM / ISO / `last` are deferred.
+ * and relative `<N>h` / `<N>m` / `<N>s`. HH:MM / ISO / `last` are deferred.
  */
 
 export type SinceResult = { sinceMs: number } | { error: string };
 
-/** Phase 1: `now` (default) and relative `<N>h` / `<N>m`.
+const UNIT_MS: Record<string, number> = { h: 3600_000, m: 60_000, s: 1000 };
+
+/** Phase 1: `now` (default) and relative `<N>h` / `<N>m` / `<N>s`.
  * (HH:MM / ISO / `last` are deferred — see the plan's Deferred section.) */
 export function parseSince(spec: string | undefined, now: number): SinceResult {
   if (!spec || spec === "now") return { sinceMs: now };
-  const m = spec.match(/^(\d+)([hm])$/);
-  if (!m) return { error: `Invalid --since: ${spec} (use now, <N>h, or <N>m)` };
+  const m = spec.match(/^(\d+)([hms])$/);
+  if (!m) {
+    return { error: `Invalid --since: ${spec} (use now, <N>h, <N>m, or <N>s)` };
+  }
   const n = Number.parseInt(m[1], 10);
-  const unitMs = m[2] === "h" ? 3600_000 : 60_000;
-  return { sinceMs: now - n * unitMs };
+  return { sinceMs: now - n * UNIT_MS[m[2]] };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -240,15 +240,21 @@ if (options.mode === "follow") {
     sinceMs: since.sinceMs,
     json: !!options.followJson,
     include,
+    once: !!options.followOnce,
   });
-  const shutdown = () => {
-    stop();
-    process.exit(0);
-  };
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
   process.stdout.on("error", () => process.exit(0)); // EPIPE on `| head`
-  // Keep the event loop alive on the interval; do not fall through to Ink.
+  // `--once` emitted the backfill synchronously and scheduled no interval, so
+  // the event loop drains and the process exits cleanly. Streaming mode keeps
+  // the loop alive on the interval and exits on a signal.
+  if (!options.followOnce) {
+    const shutdown = () => {
+      stop();
+      process.exit(0);
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  }
+  // Do not fall through to Ink.
 } else {
   runWatchOrOnce();
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -645,6 +645,25 @@ describe("parseArgs", () => {
       expect(opts.followInclude).toEqual(["bash", "edit"]);
     });
 
+    it("parses --once for one-shot mode", () => {
+      const opts = parseArgs(["follow", "--since", "60s", "--once"]);
+      expect(opts.mode).toBe("follow");
+      expect(opts.followOnce).toBe(true);
+      expect(opts.followSince).toBe("60s");
+      expect(opts.followError).toBeUndefined();
+    });
+
+    it("leaves followOnce undefined without --once", () => {
+      expect(parseArgs(["follow"]).followOnce).toBeUndefined();
+    });
+
+    it("follow --once (no --since) stays follow mode, not watch once", () => {
+      const opts = parseArgs(["follow", "--once"]);
+      expect(opts.mode).toBe("follow");
+      expect(opts.followOnce).toBe(true);
+      expect(opts.followSince).toBeUndefined();
+    });
+
     it("rejects an unknown --include type", () => {
       const opts = parseArgs(["follow", "--include", "bash,bogus"]);
       expect(opts.followError).toBeDefined();

--- a/tests/data/followRunner.test.ts
+++ b/tests/data/followRunner.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildSnapshots, runFollow } from "../../src/data/followRunner.js";
 import type {
   ActivityEntry,
@@ -113,6 +113,44 @@ describe("runFollow integration", () => {
     );
     expect(responses.length).toBeGreaterThanOrEqual(1);
     expect(responses[0]).toMatchObject({ project: "proj", provider: "claude" });
+  });
+
+  it("once: emits the seed then does not schedule the streaming interval", () => {
+    const lines: string[] = [];
+    const cfg = {
+      refreshIntervalMs: 99999,
+      hiddenSessions: [],
+      hiddenSubAgents: [],
+      filterPresets: [[]],
+      hiddenProjects: [],
+      report: {
+        include: [],
+        detailLimit: 0,
+        withGit: false,
+        format: "markdown" as const,
+      },
+      summary: {},
+    };
+    const spy = vi.spyOn(global, "setInterval");
+    const { stop } = runFollow({
+      config: cfg,
+      sinceMs: 1_000_000,
+      json: true,
+      include: null,
+      now: () => 3_000_000,
+      write: (l) => lines.push(l),
+      once: true,
+    });
+    // The seed (backfill) is still emitted...
+    expect(
+      lines.some(
+        (l) => (JSON.parse(l) as { label?: string }).label === "Response",
+      ),
+    ).toBe(true);
+    // ...but no streaming loop is scheduled.
+    expect(spy).not.toHaveBeenCalled();
+    stop(); // no-op, must be safe to call
+    spy.mockRestore();
   });
 });
 

--- a/tests/data/followSince.test.ts
+++ b/tests/data/followSince.test.ts
@@ -11,6 +11,10 @@ describe("parseSince", () => {
     expect(parseSince("2h", NOW)).toEqual({ sinceMs: NOW - 2 * 3600_000 });
     expect(parseSince("30m", NOW)).toEqual({ sinceMs: NOW - 30 * 60_000 });
   });
+  it("Ns → relative backfill in seconds", () => {
+    expect(parseSince("60s", NOW)).toEqual({ sinceMs: NOW - 60 * 1000 });
+    expect(parseSince("90s", NOW)).toEqual({ sinceMs: NOW - 90_000 });
+  });
   it("undefined defaults to now", () => {
     expect(parseSince(undefined, NOW)).toEqual({ sinceMs: NOW });
   });


### PR DESCRIPTION
## What

Two small additions to `agenthud follow`:

- **`--once`** — emit the events since `--since` and **exit**, instead of streaming forever (the `tail` to the default's `tail -f`). `agenthud follow --since 60s --once`.
- **`--since <N>s`** — relative seconds (`parseSince` previously took only `now`/`<N>h`/`<N>m`).

## How

- `runFollow` gains an `once` option: it runs the seed/backfill, then returns **without** scheduling the `setInterval`.
- `main.ts` skips the SIGINT/SIGTERM keep-alive in `--once` mode, so the event loop drains and the process **exits naturally** once stdout flushes — deliberately **not** `process.exit`, which could truncate buffered output on a pipe (`| head`, `| jq`).
- The global watch `--once` check is guarded (`args[0] !== "follow"`) so `follow --once` reaches the follow subcommand instead of the watch one-shot; bare `--once` / `watch --once` are unchanged.

## Testing (TDD)

- `parseSince` seconds; `runFollow` `once` (seed emitted, `setInterval` **not** called); CLI `follow --once` parses to `mode:"follow"` + `followOnce` (incl. the no-`--since` case).
- Full suite **830 green**, tsc clean, biome clean.
- Smoke: `follow --since 30m --once` printed recent events and exited in ~1.8s (exit 0).
- Independent review: SHIP-WITH-NITS → both nits (misleading guard comment, missing no-`--since` test) fixed.

Docs synced: in-CLI help, `CHANGELOG.md` (Unreleased), `FEATURES.md`.

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)