### PR TITLE
refactor: remove unused time constants (THIRTY_SECONDS_MS, FIVE_MINUTES_MS)

### DIFF
--- a/src/utils/timeConstants.ts
+++ b/src/utils/timeConstants.ts
@@ -6,7 +6,5 @@
  * Keeping them here avoids a data → ui import.
  */
 
-export const THIRTY_SECONDS_MS = 30 * 1000;
-export const FIVE_MINUTES_MS = 5 * 60 * 1000;
 export const THIRTY_MINUTES_MS = 30 * 60 * 1000;
 export const ONE_HOUR_MS = 60 * 60 * 1000;


### PR DESCRIPTION
Dead exports in `src/utils/timeConstants.ts` — `THIRTY_SECONDS_MS` and `FIVE_MINUTES_MS` are referenced nowhere in src or tests (surfaced during the #192 move). Removed.

`tsc --noEmit` would fail on any missed reference — it's clean. 831 tests / biome green.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal duration constants for code cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->