### PR TITLE
fix(opencode): canonicalize tool labels + per-tool icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+
 - **opencode tool labels** are now canonicalized (`read` → `Read`, `grep` →
   `Grep`, …) and carry per-tool icons, matching the claude/kiro providers
   instead of surfacing raw lowercase names with the default glyph. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+- **opencode tool labels** are now canonicalized (`read` → `Read`, `grep` →
+  `Grep`, …) and carry per-tool icons, matching the claude/kiro providers
+  instead of surfacing raw lowercase names with the default glyph. The
+  provider-agnostic `canonicalToolLabel` / `iconForCanonicalLabel` helpers in
+  `toolLabels.ts` are now shared by kiro and opencode.
+
 ### Added
 - **agenthud follow**: a live merged event stream (activity + state +
   lifecycle) across all sessions and sub-agents, emitted chronologically as

--- a/src/data/providers/kiro-activity.ts
+++ b/src/data/providers/kiro-activity.ts
@@ -32,7 +32,7 @@
 
 import type { ActivityEntry } from "../../types/index.js";
 import { ICONS } from "../../types/index.js";
-import { canonicalKiroToolLabel } from "./toolLabels.js";
+import { canonicalToolLabel, iconForCanonicalLabel } from "./toolLabels.js";
 import type { ParseResult } from "./types.js";
 
 interface KiroContentBlock {
@@ -54,14 +54,6 @@ interface KiroRecord {
     content?: KiroContentBlock[];
     meta?: { timestamp?: number };
   };
-}
-
-function iconForCanonicalLabel(label: string): string {
-  // Canonical labels match the keys of the shared ICONS table, so
-  // this is a straight lookup. Anything we don't recognize falls
-  // back to ICONS.Default (still a printable glyph, not blank).
-  const known = (ICONS as Record<string, string>)[label];
-  return known ?? ICONS.Default;
 }
 
 function summarizeToolInput(
@@ -153,7 +145,7 @@ export function parseKiroActivitiesFromLines(lines: string[]): ParseResult {
         } else if (block.kind === "toolUse") {
           const tu = block.data as KiroToolUseData;
           const rawName = typeof tu?.name === "string" ? tu.name : "tool";
-          const label = canonicalKiroToolLabel(rawName);
+          const label = canonicalToolLabel(rawName);
           const summary = summarizeToolInput(tu?.input);
           activities.push({
             timestamp: ts,

--- a/src/data/providers/opencode.ts
+++ b/src/data/providers/opencode.ts
@@ -36,6 +36,7 @@ import type {
 } from "../../types/index.js";
 import { ICONS } from "../../types/index.js";
 import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../utils/timeConstants.js";
+import { canonicalToolLabel, iconForCanonicalLabel } from "./toolLabels.js";
 import type { DiscoverOptions, ParseResult, SessionProvider } from "./types.js";
 
 export const OPENCODE_PATH_PREFIX = "opencode:";
@@ -455,12 +456,12 @@ export function parseActivities(lines: string[]): ParseResult {
         break;
       }
       case "tool": {
-        const tool = part.tool ?? "tool";
+        const label = canonicalToolLabel(part.tool ?? "tool");
         activities.push({
           timestamp: ts,
           type: "tool",
-          icon: ICONS.Default,
-          label: tool,
+          icon: iconForCanonicalLabel(label),
+          label,
           detail: part.state?.title ?? "",
         });
         break;

--- a/src/data/providers/toolLabels.ts
+++ b/src/data/providers/toolLabels.ts
@@ -63,7 +63,11 @@ export function canonicalToolLabel(raw: string): string {
 /** Icon for a canonical label. Canonical labels match the keys of the
  * shared ICONS table, so this is a straight lookup; anything we don't
  * recognize (a passed-through raw tool name) falls back to
- * `ICONS.Default` — still a printable glyph, not blank. */
+ * `ICONS.Default` — still a printable glyph, not blank. `Object.hasOwn`
+ * guards against a pass-through label like `__proto__`/`constructor`
+ * resolving an inherited prototype value instead of `ICONS.Default`. */
 export function iconForCanonicalLabel(label: string): string {
-  return (ICONS as Record<string, string>)[label] ?? ICONS.Default;
+  return Object.hasOwn(ICONS, label)
+    ? (ICONS as Record<string, string>)[label]
+    : ICONS.Default;
 }

--- a/src/data/providers/toolLabels.ts
+++ b/src/data/providers/toolLabels.ts
@@ -1,38 +1,49 @@
 /**
  * Canonical tool labels — single naming scheme that all providers
  * map into so downstream code (report filters, summary input,
- * detail viewer dispatch) only has to know one taxonomy.
+ * detail viewer dispatch, per-tool icons) only has to know one
+ * taxonomy.
  *
  * Claude already uses these names verbatim (`Read`, `Bash`, ...) so
- * its parser stamps them as-is. Kiro uses lowercase snake_case
- * (`read`, `shell`, `web_fetch`, `subagent`, `introspect`) — we
- * translate at the parser boundary. Future providers (OpenCode,
- * Kiro IDE) extend the mapping here without touching consumers.
+ * its parser stamps them as-is. Kiro and OpenCode use lowercase
+ * names (`read`, `shell`/`bash`, `web_fetch`/`webfetch`, ...) — they
+ * translate at the parser boundary via `canonicalToolLabel`.
  *
- * Design decision:
+ * Design decisions:
  * - Mapping is a `Map<string, string>` not a switch so unknown
  *   tools fall through to their raw name (preserves visibility
- *   when a provider ships a new tool we haven't catalogued yet).
+ *   when a provider ships a new tool we haven't catalogued yet —
+ *   e.g. OpenCode MCP tools like `mcp_acme_doThing`).
  * - Kiro's `introspect` collapses to `Read` because semantically
  *   it's "look at the project structure" — same bucket as a
  *   file-system read. Treating it as its own label would split
  *   the `read` filter category and surprise users.
  * - Both `task` and `subagent` collapse to `Task` since they
  *   represent the same concept (delegate to a sub-agent).
+ * - Entries added for OpenCode's vocabulary (shared, not gated per
+ *   provider): `webfetch`/`websearch` (one word, vs Kiro's
+ *   `web_fetch`/`web_search`), `list` → `Glob` (directory enumeration
+ *   sits in the read/glob bucket), `patch` → `Edit` (a diff is an edit).
  */
 
-const KIRO_TO_CANONICAL: Map<string, string> = new Map([
+import { ICONS } from "../../types/index.js";
+
+const RAW_TOOL_TO_CANONICAL: Map<string, string> = new Map([
   ["read", "Read"],
   ["introspect", "Read"],
   ["shell", "Bash"],
   ["bash", "Bash"],
   ["write", "Write"],
   ["edit", "Edit"],
+  ["patch", "Edit"],
   ["grep", "Grep"],
   ["glob", "Glob"],
+  ["list", "Glob"],
   ["web_fetch", "WebFetch"],
+  ["webfetch", "WebFetch"],
   ["fetch", "WebFetch"],
   ["web_search", "WebSearch"],
+  ["websearch", "WebSearch"],
   ["search", "WebSearch"],
   ["task", "Task"],
   ["subagent", "Task"],
@@ -42,9 +53,17 @@ const KIRO_TO_CANONICAL: Map<string, string> = new Map([
   ["askuserquestion", "AskUserQuestion"],
 ]);
 
-/** Translate a Kiro raw tool name to the canonical label. Unknown
- * names pass through as-is so a new provider tool surfaces with
- * its original identity instead of being silently mislabeled. */
-export function canonicalKiroToolLabel(raw: string): string {
-  return KIRO_TO_CANONICAL.get(raw.toLowerCase()) ?? raw;
+/** Translate a provider's raw tool name to the canonical label.
+ * Unknown names pass through as-is so a new provider tool surfaces
+ * with its original identity instead of being silently mislabeled. */
+export function canonicalToolLabel(raw: string): string {
+  return RAW_TOOL_TO_CANONICAL.get(raw.toLowerCase()) ?? raw;
+}
+
+/** Icon for a canonical label. Canonical labels match the keys of the
+ * shared ICONS table, so this is a straight lookup; anything we don't
+ * recognize (a passed-through raw tool name) falls back to
+ * `ICONS.Default` — still a printable glyph, not blank. */
+export function iconForCanonicalLabel(label: string): string {
+  return (ICONS as Record<string, string>)[label] ?? ICONS.Default;
 }

--- a/tests/data/parserCorpus.test.ts
+++ b/tests/data/parserCorpus.test.ts
@@ -99,7 +99,7 @@ describe("parser corpus: opencode parts", () => {
       [
         "User:Add error handling to the API client",
         "Thinking:I should wrap the fetch calls in try/catch blocks.",
-        "read:/src/api/client.ts",
+        "Read:/src/api/client.ts",
         "Response:I've added error handling to the API client.",
       ]
     `);

--- a/tests/data/providers/opencode.test.ts
+++ b/tests/data/providers/opencode.test.ts
@@ -216,7 +216,8 @@ describe.skipIf(!sqliteAvailable)("opencodeProvider", () => {
       "response",
     ]);
     expect(acts[0].detail).toBe("Explain repo");
-    expect(acts[1].label).toBe("read");
+    expect(acts[1].label).toBe("Read"); // canonicalized from raw "read"
+    expect(acts[1].icon).toBe("○"); // ICONS.Read, not the default glyph
     expect(acts[1].detail).toBe("file.ts");
     expect(acts[3].detail).toBe("Here is the answer");
   });
@@ -275,7 +276,33 @@ describe("opencode parseActivities (pure)", () => {
     ];
     const { activities } = parseActivities(lines);
     expect(activities.map((a) => a.type)).toEqual(["user", "thinking", "tool"]); // step-start skipped
-    expect(activities[2].label).toBe("bash");
+    expect(activities[2].label).toBe("Bash"); // canonicalized from raw "bash"
+    expect(activities[2].icon).toBe("$"); // ICONS.Bash
     expect(activities[2].detail).toBe("ls");
+  });
+
+  it("canonicalizes known tools and keeps unknown (MCP) tools as-is", () => {
+    const mk = (tool: string) =>
+      JSON.stringify({
+        role: "assistant",
+        t: 1000,
+        part: { type: "tool", tool, state: { title: "x" } },
+      });
+    const { activities } = parseActivities([
+      mk("read"),
+      mk("grep"),
+      mk("glob"),
+      mk("webfetch"),
+      mk("mcp_acme_doThing"), // uncatalogued → preserved verbatim
+    ]);
+    expect(activities.map((a) => a.label)).toEqual([
+      "Read",
+      "Grep",
+      "Glob",
+      "WebFetch",
+      "mcp_acme_doThing",
+    ]);
+    // Unknown tool still gets a printable icon, not a blank.
+    expect(activities[4].icon).toBe("$"); // ICONS.Default
   });
 });

--- a/tests/data/providers/opencode.test.ts
+++ b/tests/data/providers/opencode.test.ts
@@ -277,7 +277,10 @@ describe("opencode parseActivities (pure)", () => {
     const { activities } = parseActivities(lines);
     expect(activities.map((a) => a.type)).toEqual(["user", "thinking", "tool"]); // step-start skipped
     expect(activities[2].label).toBe("Bash"); // canonicalized from raw "bash"
-    expect(activities[2].icon).toBe("$"); // ICONS.Bash
+    // "$" is ICONS.Bash, which equals ICONS.Default by design — icons aren't
+    // unique per label (Glob/Grep both "*", etc.). Distinctive-icon coverage
+    // lives in the canonicalization test below.
+    expect(activities[2].icon).toBe("$");
     expect(activities[2].detail).toBe("ls");
   });
 
@@ -294,6 +297,7 @@ describe("opencode parseActivities (pure)", () => {
       mk("glob"),
       mk("webfetch"),
       mk("mcp_acme_doThing"), // uncatalogued → preserved verbatim
+      mk("__proto__"), // prototype key must not return an inherited value
     ]);
     expect(activities.map((a) => a.label)).toEqual([
       "Read",
@@ -301,8 +305,14 @@ describe("opencode parseActivities (pure)", () => {
       "Glob",
       "WebFetch",
       "mcp_acme_doThing",
+      "__proto__",
     ]);
-    // Unknown tool still gets a printable icon, not a blank.
-    expect(activities[4].icon).toBe("$"); // ICONS.Default
+    // Distinctive per-tool icons prove the mapping (not just the default glyph).
+    expect(activities[0].icon).toBe("○"); // ICONS.Read
+    expect(activities[3].icon).toBe("@"); // ICONS.WebFetch
+    // Unknown and prototype-key labels fall back to a printable default,
+    // never an inherited Object.prototype value.
+    expect(activities[4].icon).toBe("$"); // ICONS.Default (MCP tool)
+    expect(activities[5].icon).toBe("$"); // ICONS.Default (__proto__ guarded)
   });
 });


### PR DESCRIPTION
## Problem

opencode's `parseActivities` used the raw lowercase `part.tool` as the activity label (`read`, `bash`, `grep`) and always `ICONS.Default`, while claude/kiro map raw tool names to the shared canonical taxonomy (`Read`, `Bash`, …) in `toolLabels.ts` and pick a per-tool icon. So opencode rows read `read:…` with the default glyph, and a lowercase `read` didn't match the same `--include`/detail-dispatch paths a claude/kiro `Read` does. Surfaced by the #187 parser corpus.

## Fix

Generalize the kiro-named helper into provider-agnostic `canonicalToolLabel` / `iconForCanonicalLabel` in `toolLabels.ts` (the header already declared this the shared taxonomy "all providers map into"); move `iconForCanonicalLabel` there from `kiro-activity.ts`; extend the map with opencode's vocabulary (`webfetch`/`websearch`, `list`→`Glob`, `patch`→`Edit`); use both helpers in opencode's `tool` case. Unknown/MCP tools (e.g. `mcp_acme_doThing`) still pass through verbatim with the default icon.

## Testing (TDD)

- Flipped the opencode assertions (`read`→`Read`, `bash`→`Bash`) + corpus snapshot, seen failing first; added a canonicalization + MCP-passthrough test (icon checked too).
- kiro behavior is byte-equivalent (rename + helper move only) — kiro-activity tests green.
- Full suite **832 / tsc / biome** green.
- Independent review: **SHIP** (kiro no-regression, mappings sound, passthrough tested).

CHANGELOG updated (Unreleased → Fixed).

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool activity labels now display in standardized title case (e.g., Read, Grep, Bash) instead of lowercase.
  * Tool activity entries now show specific icons matching each tool type instead of default icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->