### PR TITLE
refactor: move time constants to utils/ (fix data→ui layer violation)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,19 +11,6 @@ surfaced during reviews.
 
 ## Quality / refactors
 
-### data → ui layer violation: time constants
-
-`src/data/sessions.ts` and `src/data/sessionLiveness.ts` import
-`THIRTY_MINUTES_MS` / `ONE_HOUR_MS` from `src/ui/constants.ts`.
-Flagged in the file headers of all four files. Time constants
-shouldn't live in the UI layer — move them to
-`src/utils/timeConstants.ts` (or onto `types/index.ts` alongside
-`ICONS`).
-
-- **Effort:** ~30 min. Pure mechanical move + update imports.
-- **When:** Any quiet PR window. Doesn't gate anything.
-- **Risk:** None — name-only change, no behavior shift.
-
 ### Viewer cursor: track by activity index, not screen row
 
 `viewerCursorLine` (`src/ui/App.tsx:424`) is a screen-row index
@@ -184,6 +171,9 @@ place (we have those now).
 These were discussed and decided against — kept here briefly so the
 decisions don't get re-litigated:
 
+- **data → ui layer violation: time constants** — done 2026-06-20
+  (#192). The four time constants moved from `ui/constants.ts` to
+  `src/utils/timeConstants.ts`; the six data-layer importers repointed.
 - **`o` key to open file in detail view** — declined 2026-06-09.
   Reasons: detail view is "inspection mode" not "actor", race
   with concurrent Claude edits, default-app association is

--- a/src/data/providers/claude.ts
+++ b/src/data/providers/claude.ts
@@ -30,9 +30,6 @@
  * - `CLAUDE_PROJECTS_DIR` env var overrides the default
  *   `~/.claude/projects` location — useful for backups or mounted
  *   volumes. Read once at module load via `getProjectsDir()`.
- * - Imports `ONE_HOUR_MS` / `THIRTY_MINUTES_MS` from
- *   `ui/constants.ts` — same layer-violation note as
- *   `sessionLiveness.ts`.
  */
 
 import {
@@ -54,7 +51,7 @@ import type {
   SessionStatus,
   SessionTree,
 } from "../../types/index.js";
-import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
+import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../utils/timeConstants.js";
 import { detectLiveState } from "../sessionLiveness.js";
 import { parseActivitiesFromLines, parseModelName } from "./claude-activity.js";
 import type { DiscoverOptions, SessionProvider } from "./types.js";

--- a/src/data/providers/codex.ts
+++ b/src/data/providers/codex.ts
@@ -52,7 +52,7 @@ import type {
   SessionTree,
 } from "../../types/index.js";
 import { ICONS } from "../../types/index.js";
-import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
+import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../utils/timeConstants.js";
 import { pickLatestUserTitle } from "./sessionTitle.js";
 import type { ParseResult, SessionProvider } from "./types.js";
 

--- a/src/data/providers/kiro-ide.ts
+++ b/src/data/providers/kiro-ide.ts
@@ -61,7 +61,7 @@ import type {
   SessionTree,
 } from "../../types/index.js";
 import { ICONS } from "../../types/index.js";
-import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
+import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../utils/timeConstants.js";
 import { pickLatestUserTitle } from "./sessionTitle.js";
 import type { ParseContext, ParseResult, SessionProvider } from "./types.js";
 

--- a/src/data/providers/kiro.ts
+++ b/src/data/providers/kiro.ts
@@ -57,7 +57,7 @@ import type {
   SessionStatus,
   SessionTree,
 } from "../../types/index.js";
-import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
+import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../utils/timeConstants.js";
 import { parseKiroActivitiesFromLines } from "./kiro-activity.js";
 import { pickLatestUserTitle } from "./sessionTitle.js";
 import type { DiscoverOptions, SessionProvider } from "./types.js";

--- a/src/data/providers/opencode.ts
+++ b/src/data/providers/opencode.ts
@@ -35,7 +35,7 @@ import type {
   SessionTree,
 } from "../../types/index.js";
 import { ICONS } from "../../types/index.js";
-import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../ui/constants.js";
+import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../utils/timeConstants.js";
 import type { DiscoverOptions, ParseResult, SessionProvider } from "./types.js";
 
 export const OPENCODE_PATH_PREFIX = "opencode:";

--- a/src/data/sessionLiveness.ts
+++ b/src/data/sessionLiveness.ts
@@ -22,13 +22,10 @@
  * - Returns `null` outside the 30-minute recency window;
  *   upstream falls back to the time-based `[hot/warm/cool/cold]`
  *   ladder.
- * - Imports `THIRTY_MINUTES_MS` from `ui/constants.ts` — a known
- *   data → ui layer violation. Should move to `utils/` or a
- *   shared time-constants module on a future refactor.
  */
 
 import type { LiveState } from "../types/index.js";
-import { THIRTY_MINUTES_MS } from "../ui/constants.js";
+import { THIRTY_MINUTES_MS } from "../utils/timeConstants.js";
 
 interface ContentBlock {
   type?: string;

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -1,9 +1,8 @@
 /**
- * Shared UI constants — time thresholds, panel widths, terminal
- * limits, box-drawing characters — plus the display-width helpers
- * (`getDisplayWidth`, `getInnerWidth`, `createTitleLine`,
- * `createBottomLine`) used by every panel for borders and
- * truncation.
+ * Shared UI constants — panel widths, terminal limits, box-drawing
+ * characters — plus the display-width helpers (`getDisplayWidth`,
+ * `getInnerWidth`, `createTitleLine`, `createBottomLine`) used by
+ * every panel for borders and truncation.
  *
  * Design decision:
  * - `getDisplayWidth` is memoized across calls. Without
@@ -16,21 +15,7 @@
  *   No staleness invalidation is needed since display width is a
  *   pure function; eviction only caps memory, and an evicted hot
  *   string recomputes on its next miss.
- *
- * Gotcha:
- * - `THIRTY_MINUTES_MS` and `ONE_HOUR_MS` are imported by
- *   `src/data/sessions.ts` and `src/data/sessionLiveness.ts` —
- *   a data → ui layer violation flagged in those files. The
- *   constants should move to `src/utils/timeConstants.ts` (or
- *   live on `types/index.ts`) on a future refactor; keeping them
- *   here for now to avoid mixing the move with unrelated work.
  */
-
-// Time constants (in milliseconds)
-export const THIRTY_SECONDS_MS = 30 * 1000;
-export const THIRTY_MINUTES_MS = 30 * 60 * 1000;
-export const ONE_HOUR_MS = 60 * 60 * 1000;
-export const FIVE_MINUTES_MS = 5 * 60 * 1000;
 
 // Default panel width (can be overridden via config)
 export const DEFAULT_PANEL_WIDTH = 70;

--- a/src/utils/timeConstants.ts
+++ b/src/utils/timeConstants.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared time durations in milliseconds.
+ *
+ * Lives in `utils/` (not `ui/`) because the consumers are the data layer —
+ * session liveness and every provider's hot/warm staleness thresholds.
+ * Keeping them here avoids a data → ui import.
+ */
+
+export const THIRTY_SECONDS_MS = 30 * 1000;
+export const FIVE_MINUTES_MS = 5 * 60 * 1000;
+export const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+export const ONE_HOUR_MS = 60 * 60 * 1000;


### PR DESCRIPTION
## What

`THIRTY_MINUTES_MS` / `ONE_HOUR_MS` (and the two unused `THIRTY_SECONDS_MS` / `FIVE_MINUTES_MS`) lived in `src/ui/constants.ts` but were consumed **only by the data layer** — `sessionLiveness.ts` + all 5 providers — a data→ui layer violation flagged in those files' headers.

Move the four time constants to a neutral `src/utils/timeConstants.ts` and repoint the six importers. Remove the obsolete layer-violation notes.

## Why it's safe

- **Pure mechanical move** — name-only, no behavior change. None of the four constants were used by the UI layer.
- Each importer's `ui/constants` import line contained *only* time constants, so the whole line repoints cleanly.
- Verification = the existing suite (the liveness + provider tests exercise these constants): **831 tests green**, `tsc` clean, `biome` clean.

BACKLOG.md updated (moved the item to "Closed").

From BACKLOG.md → Quality / refactors.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code architecture by reorganizing internal time constants to resolve dependency layering issues across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->