### PR TITLE
feat: in-pane text search (/) across Tree, Activity Viewer, and Detail View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
   `toolLabels.ts` are now shared by kiro and opencode.
 
 ### Added
+- **In-pane search (`/`)**: text search scoped to the focused pane, distinct
+  from the `f` type-filter. The Session Tree and Activity Viewer are transient
+  fzf-style narrow-finders (type to narrow, `↑`/`↓` select, `↵` jump, `Esc`
+  cancel); the Detail View is a less-style jump (type → first match, `↵`
+  commits then `n`/`N` cycle, matches highlighted). Substring + smart-case;
+  the Viewer search composes (AND) with the `f` filter.
 - **agenthud follow**: a live merged event stream (activity + state +
   lifecycle) across all sessions and sub-agents, emitted chronologically as
   human lines or, with `--json`, NDJSON. The read-only substrate a

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -474,10 +474,10 @@ the `?` overlay renders in-app.
 | Key | Action |
 |---|---|
 | `↑` `↓` / `k` `j` | Scroll |
-| `↵` / `Esc` / `q` | Close |
+| `↵` / `q` | Close |
+| `Esc` | Close (or close search if open, staying in detail view) |
 | `/` | Open search — type to jump to first match; matches highlighted |
-| `n` / `N` | Next / previous match (while search is open) |
-| `Esc` | Close search, stay in detail view |
+| `n` / `N` | Next / previous match (after pressing `↵` to commit the query) |
 
 ### Always available
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -475,6 +475,9 @@ the `?` overlay renders in-app.
 |---|---|
 | `↑` `↓` / `k` `j` | Scroll |
 | `↵` / `Esc` / `q` | Close |
+| `/` | Open search — type to jump to first match; matches highlighted |
+| `n` / `N` | Next / previous match (while search is open) |
+| `Esc` | Close search, stay in detail view |
 
 ### Always available
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -453,6 +453,7 @@ the `?` overlay renders in-app.
 | `t` | Track: auto-follow the newest live sub-agent (any nav key turns it off) |
 | `Tab` | Switch focus to activity viewer |
 | `r` | Refresh now |
+| `/` | Narrow-finder: type to filter sessions/sub-agents; `↑`/`↓` to select a hit; `↵` to select that session (viewer follows) and restore the full tree; `Esc` to cancel. |
 
 > **Note (v0.14.0):** Hide moved from `h` to `Shift+H` and became a toggle. The lowercase `h` is now the vim-left alias for `←` (jump to parent). Press `a` to reveal hidden items in the tree (they render dim with a `⊘` marker); `H` on a hidden row unhides it. A status-bar indicator surfaces hidden-but-still-active items so an accidentally-hidden hot session never becomes invisible.
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -468,6 +468,7 @@ the `?` overlay renders in-app.
 | `↵` | Open detail view for selected activity |
 | `f` | Cycle filter preset (set in `config.yaml`) |
 | `Tab` | Switch focus to project tree |
+| `/` | Narrow-finder: type to filter visible activities, `↑`/`↓` to select, `↵` to jump cursor to the chosen activity and restore the full stream, `Esc` to cancel. Composes (AND) with the `f` type-filter. |
 
 ### Detail view
 

--- a/docs/superpowers/plans/2026-06-21-search.md
+++ b/docs/superpowers/plans/2026-06-21-search.md
@@ -1,0 +1,755 @@
+# In-pane text search (`/`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `/` text search to the Session Tree, Activity Viewer (transient fzf-style narrow-finders), and Detail View (less-style jump), distinct from the `f` type-filter.
+
+**Architecture:** A pure `src/ui/search/matcher.ts` does substring + smart-case matching (returns highlight ranges). Three pure per-surface helpers compute the narrowed tree, the narrowed activity list, and the detail match positions. `App.tsx` owns a small `search` state object; `useHotkeys` gains a `search` mode that routes keystrokes while active; each panel renders matches (highlight) and a shared status-line search input. Built in three phases: matcher + shell + Detail, then Viewer, then Tree.
+
+**Tech Stack:** TypeScript (ESM), Ink (React for CLI), Vitest, Biome.
+
+## Global Constraints
+
+- All source, comments, commits in English.
+- TDD: write the failing test, see it fail for the right reason, then implement.
+- Before every commit: `npx vitest run` (full suite green), `npx tsc --noEmit` clean, `npx biome check` clean (run `npx biome check --write` first).
+- Matching is **substring + smart-case**: case-insensitive unless the query contains an uppercase char. Never fuzzy, never regex (treat query literally).
+- `search` is scoped to the **focused** surface; it is separate from and composes (AND) with the `f` type-filter. Search state is ephemeral.
+- Lists (Tree, Viewer) use a **transient finder**: type → live narrow → `Enter` selects + restores full list → `Esc` cancels + restores. Detail uses **jump**: type → jump to first match → `n`/`N` cycle → `Esc` exits.
+- Keys: `/` opens search in the focused surface; in list finders `↑`/`↓` move selection (printable keys edit the query); in Detail `n`/`N` (and `Enter`) cycle matches; `Esc` exits. `/ n N` are currently unbound; do not touch `g`/`G`.
+- Keep docs in sync in the phase that adds the keys: `getHelp()` (`src/cli.ts`), `HelpPanel` SECTIONS (`src/ui/HelpPanel.tsx`), `FEATURES.md`.
+
+---
+
+### Task 1: Pure matcher (`matcher.ts`)
+
+**Files:**
+- Create: `src/ui/search/matcher.ts`
+- Test: `tests/ui/search/matcher.test.ts`
+
+**Interfaces:**
+- Produces: `interface MatchRange { start: number; end: number }` (half-open `[start, end)`); `matchRanges(text: string, query: string): MatchRange[]`; `hasMatch(text: string, query: string): boolean`; `isCaseSensitive(query: string): boolean`. Consumed by Tasks 3–5.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/ui/search/matcher.test.ts
+import { describe, expect, it } from "vitest";
+import { hasMatch, isCaseSensitive, matchRanges } from "../../../src/ui/search/matcher.js";
+
+describe("isCaseSensitive (smart-case)", () => {
+  it("all-lowercase query → case-insensitive (false)", () => {
+    expect(isCaseSensitive("auth")).toBe(false);
+  });
+  it("any uppercase → case-sensitive (true)", () => {
+    expect(isCaseSensitive("Auth")).toBe(true);
+  });
+});
+
+describe("matchRanges", () => {
+  it("empty query → no ranges", () => {
+    expect(matchRanges("anything", "")).toEqual([]);
+  });
+  it("smart-case: lowercase query matches any case", () => {
+    expect(matchRanges("Auth and AUTH", "auth")).toEqual([
+      { start: 0, end: 4 },
+      { start: 9, end: 13 },
+    ]);
+  });
+  it("smart-case: uppercase query is case-sensitive", () => {
+    expect(matchRanges("Auth and auth", "Auth")).toEqual([{ start: 0, end: 4 }]);
+  });
+  it("returns non-overlapping ranges left to right", () => {
+    expect(matchRanges("aaaa", "aa")).toEqual([
+      { start: 0, end: 2 },
+      { start: 2, end: 4 },
+    ]);
+  });
+  it("no match → empty", () => {
+    expect(matchRanges("abc", "xyz")).toEqual([]);
+  });
+});
+
+describe("hasMatch", () => {
+  it("true on substring hit, false on miss/empty", () => {
+    expect(hasMatch("activityParser", "Parser")).toBe(true); // smart-case sensitive
+    expect(hasMatch("activityParser", "parser")).toBe(true); // insensitive
+    expect(hasMatch("activityParser", "zzz")).toBe(false);
+    expect(hasMatch("x", "")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/ui/search/matcher.test.ts`
+Expected: FAIL — cannot resolve `../../../src/ui/search/matcher.js`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/ui/search/matcher.ts
+/**
+ * Substring matching with smart-case for the in-pane search. Returns
+ * highlight ranges so callers can render matches; never fuzzy, never
+ * regex — the query is matched literally.
+ */
+
+export interface MatchRange {
+  start: number; // inclusive
+  end: number; // exclusive (half-open)
+}
+
+/** Smart-case: case-sensitive iff the query contains an uppercase letter. */
+export function isCaseSensitive(query: string): boolean {
+  return /[A-Z]/.test(query);
+}
+
+/** All non-overlapping match ranges of `query` in `text`, left to right.
+ * Empty when the query is empty or there is no match. */
+export function matchRanges(text: string, query: string): MatchRange[] {
+  if (!query) return [];
+  const cs = isCaseSensitive(query);
+  const hay = cs ? text : text.toLowerCase();
+  const needle = cs ? query : query.toLowerCase();
+  const out: MatchRange[] = [];
+  let i = hay.indexOf(needle);
+  while (i !== -1) {
+    out.push({ start: i, end: i + needle.length });
+    i = hay.indexOf(needle, i + needle.length); // non-overlapping
+  }
+  return out;
+}
+
+/** Whether `query` occurs in `text` (smart-case). False for an empty query. */
+export function hasMatch(text: string, query: string): boolean {
+  if (!query) return false;
+  const cs = isCaseSensitive(query);
+  return (cs ? text : text.toLowerCase()).includes(cs ? query : query.toLowerCase());
+}
+```
+
+- [ ] **Step 4: Run test + typecheck to verify pass**
+
+Run: `npx vitest run tests/ui/search/matcher.test.ts && npx tsc --noEmit`
+Expected: PASS, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx biome check --write src/ui/search/matcher.ts tests/ui/search/matcher.test.ts
+git add src/ui/search/matcher.ts tests/ui/search/matcher.test.ts
+git commit -m "feat(search): pure substring+smart-case matcher
+
+Refs #198"
+```
+
+---
+
+### Task 2: Search mode in `useHotkeys`
+
+Add a search mode that, while active, routes every keystroke to a search
+handler; and a `/` binding that opens search for the focused surface. No App
+wiring yet — this task is the router contract + its tests.
+
+**Files:**
+- Modify: `src/ui/hooks/useHotkeys.ts` (props `UseHotkeysOptions`, the input handler)
+- Test: `tests/ui/hooks/useHotkeys.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: three new `UseHotkeysOptions` fields — `searchActive: boolean`, `onOpenSearch: () => void`, `onSearchKey: (input: string, key: KeyFlags) => void` (where `KeyFlags` is the same `key` object shape `handleInput` already receives). Behavior: when `searchActive` is true, the handler calls `onSearchKey(input, key)` and returns immediately (before help/detail/main routing). When not active, `/` (no ctrl) calls `onOpenSearch()` and returns.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/ui/hooks/useHotkeys.test.ts` (follow the file's existing harness for building options + calling `handleInput`; read the top of the file). Minimal new cases:
+
+```ts
+it("routes all keys to onSearchKey while searchActive, before other modes", () => {
+  const onSearchKey = vi.fn();
+  const onQuit = vi.fn();
+  const { handleInput } = makeHotkeys({ searchActive: true, onSearchKey, onQuit });
+  handleInput("q", keyOf({}));
+  expect(onSearchKey).toHaveBeenCalledWith("q", expect.any(Object));
+  expect(onQuit).not.toHaveBeenCalled(); // search swallows it
+});
+
+it("'/' opens search for the focused surface when not active", () => {
+  const onOpenSearch = vi.fn();
+  const { handleInput } = makeHotkeys({ searchActive: false, onOpenSearch });
+  handleInput("/", keyOf({}));
+  expect(onOpenSearch).toHaveBeenCalledTimes(1);
+});
+```
+
+If the test file lacks `makeHotkeys`/`keyOf` helpers, mirror the existing
+option-builder/key-builder the neighbouring tests use (the file already
+constructs options and a `key` object). Provide `searchActive`/`onOpenSearch`/
+`onSearchKey` defaults in that builder.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/ui/hooks/useHotkeys.test.ts -t "search"`
+Expected: FAIL — `searchActive`/`onOpenSearch`/`onSearchKey` not handled.
+
+- [ ] **Step 3: Implement**
+
+In `UseHotkeysOptions` (`src/ui/hooks/useHotkeys.ts`) add:
+
+```ts
+  searchActive: boolean;
+  onOpenSearch: () => void;
+  onSearchKey: (
+    input: string,
+    key: {
+      upArrow: boolean;
+      downArrow: boolean;
+      tab: boolean;
+      pageUp: boolean;
+      pageDown: boolean;
+      return: boolean;
+      ctrl: boolean;
+      escape?: boolean;
+      leftArrow?: boolean;
+      rightArrow?: boolean;
+      backspace?: boolean;
+      delete?: boolean;
+    },
+  ) => void;
+```
+
+Ink's key object carries `backspace`/`delete` at runtime but the existing
+`handleInput` key type omits them. Widen BOTH the `handleInput` param type
+(`UseHotkeysResult`) and `onSearchKey` above to include
+`backspace?: boolean; delete?: boolean`, so the search handler can read them
+without a cast. `handleInput` already receives the full Ink key from `useInput`
+and passes it straight to `onSearchKey`.
+
+Destructure `searchActive`, `onOpenSearch`, `onSearchKey` alongside the other
+options. At the very top of the input handler — BEFORE the help-mode and
+detail-mode blocks (they are the first checks today) — add:
+
+```ts
+    // Search mode swallows every key and routes it to the search handler.
+    if (searchActive) {
+      onSearchKey(input, key);
+      return;
+    }
+```
+
+Then, in the main (non-mode) section, add a `/` binding next to the other
+single-key bindings (e.g. just before the `key.tab` branch):
+
+```ts
+    if (input === "/" && !key.ctrl) {
+      onOpenSearch();
+      return;
+    }
+```
+
+- [ ] **Step 4: Run test + typecheck**
+
+Run: `npx vitest run tests/ui/hooks/useHotkeys.test.ts && npx tsc --noEmit`
+Expected: PASS. (tsc will flag the new required options at the `useHotkeys({…})`
+call site in `App.tsx` — Task 3 supplies them. If tsc fails ONLY on App.tsx's
+call site missing the three props, that is expected; add temporary
+`searchActive: false, onOpenSearch: () => {}, onSearchKey: () => {}` to the
+App call site in this task so the build stays green, and Task 3 replaces them.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx biome check --write src/ui/hooks/useHotkeys.ts src/ui/App.tsx tests/ui/hooks/useHotkeys.test.ts
+git add src/ui/hooks/useHotkeys.ts src/ui/App.tsx tests/ui/hooks/useHotkeys.test.ts
+git commit -m "feat(search): search mode routing in useHotkeys
+
+Refs #198"
+```
+
+---
+
+### Task 3: Detail View search + shared search shell (Phase 1 deliverable)
+
+Establishes the App-level `search` state, the status-line search input, and the
+first surface: less-style jump in the Detail View.
+
+**Files:**
+- Create: `src/ui/search/detailMatches.ts`
+- Create: `src/ui/search/SearchInput.tsx`
+- Modify: `src/ui/App.tsx` (search state, callbacks, render the input, wire `useHotkeys`)
+- Modify: `src/ui/DetailViewPanel.tsx` (highlight matches, scroll the current match into view)
+- Test: `tests/ui/search/detailMatches.test.ts`
+
+**Interfaces:**
+- Consumes: `matchRanges`, `hasMatch` (Task 1); `searchActive`/`onOpenSearch`/`onSearchKey` (Task 2).
+- Produces: the App `search` state shape (below) and `detailMatchLines(lines: string[], query: string): number[]` (the indices of body lines that contain a match, in order) used to drive `n`/`N` jumps.
+
+App search state shape (add to `App.tsx` state):
+
+```ts
+type SearchSurface = "tree" | "viewer" | "detail";
+interface SearchState {
+  surface: SearchSurface;
+  query: string;
+  index: number; // current match index (detail: line-match #; lists: selected match row)
+}
+// const [search, setSearch] = useState<SearchState | null>(null);
+```
+
+- [ ] **Step 1: Write the failing test (pure detail matcher)**
+
+```ts
+// tests/ui/search/detailMatches.test.ts
+import { describe, expect, it } from "vitest";
+import { detailMatchLines } from "../../../src/ui/search/detailMatches.js";
+
+describe("detailMatchLines", () => {
+  const lines = ["import foo", "const x = 1", "foo(x)", "done"];
+  it("returns indices of lines containing the query (smart-case)", () => {
+    expect(detailMatchLines(lines, "foo")).toEqual([0, 2]);
+  });
+  it("empty query → no matches", () => {
+    expect(detailMatchLines(lines, "")).toEqual([]);
+  });
+  it("uppercase query is case-sensitive", () => {
+    expect(detailMatchLines(["Foo", "foo"], "Foo")).toEqual([0]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/ui/search/detailMatches.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the pure helper**
+
+```ts
+// src/ui/search/detailMatches.ts
+import { hasMatch } from "./matcher.js";
+
+/** Indices of body lines that contain a match for `query`, in order.
+ * Drives the Detail View's `n`/`N` jump. Empty for an empty query. */
+export function detailMatchLines(lines: string[], query: string): number[] {
+  if (!query) return [];
+  const out: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (hasMatch(lines[i], query)) out.push(i);
+  }
+  return out;
+}
+```
+
+Run: `npx vitest run tests/ui/search/detailMatches.test.ts` → PASS.
+
+- [ ] **Step 4: Build the status-line `SearchInput` component**
+
+```tsx
+// src/ui/search/SearchInput.tsx
+import { Text } from "ink";
+
+/** One-line search prompt shown in the status area: `/query   3/12`.
+ * `total` 0 renders `0/0`; `current` is 1-based for display. */
+export function SearchInput(props: {
+  query: string;
+  current: number; // 1-based; 0 when no matches
+  total: number;
+}): JSX.Element {
+  const count = props.total === 0 ? "0/0" : `${props.current}/${props.total}`;
+  return (
+    <Text>
+      <Text color="cyan">/</Text>
+      {props.query}
+      <Text dimColor>{`   ${count}`}</Text>
+    </Text>
+  );
+}
+```
+
+- [ ] **Step 5: Wire search state + keys + Detail behavior in `App.tsx`**
+
+Read the `useHotkeys({…})` call site (~line 1045) and the Detail render path
+first. Then:
+
+1. Add state: `const [search, setSearch] = useState<SearchState | null>(null);`
+   (with the `SearchSurface`/`SearchState` types above).
+2. Compute the Detail body lines the view already renders (the same array
+   `DetailViewPanel` scrolls — locate how App passes detail content; reuse it).
+   Derive matches when `search?.surface === "detail"`:
+   `const detailHits = search?.surface === "detail" ? detailMatchLines(detailLines, search.query) : [];`
+3. Pass the three new options to `useHotkeys`:
+
+```ts
+    searchActive: search !== null,
+    onOpenSearch: () => {
+      const surface: SearchSurface = detailMode ? "detail" : focus;
+      setSearch({ surface, query: "", index: 0 });
+    },
+    onSearchKey: (input, key) => {
+      setSearch((s) => {
+        if (!s) return s;
+        if (key.escape) return null; // cancel
+        if (s.surface === "detail") {
+          if (key.return || input === "n") return { ...s, index: s.index + 1 };
+          if (input === "N") return { ...s, index: s.index - 1 };
+        }
+        if (key.delete || key.backspace) return { ...s, query: s.query.slice(0, -1) };
+        if (input && !key.ctrl && input.length === 1) return { ...s, query: s.query + input, index: 0 };
+        return s;
+      });
+    },
+```
+
+   (Ink delivers Backspace via `key.backspace`/`key.delete` — include both in
+   the `KeyFlags` you accept. For lists, `↑`/`↓` and `Enter` are handled in
+   Tasks 4–5; here only the detail branch acts on `n`/`N`/`Enter`.)
+4. Render the search input in the status area when `search !== null`, replacing
+   or overlaying the normal status line:
+
+```tsx
+{search ? (
+  <SearchInput
+    query={search.query}
+    total={search.surface === "detail" ? detailHits.length : 0}
+    current={detailHits.length ? ((((search.index % detailHits.length) + detailHits.length) % detailHits.length) + 1) : 0}
+  />
+) : (
+  /* existing status bar render */
+)}
+```
+
+5. Pass the active match line to `DetailViewPanel` so it can scroll/ highlight:
+   compute `const detailCurrentLine = detailHits.length ? detailHits[(((search?.index ?? 0) % detailHits.length) + detailHits.length) % detailHits.length] : null;`
+   and pass `searchQuery={search?.surface === "detail" ? search.query : ""}` and
+   `activeMatchLine={detailCurrentLine}` props.
+
+- [ ] **Step 6: Highlight + scroll in `DetailViewPanel.tsx`**
+
+Read the panel's line-render loop. Add two optional props
+(`searchQuery?: string; activeMatchLine?: number | null`). When `searchQuery`
+is non-empty, for each rendered line use `matchRanges(line, searchQuery)` to
+wrap matched spans in `<Text inverse>…</Text>` (the active match line may use a
+distinct color, e.g. `backgroundColor="yellow"`). When `activeMatchLine` is
+non-null, adjust the panel's scroll offset so that line is within the visible
+window (mirror the existing scroll-clamp logic; do not add a second scroll
+system).
+
+- [ ] **Step 7: Manual + automated verification**
+
+Run: `npx vitest run && npx tsc --noEmit`, then build and try it:
+`npm run build && node dist/index.js` → open a session, `↵` on an activity with
+a long body, press `/`, type a term → first match highlighted and scrolled to;
+`n`/`N` cycle; `Esc` exits search but stays in the Detail View.
+Expected: full suite green, tsc clean, manual behavior as described.
+
+- [ ] **Step 8: Docs sync + commit**
+
+Add the `/` and `n`/`N` (Detail) keys to `getHelp()` (`src/cli.ts`),
+`HelpPanel` SECTIONS (`src/ui/HelpPanel.tsx`), and the keybindings table in
+`FEATURES.md`.
+
+```bash
+npx biome check --write src/ui/search src/ui/App.tsx src/ui/DetailViewPanel.tsx src/cli.ts src/ui/HelpPanel.tsx tests/ui/search/detailMatches.test.ts
+git add -A
+git commit -m "feat(search): Detail View jump search + shared search shell
+
+Refs #198"
+```
+
+---
+
+### Task 4: Activity Viewer narrow-finder (Phase 2)
+
+**Files:**
+- Create: `src/ui/search/activityMatch.ts`
+- Modify: `src/ui/App.tsx` (viewer search branch in `onSearchKey`, derive narrowed list, status count, Enter→cursor)
+- Modify: `src/ui/ActivityViewerPanel.tsx` (render the narrowed list + highlight)
+- Test: `tests/ui/search/activityMatch.test.ts`
+
+**Interfaces:**
+- Consumes: `hasMatch`/`matchRanges` (Task 1); the App `search` state + `SearchInput` shell (Task 3).
+- Produces: `activityMatches(activities: ActivityEntry[], query: string): number[]` (indices into the *input* array that match on `label` or one-line `detail`), used to narrow + to map the finder selection back to the real activity.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/ui/search/activityMatch.test.ts
+import { describe, expect, it } from "vitest";
+import type { ActivityEntry } from "../../../src/types/index.js";
+import { activityMatches } from "../../../src/ui/search/activityMatch.js";
+
+const a = (label: string, detail: string): ActivityEntry => ({
+  timestamp: new Date(0),
+  type: "tool",
+  icon: "$",
+  label,
+  detail,
+});
+
+describe("activityMatches", () => {
+  const acts = [a("Bash", "npm test"), a("Read", "auth.ts"), a("Edit", "main.ts")];
+  it("matches label or one-line detail (smart-case)", () => {
+    expect(activityMatches(acts, "auth")).toEqual([1]); // detail
+    expect(activityMatches(acts, "edit")).toEqual([2]); // label
+  });
+  it("empty query → no matches", () => {
+    expect(activityMatches(acts, "")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npx vitest run tests/ui/search/activityMatch.test.ts` → module missing.
+
+- [ ] **Step 3: Implement the pure helper**
+
+```ts
+// src/ui/search/activityMatch.ts
+import type { ActivityEntry } from "../../types/index.js";
+import { hasMatch } from "./matcher.js";
+
+/** Indices of activities whose label or one-line detail match `query`
+ * (smart-case). The multi-line detailBody is intentionally NOT searched
+ * here — that is the Detail View's job. Empty for an empty query. */
+export function activityMatches(
+  activities: ActivityEntry[],
+  query: string,
+): number[] {
+  if (!query) return [];
+  const out: number[] = [];
+  for (let i = 0; i < activities.length; i++) {
+    const a = activities[i];
+    if (hasMatch(a.label, query) || hasMatch(a.detail, query)) out.push(i);
+  }
+  return out;
+}
+```
+
+Run the test → PASS.
+
+- [ ] **Step 4: Wire the Viewer finder in `App.tsx`**
+
+The viewer renders `activities` after the `f` type-filter (locate the filtered
+array passed to `ActivityViewerPanel`). When `search?.surface === "viewer"`:
+
+```ts
+const viewerHits = search?.surface === "viewer"
+  ? activityMatches(filteredActivities, search.query)
+  : [];
+```
+
+Extend `onSearchKey`'s list handling for `surface === "viewer"`:
+- `↑` (key.upArrow): `index = (index - 1 + n) % n`
+- `↓` (key.downArrow): `index = (index + 1) % n` (n = `viewerHits.length`, guard 0)
+- `Enter` (key.return): move the viewer cursor to the matched activity, then
+  `setSearch(null)`. Map the hit to the viewer's cursor model: the panel uses
+  `viewerCursorLine` ("entries back from newest"); set it from the chosen
+  activity's position (`filteredActivities.length - 1 - hitIndex`). Read the
+  existing cursor math and reuse it; do not invent a parallel index.
+
+Pass to `ActivityViewerPanel`: `searchQuery` (when viewer surface),
+`searchHits={viewerHits}`, and `searchSelected` (the current `index`), so the
+panel can render only matched rows (narrow) with the selected one emphasized
+and the query highlighted. Update the `SearchInput` total/current to use
+`viewerHits` when `surface === "viewer"`.
+
+- [ ] **Step 5: Narrow + highlight in `ActivityViewerPanel.tsx`**
+
+Read the panel's row-render loop. Add optional props
+(`searchQuery?: string; searchHits?: number[]; searchSelected?: number`). When
+`searchHits` is provided, render only those rows (the narrow), emphasize
+`searchHits[searchSelected]`, and highlight matched spans via
+`matchRanges(rowText, searchQuery)`. When absent, render normally (unchanged).
+
+- [ ] **Step 6: Verify**
+
+`npx vitest run && npx tsc --noEmit`; build and try: focus the viewer, `/`,
+type → list narrows to matches, `↑/↓` move selection, `Enter` jumps the cursor
+to that activity and restores the full stream; `Esc` cancels. Confirm it
+composes with `f` (apply a filter, then search narrows within it).
+
+- [ ] **Step 7: Docs sync + commit**
+
+Note the Viewer search behavior under the `/` entry in `getHelp()`,
+`HelpPanel`, and `FEATURES.md`.
+
+```bash
+npx biome check --write src/ui/search src/ui/App.tsx src/ui/ActivityViewerPanel.tsx src/cli.ts src/ui/HelpPanel.tsx tests/ui/search/activityMatch.test.ts
+git add -A
+git commit -m "feat(search): Activity Viewer narrow-finder
+
+Refs #198"
+```
+
+---
+
+### Task 5: Session Tree narrow-finder (Phase 3)
+
+**Files:**
+- Create: `src/ui/search/treeSearch.ts`
+- Modify: `src/ui/App.tsx` (tree search branch, narrowed tree, Enter→select)
+- Modify: `src/ui/SessionTreePanel.tsx` (render narrowed tree + highlight)
+- Test: `tests/ui/search/treeSearch.test.ts`
+
+**Interfaces:**
+- Consumes: `hasMatch` (Task 1); the App `search` state + shell (Task 3); the
+  `SessionTree`/`SessionNode`/`ProjectNode` types (`src/types/index.ts`); mirrors
+  the shape of `filterTreeByHidden` in `App.tsx`.
+- Produces: `filterTreeBySearch(tree: SessionTree, query: string): SessionTree`
+  (hierarchical narrow) and `treeSearchHits(tree: SessionTree, query: string):
+  string[]` (ids of matching session/sub-agent nodes, in display order, for
+  selection).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/ui/search/treeSearch.test.ts
+import { describe, expect, it } from "vitest";
+import type { ProjectNode, SessionNode, SessionTree } from "../../../src/types/index.js";
+import { filterTreeBySearch, treeSearchHits } from "../../../src/ui/search/treeSearch.js";
+
+const sess = (id: string, prompt: string, subs: SessionNode[] = []): SessionNode => ({
+  id, hideKey: id, filePath: `/x/${id}.jsonl`, projectPath: "/x", projectName: "x",
+  lastModifiedMs: 0, status: "cold", modelName: null, subAgents: subs,
+  nonInteractive: false, firstUserPrompt: prompt, liveState: null,
+});
+const proj = (name: string, sessions: SessionNode[]): ProjectNode => ({
+  name, projectPath: `/${name}`, sessions, hotness: "cold",
+});
+const tree = (projects: ProjectNode[]): SessionTree => ({ projects, coldProjects: [] });
+
+describe("filterTreeBySearch", () => {
+  it("keeps a matching session and its parent project; drops the rest", () => {
+    const t = tree([
+      proj("alpha", [sess("s1", "add auth flow"), sess("s2", "fix css")]),
+      proj("beta", [sess("s3", "refactor db")]),
+    ]);
+    const out = filterTreeBySearch(t, "auth");
+    expect(out.projects.map((p) => p.name)).toEqual(["alpha"]);
+    expect(out.projects[0].sessions.map((s) => s.id)).toEqual(["s1"]);
+  });
+  it("matches on project name (keeps the project, all its sessions)", () => {
+    const t = tree([proj("beta", [sess("s3", "refactor db")])]);
+    expect(filterTreeBySearch(t, "beta").projects).toHaveLength(1);
+  });
+  it("matches a sub-agent → keeps its parent session + project", () => {
+    const t = tree([proj("alpha", [sess("s1", "top", [sess("sa1", "run auth tests")])])]);
+    const out = filterTreeBySearch(t, "auth");
+    expect(out.projects[0].sessions[0].subAgents.map((s) => s.id)).toEqual(["sa1"]);
+  });
+  it("empty query → tree unchanged", () => {
+    const t = tree([proj("alpha", [sess("s1", "x")])]);
+    expect(filterTreeBySearch(t, "")).toEqual(t);
+  });
+});
+
+describe("treeSearchHits", () => {
+  it("returns matching node ids in display order", () => {
+    const t = tree([proj("alpha", [sess("s1", "add auth"), sess("s2", "auth bug")])]);
+    expect(treeSearchHits(t, "auth")).toEqual(["s1", "s2"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails** — module missing.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/ui/search/treeSearch.ts
+import type { ProjectNode, SessionNode, SessionTree } from "../../types/index.js";
+import { hasMatch } from "./matcher.js";
+
+function sessionText(s: SessionNode): string {
+  return `${s.firstUserPrompt ?? ""} ${s.id} ${s.agentId ?? ""}`;
+}
+
+function filterSession(s: SessionNode, q: string): SessionNode | null {
+  const subs = s.subAgents.map((sa) => filterSession(sa, q)).filter(Boolean) as SessionNode[];
+  if (hasMatch(sessionText(s), q) || subs.length > 0) return { ...s, subAgents: subs };
+  return null;
+}
+
+function filterProject(p: ProjectNode, q: string): ProjectNode | null {
+  if (hasMatch(p.name, q)) return p; // project-name hit keeps all sessions
+  const sessions = p.sessions.map((s) => filterSession(s, q)).filter(Boolean) as SessionNode[];
+  return sessions.length > 0 ? { ...p, sessions } : null;
+}
+
+/** Hierarchically narrow the tree to nodes that match `query` (smart-case),
+ * keeping ancestors of any match. Empty query returns the tree unchanged. */
+export function filterTreeBySearch(tree: SessionTree, query: string): SessionTree {
+  if (!query) return tree;
+  const narrow = (projects: ProjectNode[]) =>
+    projects.map((p) => filterProject(p, query)).filter(Boolean) as ProjectNode[];
+  return { ...tree, projects: narrow(tree.projects), coldProjects: narrow(tree.coldProjects) };
+}
+
+/** Ids of matching session/sub-agent nodes in display order (for selection). */
+export function treeSearchHits(tree: SessionTree, query: string): string[] {
+  if (!query) return [];
+  const out: string[] = [];
+  const walk = (s: SessionNode) => {
+    if (hasMatch(sessionText(s), query)) out.push(s.id);
+    s.subAgents.forEach(walk);
+  };
+  for (const grp of [tree.projects, tree.coldProjects]) {
+    for (const p of grp) p.sessions.forEach(walk);
+  }
+  return out;
+}
+```
+
+(Verify `SessionTree` has both `projects` and `coldProjects` — confirm field
+names in `src/types/index.ts` and adjust if the cold group is named
+differently.)
+
+Run the test → PASS.
+
+- [ ] **Step 4: Wire the Tree finder in `App.tsx`**
+
+When `search?.surface === "tree"`: derive the narrowed tree for rendering
+(`filterTreeBySearch(displayTree, search.query)`) and the hit ids
+(`treeSearchHits(...)`). Extend `onSearchKey`'s list branch for `"tree"`:
+`↑`/`↓` move `index` over the hits (mod length); `Enter` calls
+`setSelectedId(hits[index])` then `setSearch(null)` (restoring the full tree
+via the normal non-search render path); `Esc` → `setSearch(null)` with the
+prior selection intact. Feed the narrowed tree + query + selected hit to
+`SessionTreePanel`, and the `SearchInput` count from `treeSearchHits`.
+
+- [ ] **Step 5: Narrow + highlight in `SessionTreePanel.tsx`**
+
+Read the panel's row-render loop. Add optional props (`searchQuery?: string`
+and, if the panel renders from a tree prop, pass the already-narrowed tree).
+Highlight matched spans in each row via `matchRanges`; emphasize the selected
+hit. When no search is active, render unchanged.
+
+- [ ] **Step 6: Verify**
+
+`npx vitest run && npx tsc --noEmit`; build and try: focus the tree, `/`, type →
+tree narrows to matching projects/sessions (ancestors kept), `↑/↓` move
+selection, `Enter` selects that session (viewer follows) and restores the full
+tree; `Esc` cancels.
+
+- [ ] **Step 7: Docs sync + commit**
+
+Finalize the `/` search entry across `getHelp()`, `HelpPanel`, and `FEATURES.md`
+(all three surfaces documented).
+
+```bash
+npx biome check --write src/ui/search src/ui/App.tsx src/ui/SessionTreePanel.tsx src/cli.ts src/ui/HelpPanel.tsx tests/ui/search/treeSearch.test.ts
+git add -A
+git commit -m "feat(search): Session Tree narrow-finder
+
+Refs #198"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `npx vitest run` — full suite green (matcher + detailMatches + activityMatch + treeSearch + hotkeys + existing).
+- [ ] `npx tsc --noEmit` clean; `npx biome check` clean.
+- [ ] Manual: `/` works in all three surfaces; `f` filter + viewer search compose; `Esc` always exits search; `g`/`G` still scroll; `tab`/other keys unaffected when not searching.
+- [ ] Docs: `getHelp()`, `HelpPanel`, `FEATURES.md` all document `/` (+ `n`/`N` for Detail).
+- [ ] Independent whole-branch review (fresh subagent) against this plan + the spec.
+- [ ] PR `Closes #198`, carrying spec + plan + code.

--- a/docs/superpowers/specs/2026-06-21-search-design.md
+++ b/docs/superpowers/specs/2026-06-21-search-design.md
@@ -1,0 +1,173 @@
+# In-pane text search (`/`) — design
+
+> Issue: #198 · Branch: `feat/198-search`
+
+## Context
+
+AgentHUD has a type-`filter` (`f`) that cycles `config.filterPresets` to narrow
+the Activity Viewer by activity *type* (response/bash/edit/…). It has no text
+**search**: with dozens of sessions you cannot jump to "the auth session", and
+in a long activity stream or a long Bash/diff body you cannot locate a string.
+
+The three surfaces a user looks at are all local to the running TUI:
+
+- **Session Tree** (top): projects → sessions → sub-agents.
+- **Activity Viewer** (bottom): the selected session's activity stream (each row
+  is `label` + a one-line `detail`).
+- **Detail View** (overlay): one activity's full body — a diff, file content, or
+  Bash stdout/stderr, which can be long.
+
+Cross-session / global search (grep across every session on disk) is explicitly
+out of scope — it is a much larger, separate feature (indexing, performance, a
+new results surface).
+
+## Goals
+
+Add a text search bound to `/`, scoped to the **focused** surface, distinct from
+the `f` type-filter. Two interaction models, chosen to fit each surface:
+
+- **Lists (Tree, Viewer) — transient finder** (fzf-style): `/` opens a search
+  input; typing narrows the list live to substring matches; `Enter` selects the
+  highlighted item and restores the full list with that item selected; `Esc`
+  cancels and restores with no change. Search *locates*; the `f` filter
+  *persists* — the two stay distinct.
+- **Detail View — jump** (less-style): `/` opens the input; typing jumps to the
+  first match (live); `n`/`N` cycle next/previous; `Esc` exits. The body is
+  unchanged; matches are highlighted.
+
+Matching is **substring with smart-case** (all-lowercase query → case-
+insensitive; any uppercase → case-sensitive). The matched span is rendered with
+an inverse highlight. A bottom status line shows the query and match count
+(`/auth   3/12`).
+
+## Non-goals
+
+- **Global / cross-session search.** Current TUI surfaces only.
+- **Fuzzy matching.** Substring only — predictable, and it matches the
+  less-style jump semantics in Detail. (Could be a later option.)
+- **Regex.** Plain substring. (Later option if asked.)
+- **Replacing the `f` type-filter.** Search is additive and orthogonal; in the
+  Viewer the two compose (AND).
+- **Persisting search across sessions/restarts.** Search state is ephemeral.
+
+## Keys
+
+`/ n N` are currently unbound; `g`/`G` remain scroll-to-top/bottom and are not
+touched.
+
+- `/` — open search in the focused surface (Tree if tree-focused, Viewer if
+  viewer-focused, Detail if the Detail overlay is open).
+- While the **list finder** is open: printable keys edit the query; `↑`/`↓` move
+  the selection among the narrowed matches (j/k are reserved for the query);
+  `Enter` selects + restores; `Esc` cancels + restores.
+- While **Detail search** is open: printable keys edit the query (live jump to
+  first match); `Enter` and `n` jump to the next match, `N` to the previous;
+  `Esc` exits search (stays in the Detail View).
+- `Backspace` edits the query in all modes.
+
+Search mode is exclusive and short-circuits like the existing help/detail modes
+(`useHotkeys` already routes by focus + mode; search becomes another mode).
+
+## Surface behavior
+
+### Session Tree (transient finder)
+
+- **Match fields:** project name, session/sub-agent description
+  (`firstUserPrompt`), and id. (Model/provider are not matched in v1 — low value,
+  easy to add later.)
+- **Hierarchical narrow:** a row is kept if it matches *or* has a descendant that
+  matches — so a matching session keeps its parent project visible. Empty
+  projects (no matching descendant and no self-match) are dropped.
+- **Selection:** `Enter` sets the tree selection to the highlighted session/
+  sub-agent, closes the finder, and restores the full tree. `Esc` restores with
+  the prior selection.
+
+### Activity Viewer (transient finder)
+
+- **Match fields:** activity `label` + one-line `detail`. The multi-line
+  `detailBody` is **not** searched here — that is the Detail View's job.
+- **Composition:** search narrows *within* the currently `f`-filtered activities
+  (AND). Clearing search restores the `f`-filtered stream; the `f` filter is
+  independent.
+- **Selection:** `Enter` moves the viewer cursor to the highlighted activity and
+  restores the full (filtered) stream. `Esc` restores the prior cursor.
+
+### Detail View (jump)
+
+- **Match target:** the rendered body text (the same lines the view scrolls).
+- `n`/`N` cycle matches and scroll the body so the current match is visible; the
+  current match gets a distinct highlight from the others. `Esc` exits search;
+  the Detail View stays open at the current scroll position.
+
+## Components
+
+Keep units small and pure where possible.
+
+- **`src/ui/search/matcher.ts`** — pure matching. `matchRanges(text, query):
+  Array<[start, end]>` (smart-case; empty for no match / empty query) and a thin
+  `hasMatch(text, query): boolean`. The single source of match + highlight
+  truth, unit-tested in isolation.
+- **Tree narrow** — a pure `filterTreeBySearch(tree, query)` mirroring the
+  existing `filterTreeByHidden` shape (`src/ui/App.tsx`), returning the
+  hierarchically-narrowed tree.
+- **Viewer narrow** — a pure predicate over `ActivityEntry` (label + detail)
+  reusing `matcher`.
+- **Detail matches** — a pure helper returning the match line/column positions
+  over the body lines for jump + highlight.
+- **Search state + input shell** — a small piece of UI state (active surface,
+  query, selection/match index) and a status-line input renderer. Routed by a
+  new `search` mode in `useHotkeys` (sibling to help/detail modes).
+
+## Data flow
+
+```
+'/'  → enter search mode for the focused surface
+typing → matcher.matchRanges over that surface's text
+  · lists  → narrow (pure filter) + highlight; ↑/↓ move selection
+  · detail → compute match positions; jump to first; highlight
+Enter → lists: commit selection, restore full list; detail: next match
+Esc   → restore (lists) / exit (detail); leave search mode
+```
+
+## Error handling
+
+- Empty query → no matches, no narrow (list shows full set; detail no jump).
+- No matches → status line shows `0/0`; lists render empty-with-hint; detail
+  stays put. No throw.
+- Query with regex-special characters is treated literally (substring, not
+  regex) — no escaping pitfalls.
+- Search state resets when the focused surface changes or the underlying data
+  refreshes in a way that invalidates the selection (fall back to the live edge,
+  consistent with existing viewer behavior).
+
+## Testing
+
+- **`matcher.ts`** unit tests: substring hit/miss, smart-case (lowercase vs
+  mixed-case query), multiple ranges in one string, empty query, overlapping/
+  adjacent matches, unicode width-safe ranges.
+- **Tree narrow**: matching session keeps its project; matching project keeps
+  itself; non-matching branches dropped; sub-agent match keeps parent chain.
+- **Viewer narrow**: matches label and detail; composes with a `f` filter (AND);
+  Enter selects the right activity.
+- **Detail jump**: first-match jump, `n`/`N` wrap-around, current-vs-other
+  highlight, `Esc` keeps scroll.
+- **Hotkeys**: `/` enters search for the focused surface; keys route to the
+  query; `Esc`/`Enter` lifecycle; search mode short-circuits other bindings.
+
+All via TDD. `tsc --noEmit` and whole-repo `biome check` clean before each
+commit. Docs kept in sync (`getHelp()`, `HelpPanel` SECTIONS, FEATURES.md).
+
+## Phasing
+
+One spec, a staged plan — each phase is independently shippable.
+
+1. **Shared matcher + search shell + Detail search.** Establishes
+   `matcher.ts`, the search mode in `useHotkeys`, the status-line input, and the
+   simplest surface (jump, no narrow, no selection-restore).
+2. **Activity Viewer narrow-finder.** Adds list-narrow + transient-finder
+   lifecycle + AND composition with `f`.
+3. **Session Tree narrow-finder.** Hierarchical narrow + selection restore — the
+   highest-value, most complex surface, built last on the proven shell.
+
+Each phase updates `getHelp()`, `HelpPanel`, and FEATURES.md for the keys it
+adds.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -144,11 +144,11 @@ Commands:
                                 the current directory. Exits 1 if no
                                 such project is found.
 
-  TUI keybindings (detail view):
-    /                           Open search — jump to first match,
-                                matches highlighted
-    n / N                       Next / previous match
-    Esc                         Close search, stay in detail view
+  TUI keybindings:
+    /                           Search the focused pane — tree/viewer
+                                narrow to matches (↑↓ select, ↵ jump),
+                                detail view jumps (n/N next/prev)
+    Esc                         Close search, stay in focused pane
     ↑↓/jk, Ctrl+U/D            Scroll; ↵/Esc/q to close detail
 
   report [--date DATE] [--include TYPES] [--format FORMAT]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -144,6 +144,13 @@ Commands:
                                 the current directory. Exits 1 if no
                                 such project is found.
 
+  TUI keybindings (detail view):
+    /                           Open search — jump to first match,
+                                matches highlighted
+    n / N                       Next / previous match
+    Esc                         Close search, stay in detail view
+    ↑↓/jk, Ctrl+U/D            Scroll; ↵/Esc/q to close detail
+
   report [--date DATE] [--include TYPES] [--format FORMAT]
          [--detail-limit N] [--with-git]
                                 Print activity report for a date

--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -39,6 +39,7 @@ import {
   getDisplayWidth,
   getInnerWidth,
 } from "./constants.js";
+import { matchRanges } from "./search/matcher.js";
 
 export interface ActivityStyle {
   color?: string;
@@ -125,6 +126,12 @@ export interface ActivityViewerPanelProps {
   hasFocus: boolean;
   spinner?: string;
   filterLabel?: string;
+  /** When set (viewer narrow-finder active), only matched rows are rendered. */
+  searchHits?: number[];
+  /** The search query used to compute `searchHits` — used for match highlighting. */
+  searchQuery?: string;
+  /** Index into `searchHits` identifying the currently selected match (0-based). */
+  searchSelected?: number;
 }
 
 function formatActivityTime(date: Date, now: Date): string {
@@ -271,6 +278,33 @@ const ActivityRow = memo(function ActivityRow({
   );
 });
 
+/**
+ * Render a text string with match ranges highlighted in yellow.
+ * Segments outside matches are plain text; matched segments are bold+yellow.
+ */
+function renderHighlighted(text: string, query: string): React.ReactElement {
+  const ranges = matchRanges(text, query);
+  if (ranges.length === 0) return <>{text}</>;
+  const segments: React.ReactElement[] = [];
+  let pos = 0;
+  for (let i = 0; i < ranges.length; i++) {
+    const { start, end } = ranges[i];
+    if (start > pos) {
+      segments.push(<Text key={`pre-${i}`}>{text.slice(pos, start)}</Text>);
+    }
+    segments.push(
+      <Text key={`match-${i}`} color="yellow" bold>
+        {text.slice(start, end)}
+      </Text>,
+    );
+    pos = end;
+  }
+  if (pos < text.length) {
+    segments.push(<Text key="tail">{text.slice(pos)}</Text>);
+  }
+  return <>{segments}</>;
+}
+
 export function ActivityViewerPanel({
   activities,
   sessionName,
@@ -285,9 +319,123 @@ export function ActivityViewerPanel({
   hasFocus,
   spinner = "",
   filterLabel,
+  searchHits,
+  searchQuery,
+  searchSelected,
 }: ActivityViewerPanelProps): React.ReactElement {
   const innerWidth = getInnerWidth(width);
   const contentWidth = innerWidth - 1;
+
+  // Narrow-finder mode: when searchHits is provided, render only matched rows.
+  if (searchHits !== undefined && searchQuery !== undefined) {
+    const safeSelected =
+      searchHits.length > 0
+        ? (((searchSelected ?? 0) % searchHits.length) + searchHits.length) %
+          searchHits.length
+        : 0;
+    const now = new Date();
+    const lines: React.ReactElement[] = [];
+    const filterSuffix =
+      filterLabel && filterLabel !== "all" ? ` · ${filterLabel}` : "";
+    const titleSuffix = `[SEARCH${filterSuffix}]`;
+
+    if (searchHits.length === 0) {
+      const emptyText = searchQuery ? "No matches" : "No activity yet";
+      const emptyPadding = Math.max(0, contentWidth - emptyText.length);
+      lines.push(
+        <Text key="empty">
+          {BOX.v} <Text dimColor>{emptyText}</Text>
+          {" ".repeat(emptyPadding)}
+          {BOX.v}
+        </Text>,
+      );
+    } else {
+      for (let i = 0; i < searchHits.length; i++) {
+        const actIdx = searchHits[i];
+        const activity = activities[actIdx];
+        if (!activity) continue;
+        const isSelected = i === safeSelected;
+        const style = getActivityStyle(activity);
+        const timestamp = `[${formatActivityTime(activity.timestamp, now)}] `;
+        const timestampWidth = timestamp.length;
+        const icon = activity.icon;
+        const iconWidth = getDisplayWidth(icon);
+        const label = activity.label;
+        const detail = activity.detail;
+        const count = activity.count;
+        const countSuffix = count && count > 1 ? ` (×${count})` : "";
+        const labelPart = detail ? `${label}: ` : label;
+        const labelWidth = labelPart.length;
+        const detailMaxWidth =
+          width -
+          2 -
+          timestampWidth -
+          iconWidth -
+          1 -
+          labelWidth -
+          countSuffix.length -
+          1;
+        const flatDetail = detail ? flattenForOneLine(detail) : "";
+        const truncatedDetail = flatDetail
+          ? truncateDetail(flatDetail, Math.max(0, detailMaxWidth))
+          : "";
+        const labelContent = detail
+          ? `${labelPart}${truncatedDetail}${countSuffix}`
+          : label + countSuffix;
+        const usedWidth =
+          1 +
+          1 +
+          timestampWidth +
+          iconWidth +
+          1 +
+          getDisplayWidth(labelContent) +
+          1;
+        const padding = Math.max(0, width - usedWidth);
+
+        // Build highlighted label content
+        const fullText = labelContent;
+        const highlightedContent = searchQuery
+          ? renderHighlighted(fullText, searchQuery)
+          : fullText;
+
+        lines.push(
+          <Text key={`search-row-${i}`}>
+            {BOX.v}{" "}
+            <Text backgroundColor={isSelected ? "blue" : undefined}>
+              <Text dimColor={!isSelected}>{timestamp}</Text>
+              <Text color="cyan">{icon}</Text>{" "}
+              <Text
+                color={isSelected ? undefined : style.color}
+                dimColor={!isSelected && style.dimColor}
+              >
+                {highlightedContent}
+              </Text>
+              {" ".repeat(padding)}
+            </Text>
+            {BOX.v}
+          </Text>,
+        );
+      }
+    }
+
+    const emptyRow = `${BOX.v}${" ".repeat(contentWidth + 1)}${BOX.v}`;
+    const padCount = Math.max(0, visibleRows - lines.length);
+    const padded: React.ReactElement[] = [];
+    for (let i = 0; i < padCount; i++) {
+      padded.push(<Text key={`pad-${i}`}>{emptyRow}</Text>);
+    }
+    const finalLines = [...padded, ...lines];
+
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text color="cyan">
+          {createTitleLine(sessionName, titleSuffix, width)}
+        </Text>
+        {finalLines}
+        <Text>{createBottomLine(width)}</Text>
+      </Box>
+    );
+  }
 
   const filterSuffix =
     filterLabel && filterLabel !== "all" ? ` · ${filterLabel}` : "";

--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -350,8 +350,17 @@ export function ActivityViewerPanel({
         </Text>,
       );
     } else {
-      for (let i = 0; i < searchHits.length; i++) {
-        const actIdx = searchHits[i];
+      // Window the hit list so the selected hit stays visible within
+      // `visibleRows`. Mirror the normal render path's slice logic.
+      const windowStart = Math.max(
+        0,
+        Math.min(safeSelected, searchHits.length - visibleRows),
+      );
+      const windowEnd = Math.min(searchHits.length, windowStart + visibleRows);
+      const windowedHits = searchHits.slice(windowStart, windowEnd);
+      for (let wi = 0; wi < windowedHits.length; wi++) {
+        const i = windowStart + wi; // global hit index
+        const actIdx = windowedHits[wi];
         const activity = activities[actIdx];
         if (!activity) continue;
         const isSelected = i === safeSelected;
@@ -399,7 +408,7 @@ export function ActivityViewerPanel({
           : fullText;
 
         lines.push(
-          <Text key={`search-row-${i}`}>
+          <Text key={`search-row-${wi}`}>
             {BOX.v}{" "}
             <Text backgroundColor={isSelected ? "blue" : undefined}>
               <Text dimColor={!isSelected}>{timestamp}</Text>

--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -132,6 +132,12 @@ export interface ActivityViewerPanelProps {
   searchQuery?: string;
   /** Index into `searchHits` identifying the currently selected match (0-based). */
   searchSelected?: number;
+  /**
+   * Persisted edge-scroll window start for viewer narrow-finder. When provided,
+   * this value is used directly (with defensive clamp) instead of computing
+   * windowStart from safeSelected, enabling fzf-style stable-window scrolling.
+   */
+  searchWindowStart?: number;
 }
 
 function formatActivityTime(date: Date, now: Date): string {
@@ -322,6 +328,7 @@ export function ActivityViewerPanel({
   searchHits,
   searchQuery,
   searchSelected,
+  searchWindowStart,
 }: ActivityViewerPanelProps): React.ReactElement {
   const innerWidth = getInnerWidth(width);
   const contentWidth = innerWidth - 1;
@@ -351,11 +358,14 @@ export function ActivityViewerPanel({
       );
     } else {
       // Window the hit list so the selected hit stays visible within
-      // `visibleRows`. Mirror the normal render path's slice logic.
-      const windowStart = Math.max(
-        0,
-        Math.min(safeSelected, searchHits.length - visibleRows),
-      );
+      // `visibleRows`. Use the persisted edge-scroll start from App when
+      // available (fzf-style stable window); fall back to pinning the
+      // selected hit at the top (legacy behaviour) when it isn't.
+      const maxWindowStart = Math.max(0, searchHits.length - visibleRows);
+      const windowStart =
+        searchWindowStart !== undefined
+          ? Math.max(0, Math.min(searchWindowStart, maxWindowStart))
+          : Math.max(0, Math.min(safeSelected, maxWindowStart));
       const windowEnd = Math.min(searchHits.length, windowStart + visibleRows);
       const windowedHits = searchHits.slice(windowStart, windowEnd);
       for (let wi = 0; wi < windowedHits.length; wi++) {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -73,7 +73,16 @@ import { useHotkeys } from "./hooks/useHotkeys.js";
 import { useSpinner } from "./hooks/useSpinner.js";
 import { useTick } from "./hooks/useTick.js";
 import { SessionTreePanel } from "./SessionTreePanel.js";
+import { detailMatchLines } from "./search/detailMatches.js";
+import { SearchInput } from "./search/SearchInput.js";
 import { adjustViewerCursorOnNewActivities } from "./viewerCursor.js";
+
+type SearchSurface = "tree" | "viewer" | "detail";
+interface SearchState {
+  surface: SearchSurface;
+  query: string;
+  index: number; // current match index (detail: line-match #; lists: selected match row)
+}
 
 const VIEWER_HEIGHT_FRACTION = 0.55;
 
@@ -668,6 +677,9 @@ export function App({
   // `discoverSessions` always carries hidden items + their `hidden`
   // marks so toggling can flip the view instantly without a refetch.
   const [showHidden, setShowHidden] = useState(false);
+
+  // In-pane search state. null = search closed.
+  const [search, setSearch] = useState<SearchState | null>(null);
 
   // Tree as the renderer sees it. Defaults to the hidden-stripped
   // view; flips to the full source tree when `showHidden` is on.
@@ -1483,13 +1495,54 @@ export function App({
     onQuit: exit,
     onFilter: () => setFilterIndex((i) => (i + 1) % filterPresets.length),
     filterLabel,
-    // TODO(Task 3): replace these stubs with real search state
-    searchActive: false,
-    onOpenSearch: () => {},
-    onSearchKey: () => {},
+    searchActive: search !== null,
+    onOpenSearch: () => {
+      const surface: SearchSurface = detailMode ? "detail" : focus;
+      setSearch({ surface, query: "", index: 0 });
+    },
+    onSearchKey: (input, key) => {
+      setSearch((s) => {
+        if (!s) return s;
+        if (key.escape) return null; // cancel
+        if (s.surface === "detail") {
+          if (key.return || input === "n") return { ...s, index: s.index + 1 };
+          if (input === "N") return { ...s, index: s.index - 1 };
+        }
+        if (key.delete || key.backspace)
+          return { ...s, query: s.query.slice(0, -1) };
+        if (input && !key.ctrl && input.length === 1)
+          return { ...s, query: s.query + input, index: 0 };
+        return s;
+      });
+    },
   });
 
   useInput((input, key) => handleInput(input, key), { isActive: isWatchMode });
+
+  // Detail search: derive the raw source lines from the active detail body
+  // (split by \n, before wrapping) so detailMatchLines can index into them.
+  const detailRawLines = useMemo(() => {
+    if (!detailActivity) return [];
+    const body = detailActivity.detailBody ?? detailActivity.detail ?? "";
+    return body.split("\n");
+  }, [detailActivity]);
+
+  const detailHits = useMemo(
+    () =>
+      search?.surface === "detail" && search.query
+        ? detailMatchLines(detailRawLines, search.query)
+        : [],
+    [search, detailRawLines],
+  );
+
+  // Wrap index into the valid match range (modular arithmetic, handles negatives).
+  const detailCurrentLine =
+    detailHits.length > 0
+      ? detailHits[
+          (((search?.index ?? 0) % detailHits.length) + detailHits.length) %
+            detailHits.length
+        ]
+      : null;
 
   const rawSelected = allFlat.find((s) => s.id === selectedId);
   // For project sentinels, resolve to the project's hottest session so the
@@ -1561,7 +1614,22 @@ export function App({
             items = items.slice(1);
             shortcuts = items.join(sep);
           }
-          return (
+          return search ? (
+            <Box marginBottom={1} width={width}>
+              <SearchInput
+                query={search.query}
+                total={search.surface === "detail" ? detailHits.length : 0}
+                current={
+                  detailHits.length
+                    ? (((search.index % detailHits.length) +
+                        detailHits.length) %
+                        detailHits.length) +
+                      1
+                    : 0
+                }
+              />
+            </Box>
+          ) : (
             <Box marginBottom={1} justifyContent="space-between" width={width}>
               <Text dimColor>{showBranding ? branding : ""}</Text>
               <Text dimColor>{shortcuts}</Text>
@@ -1610,6 +1678,8 @@ export function App({
                 scrollOffset={detailScrollOffset}
                 visibleRows={viewerRows}
                 width={width}
+                searchQuery={search?.surface === "detail" ? search.query : ""}
+                activeMatchLine={detailCurrentLine}
               />
             ) : (
               <ActivityViewerPanel

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -73,6 +73,7 @@ import { useHotkeys } from "./hooks/useHotkeys.js";
 import { useSpinner } from "./hooks/useSpinner.js";
 import { useTick } from "./hooks/useTick.js";
 import { SessionTreePanel } from "./SessionTreePanel.js";
+import { activityMatches } from "./search/activityMatch.js";
 import { detailMatchLines } from "./search/detailMatches.js";
 import { SearchInput } from "./search/SearchInput.js";
 import type { SearchState } from "./search/searchKey.js";
@@ -1498,13 +1499,66 @@ export function App({
       setSearch({ surface, query: "", index: 0, committed: false });
     },
     onSearchKey: (input, key) => {
+      // Viewer surface: narrow-finder. ↑/↓ move selection; Enter jumps cursor + closes; Esc cancels.
+      // These keys can't be handled inside setSearch's functional updater (side effects needed),
+      // so we dispatch them imperatively here while search is still the current closed-over value.
+      if (search?.surface === "viewer") {
+        if (key.escape) {
+          setSearch(null);
+          return;
+        }
+        const hits = activityMatches(mergedActivities, search.query);
+        if (key.upArrow) {
+          if (hits.length === 0) return;
+          const n = hits.length;
+          setSearch((s) =>
+            s ? { ...s, index: (((s.index - 1) % n) + n) % n } : s,
+          );
+          return;
+        }
+        if (key.downArrow) {
+          if (hits.length === 0) return;
+          const n = hits.length;
+          setSearch((s) => (s ? { ...s, index: (s.index + 1) % n } : s));
+          return;
+        }
+        if (key.return) {
+          if (hits.length > 0) {
+            const safeIndex =
+              ((search.index % hits.length) + hits.length) % hits.length;
+            const hitIndex = hits[safeIndex];
+            if (hitIndex !== undefined) {
+              // cursorLine = "entries back from newest" → filteredActivities.length - 1 - hitIndex
+              const newCursorLine = mergedActivities.length - 1 - hitIndex;
+              setViewerCursorLine(Math.max(0, newCursorLine));
+              setIsLive(false);
+              setScrollOffset(0);
+            }
+          }
+          setSearch(null);
+          return;
+        }
+        if (key.delete || key.backspace) {
+          setSearch((s) =>
+            s ? { ...s, query: s.query.slice(0, -1), index: 0 } : s,
+          );
+          return;
+        }
+        if (input && !key.ctrl && input.length === 1) {
+          setSearch((s) =>
+            s ? { ...s, query: s.query + input, index: 0 } : s,
+          );
+          return;
+        }
+        return;
+      }
       setSearch((s) => {
         if (!s) return s;
         // Detail surface: delegate to the two-phase pure reducer.
         if (s.surface === "detail") {
           return applyDetailSearchKey(s, input, key);
         }
-        // Tree / viewer surfaces: simple single-phase logic.
+        // Tree surface: simple single-phase logic.
         if (key.escape) return null; // cancel
         if (key.delete || key.backspace)
           return { ...s, query: s.query.slice(0, -1) };
@@ -1531,6 +1585,15 @@ export function App({
         ? detailMatchLines(detailRawLines, search.query)
         : [],
     [search, detailRawLines],
+  );
+
+  // Viewer search: indices into mergedActivities that match the query.
+  const viewerHits = useMemo(
+    () =>
+      search?.surface === "viewer" && search.query
+        ? activityMatches(mergedActivities, search.query)
+        : [],
+    [search, mergedActivities],
   );
 
   // Wrap index into the valid match range (modular arithmetic, handles negatives).
@@ -1616,14 +1679,25 @@ export function App({
             <Box marginBottom={1} width={width}>
               <SearchInput
                 query={search.query}
-                total={search.surface === "detail" ? detailHits.length : 0}
+                total={
+                  search.surface === "detail"
+                    ? detailHits.length
+                    : search.surface === "viewer"
+                      ? viewerHits.length
+                      : 0
+                }
                 current={
-                  detailHits.length
+                  search.surface === "detail" && detailHits.length
                     ? (((search.index % detailHits.length) +
                         detailHits.length) %
                         detailHits.length) +
                       1
-                    : 0
+                    : search.surface === "viewer" && viewerHits.length
+                      ? (((search.index % viewerHits.length) +
+                          viewerHits.length) %
+                          viewerHits.length) +
+                        1
+                      : 0
                 }
               />
             </Box>
@@ -1694,6 +1768,15 @@ export function App({
                 hasFocus={focus === "viewer"}
                 spinner={spinner}
                 filterLabel={filterLabel}
+                searchQuery={
+                  search?.surface === "viewer" ? search.query : undefined
+                }
+                searchHits={
+                  search?.surface === "viewer" ? viewerHits : undefined
+                }
+                searchSelected={
+                  search?.surface === "viewer" ? search.index : undefined
+                }
               />
             )}
           </Box>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -78,7 +78,10 @@ import { detailMatchLines } from "./search/detailMatches.js";
 import { SearchInput } from "./search/SearchInput.js";
 import type { SearchState } from "./search/searchKey.js";
 import { applyDetailSearchKey } from "./search/searchKey.js";
-import { adjustViewerCursorOnNewActivities } from "./viewerCursor.js";
+import {
+  adjustViewerCursorOnNewActivities,
+  scrollOffsetForCursor,
+} from "./viewerCursor.js";
 
 type SearchSurface = "tree" | "viewer" | "detail";
 
@@ -1528,11 +1531,14 @@ export function App({
               ((search.index % hits.length) + hits.length) % hits.length;
             const hitIndex = hits[safeIndex];
             if (hitIndex !== undefined) {
-              // cursorLine = "entries back from newest" → filteredActivities.length - 1 - hitIndex
-              const newCursorLine = mergedActivities.length - 1 - hitIndex;
-              setViewerCursorLine(Math.max(0, newCursorLine));
+              const newScrollOffset = scrollOffsetForCursor(
+                mergedActivities.length,
+                hitIndex,
+                viewerRows,
+              );
+              setViewerCursorLine(0);
               setIsLive(false);
-              setScrollOffset(0);
+              setScrollOffset(newScrollOffset);
             }
           }
           setSearch(null);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1483,6 +1483,10 @@ export function App({
     onQuit: exit,
     onFilter: () => setFilterIndex((i) => (i + 1) % filterPresets.length),
     filterLabel,
+    // TODO(Task 3): replace these stubs with real search state
+    searchActive: false,
+    onOpenSearch: () => {},
+    onSearchKey: () => {},
   });
 
   useInput((input, key) => handleInput(input, key), { isActive: isWatchMode });

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -75,14 +75,11 @@ import { useTick } from "./hooks/useTick.js";
 import { SessionTreePanel } from "./SessionTreePanel.js";
 import { detailMatchLines } from "./search/detailMatches.js";
 import { SearchInput } from "./search/SearchInput.js";
+import type { SearchState } from "./search/searchKey.js";
+import { applyDetailSearchKey } from "./search/searchKey.js";
 import { adjustViewerCursorOnNewActivities } from "./viewerCursor.js";
 
 type SearchSurface = "tree" | "viewer" | "detail";
-interface SearchState {
-  surface: SearchSurface;
-  query: string;
-  index: number; // current match index (detail: line-match #; lists: selected match row)
-}
 
 const VIEWER_HEIGHT_FRACTION = 0.55;
 
@@ -1498,16 +1495,17 @@ export function App({
     searchActive: search !== null,
     onOpenSearch: () => {
       const surface: SearchSurface = detailMode ? "detail" : focus;
-      setSearch({ surface, query: "", index: 0 });
+      setSearch({ surface, query: "", index: 0, committed: false });
     },
     onSearchKey: (input, key) => {
       setSearch((s) => {
         if (!s) return s;
-        if (key.escape) return null; // cancel
+        // Detail surface: delegate to the two-phase pure reducer.
         if (s.surface === "detail") {
-          if (key.return || input === "n") return { ...s, index: s.index + 1 };
-          if (input === "N") return { ...s, index: s.index - 1 };
+          return applyDetailSearchKey(s, input, key);
         }
+        // Tree / viewer surfaces: simple single-phase logic.
+        if (key.escape) return null; // cancel
         if (key.delete || key.backspace)
           return { ...s, query: s.query.slice(0, -1) };
         if (input && !key.ctrl && input.length === 1)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -78,6 +78,7 @@ import { detailMatchLines } from "./search/detailMatches.js";
 import { SearchInput } from "./search/SearchInput.js";
 import type { SearchState } from "./search/searchKey.js";
 import { applyDetailSearchKey } from "./search/searchKey.js";
+import { filterTreeBySearch, treeSearchHits } from "./search/treeSearch.js";
 import {
   adjustViewerCursorOnNewActivities,
   scrollOffsetForCursor,
@@ -1558,18 +1559,63 @@ export function App({
         }
         return;
       }
+
+      // Tree surface: narrow-finder. ↑/↓ move index over hits (mod length);
+      // Enter selects the hit + restores full tree; Esc cancels.
+      if (search?.surface === "tree") {
+        if (key.escape) {
+          setSearch(null);
+          return;
+        }
+        const hits = treeSearchHits(displayTree, search.query);
+        if (key.upArrow) {
+          if (hits.length === 0) return;
+          const n = hits.length;
+          setSearch((s) =>
+            s ? { ...s, index: (((s.index - 1) % n) + n) % n } : s,
+          );
+          return;
+        }
+        if (key.downArrow) {
+          if (hits.length === 0) return;
+          const n = hits.length;
+          setSearch((s) => (s ? { ...s, index: (s.index + 1) % n } : s));
+          return;
+        }
+        if (key.return) {
+          if (hits.length > 0) {
+            const safeIndex =
+              ((search.index % hits.length) + hits.length) % hits.length;
+            const hitId = hits[safeIndex];
+            if (hitId !== undefined) {
+              setSelectedId(hitId);
+              stopTracking();
+            }
+          }
+          setSearch(null);
+          return;
+        }
+        if (key.delete || key.backspace) {
+          setSearch((s) =>
+            s ? { ...s, query: s.query.slice(0, -1), index: 0 } : s,
+          );
+          return;
+        }
+        if (input && !key.ctrl && input.length === 1) {
+          setSearch((s) =>
+            s ? { ...s, query: s.query + input, index: 0 } : s,
+          );
+          return;
+        }
+        return;
+      }
+
       setSearch((s) => {
         if (!s) return s;
         // Detail surface: delegate to the two-phase pure reducer.
         if (s.surface === "detail") {
           return applyDetailSearchKey(s, input, key);
         }
-        // Tree surface: simple single-phase logic.
-        if (key.escape) return null; // cancel
-        if (key.delete || key.backspace)
-          return { ...s, query: s.query.slice(0, -1) };
-        if (input && !key.ctrl && input.length === 1)
-          return { ...s, query: s.query + input, index: 0 };
         return s;
       });
     },
@@ -1600,6 +1646,20 @@ export function App({
         ? activityMatches(mergedActivities, search.query)
         : [],
     [search, mergedActivities],
+  );
+
+  // Tree search: narrowed tree + matching session/sub-agent ids.
+  const treeSearchQuery = search?.surface === "tree" ? search.query : undefined;
+  const narrowedTree = useMemo(
+    () =>
+      treeSearchQuery
+        ? filterTreeBySearch(displayTree, treeSearchQuery)
+        : displayTree,
+    [treeSearchQuery, displayTree],
+  );
+  const treeHits = useMemo(
+    () => (treeSearchQuery ? treeSearchHits(displayTree, treeSearchQuery) : []),
+    [treeSearchQuery, displayTree],
   );
 
   // Wrap index into the valid match range (modular arithmetic, handles negatives).
@@ -1690,7 +1750,9 @@ export function App({
                     ? detailHits.length
                     : search.surface === "viewer"
                       ? viewerHits.length
-                      : 0
+                      : search.surface === "tree"
+                        ? treeHits.length
+                        : 0
                 }
                 current={
                   search.surface === "detail" && detailHits.length
@@ -1703,7 +1765,12 @@ export function App({
                           viewerHits.length) %
                           viewerHits.length) +
                         1
-                      : 0
+                      : search.surface === "tree" && treeHits.length
+                        ? (((search.index % treeHits.length) +
+                            treeHits.length) %
+                            treeHits.length) +
+                          1
+                        : 0
                 }
               />
             </Box>
@@ -1735,8 +1802,8 @@ export function App({
           )}
 
           <SessionTreePanel
-            projects={displayTree.projects ?? []}
-            coldProjects={displayTree.coldProjects ?? []}
+            projects={narrowedTree.projects ?? []}
+            coldProjects={narrowedTree.coldProjects ?? []}
             selectedId={selectedId}
             hasFocus={focus === "tree"}
             width={width}
@@ -1746,6 +1813,15 @@ export function App({
             spinner={spinner}
             scopeLabel={scopeToProject ? basename(scopeToProject) : undefined}
             census={isWatchMode ? census : undefined}
+            searchQuery={search?.surface === "tree" ? search.query : undefined}
+            searchHitId={
+              search?.surface === "tree" && treeHits.length > 0
+                ? treeHits[
+                    ((search.index % treeHits.length) + treeHits.length) %
+                      treeHits.length
+                  ]
+                : undefined
+            }
           />
 
           <Box marginTop={1}>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -75,6 +75,7 @@ import { useTick } from "./hooks/useTick.js";
 import { SessionTreePanel } from "./SessionTreePanel.js";
 import { activityMatches } from "./search/activityMatch.js";
 import { detailMatchLines } from "./search/detailMatches.js";
+import { edgeScrollWindowStart } from "./search/edgeScroll.js";
 import { SearchInput } from "./search/SearchInput.js";
 import type { SearchState } from "./search/searchKey.js";
 import { applyDetailSearchKey } from "./search/searchKey.js";
@@ -682,6 +683,11 @@ export function App({
 
   // In-pane search state. null = search closed.
   const [search, setSearch] = useState<SearchState | null>(null);
+
+  // Persisted window-start for viewer narrow-finder edge-scroll. Reset to 0
+  // when search opens or query resets (index → 0 on query change). Updated
+  // via edgeScrollWindowStart on every ↑/↓ in viewer search mode.
+  const [viewerSearchWindowStart, setViewerSearchWindowStart] = useState(0);
 
   // Tree as the renderer sees it. Defaults to the hidden-stripped
   // view; flips to the full source tree when `showHidden` is on.
@@ -1501,6 +1507,7 @@ export function App({
     onOpenSearch: () => {
       const surface: SearchSurface = detailMode ? "detail" : focus;
       setSearch({ surface, query: "", index: 0, committed: false });
+      if (!detailMode && focus === "viewer") setViewerSearchWindowStart(0);
     },
     onSearchKey: (input, key) => {
       // Viewer surface: narrow-finder. ↑/↓ move selection; Enter jumps cursor + closes; Esc cancels.
@@ -1515,15 +1522,21 @@ export function App({
         if (key.upArrow) {
           if (hits.length === 0) return;
           const n = hits.length;
-          setSearch((s) =>
-            s ? { ...s, index: (((s.index - 1) % n) + n) % n } : s,
+          const newIndex = (((search.index - 1) % n) + n) % n;
+          setSearch((s) => (s ? { ...s, index: newIndex } : s));
+          setViewerSearchWindowStart((prev) =>
+            edgeScrollWindowStart(prev, newIndex, viewerRows, hits.length),
           );
           return;
         }
         if (key.downArrow) {
           if (hits.length === 0) return;
           const n = hits.length;
-          setSearch((s) => (s ? { ...s, index: (s.index + 1) % n } : s));
+          const newIndex = (search.index + 1) % n;
+          setSearch((s) => (s ? { ...s, index: newIndex } : s));
+          setViewerSearchWindowStart((prev) =>
+            edgeScrollWindowStart(prev, newIndex, viewerRows, hits.length),
+          );
           return;
         }
         if (key.return) {
@@ -1549,12 +1562,14 @@ export function App({
           setSearch((s) =>
             s ? { ...s, query: s.query.slice(0, -1), index: 0 } : s,
           );
+          setViewerSearchWindowStart(0);
           return;
         }
         if (input && !key.ctrl && input.length === 1) {
           setSearch((s) =>
             s ? { ...s, query: s.query + input, index: 0 } : s,
           );
+          setViewerSearchWindowStart(0);
           return;
         }
         return;
@@ -1858,6 +1873,11 @@ export function App({
                 }
                 searchSelected={
                   search?.surface === "viewer" ? search.index : undefined
+                }
+                searchWindowStart={
+                  search?.surface === "viewer"
+                    ? viewerSearchWindowStart
+                    : undefined
                 }
               />
             )}

--- a/src/ui/DetailViewPanel.tsx
+++ b/src/ui/DetailViewPanel.tsx
@@ -41,6 +41,7 @@ import {
   getLineStyle,
   type LineCategory,
 } from "./lineColoring.js";
+import { matchRanges } from "./search/matcher.js";
 
 export function wrapText(text: string, maxWidth: number): string[] {
   if (!text) return ["(empty)"];
@@ -150,6 +151,63 @@ export interface DetailViewPanelProps {
   width: number;
   visibleRows: number;
   scrollOffset: number;
+  /** Non-empty string activates in-line match highlighting. */
+  searchQuery?: string;
+  /** Index into the raw source lines that is the active (current) match.
+   * The panel scrolls to keep this line in the visible window. */
+  activeMatchLine?: number | null;
+}
+
+/** Render a line with matched substrings highlighted via inverse video.
+ * The active match line uses a yellow background; other matched lines use
+ * inverse. Falls through to a plain `<Text>` when no ranges match. */
+function renderHighlightedLine(
+  text: string,
+  query: string,
+  isActiveLine: boolean,
+  lineColor: string | undefined,
+  lineDimColor: boolean | undefined,
+): React.ReactElement {
+  const ranges = matchRanges(text, query);
+  if (ranges.length === 0) {
+    return (
+      <Text color={lineColor} dimColor={lineDimColor}>
+        {text}
+      </Text>
+    );
+  }
+  const parts: React.ReactElement[] = [];
+  let cursor = 0;
+  for (let r = 0; r < ranges.length; r++) {
+    const { start, end } = ranges[r];
+    if (cursor < start) {
+      parts.push(
+        <Text key={`pre-${r}`} color={lineColor} dimColor={lineDimColor}>
+          {text.slice(cursor, start)}
+        </Text>,
+      );
+    }
+    parts.push(
+      isActiveLine ? (
+        <Text key={`match-${r}`} backgroundColor="yellow" color="black">
+          {text.slice(start, end)}
+        </Text>
+      ) : (
+        <Text key={`match-${r}`} inverse>
+          {text.slice(start, end)}
+        </Text>
+      ),
+    );
+    cursor = end;
+  }
+  if (cursor < text.length) {
+    parts.push(
+      <Text key="tail" color={lineColor} dimColor={lineDimColor}>
+        {text.slice(cursor)}
+      </Text>,
+    );
+  }
+  return <>{parts}</>;
 }
 
 export function DetailViewPanel({
@@ -157,6 +215,8 @@ export function DetailViewPanel({
   width,
   visibleRows,
   scrollOffset,
+  searchQuery = "",
+  activeMatchLine = null,
 }: DetailViewPanelProps): React.ReactElement {
   const innerWidth = getInnerWidth(width);
   const contentWidth = innerWidth - 1;
@@ -174,17 +234,76 @@ export function DetailViewPanel({
     activity.detailKind === "diff" ||
     activity.detailKind === "code" ||
     activity.type === "commit";
-  const allLines = wrapClassified(
-    body,
-    contentWidth,
-    classifier,
-    preserveWhitespace,
-  );
+
+  // Build wrapped lines annotated with the source line index so we can
+  // scroll the active match into view without a second scroll system.
+  const sourceLines = (body ?? "").split("\n");
+  const categories = classifier(sourceLines);
+  const allLines: Array<{
+    text: string;
+    category: LineCategory;
+    sourceLineIdx: number;
+  }> = [];
+  if (!body) {
+    allLines.push({ text: "(empty)", category: "prose", sourceLineIdx: 0 });
+  } else {
+    for (let si = 0; si < sourceLines.length; si++) {
+      const line = sourceLines[si];
+      const cat = categories[si] ?? "prose";
+      if (!line) {
+        allLines.push({ text: "", category: cat, sourceLineIdx: si });
+        continue;
+      }
+      if (preserveWhitespace) {
+        for (const chunk of hardWrapByWidth(line, contentWidth)) {
+          allLines.push({ text: chunk, category: cat, sourceLineIdx: si });
+        }
+      } else {
+        const words = line.split(" ");
+        let current = "";
+        for (const word of words) {
+          if (!current) {
+            current = word;
+          } else if (getDisplayWidth(`${current} ${word}`) <= contentWidth) {
+            current += ` ${word}`;
+          } else {
+            allLines.push({ text: current, category: cat, sourceLineIdx: si });
+            current = word;
+          }
+        }
+        if (current)
+          allLines.push({ text: current, category: cat, sourceLineIdx: si });
+      }
+    }
+    if (allLines.length === 0)
+      allLines.push({ text: "(empty)", category: "prose", sourceLineIdx: 0 });
+  }
+
   const totalLines = allLines.length;
-  const clampedOffset = Math.min(
+
+  // If there is an active match, find the first rendered line for that source
+  // line and snap the scroll offset so it appears in the visible window.
+  let effectiveOffset = Math.min(
     scrollOffset,
     Math.max(0, totalLines - visibleRows),
   );
+  if (activeMatchLine !== null && activeMatchLine !== undefined) {
+    const renderedIdx = allLines.findIndex(
+      (l) => l.sourceLineIdx === activeMatchLine,
+    );
+    if (renderedIdx !== -1) {
+      // Scroll up if active match is above the window.
+      if (renderedIdx < effectiveOffset) effectiveOffset = renderedIdx;
+      // Scroll down if active match is below the window.
+      if (renderedIdx >= effectiveOffset + visibleRows)
+        effectiveOffset = Math.min(
+          renderedIdx,
+          Math.max(0, totalLines - visibleRows),
+        );
+    }
+  }
+
+  const clampedOffset = effectiveOffset;
   const visibleSlice = allLines.slice(
     clampedOffset,
     clampedOffset + visibleRows,
@@ -209,22 +328,49 @@ export function DetailViewPanel({
 
   const contentRows: React.ReactElement[] = [];
   for (let i = 0; i < visibleRows; i++) {
-    const entry = visibleSlice[i] ?? { text: "", category: "prose" as const };
+    const entry = visibleSlice[i] ?? {
+      text: "",
+      category: "prose" as const,
+      sourceLineIdx: -1,
+    };
     const padding = Math.max(0, contentWidth - getDisplayWidth(entry.text));
     const lineStyle = getLineStyle(entry.category);
     const gutterSplit = activity.detailNumbered
       ? splitLineNumberGutter(entry.text)
       : null;
+    const isActiveLine =
+      searchQuery !== "" &&
+      activeMatchLine !== null &&
+      activeMatchLine !== undefined &&
+      entry.sourceLineIdx === activeMatchLine;
     contentRows.push(
       <Text key={i}>
         {BOX.v}{" "}
         {gutterSplit ? (
           <>
             <Text dimColor>{gutterSplit[0]}</Text>
-            <Text color={lineStyle.color} dimColor={lineStyle.dimColor}>
-              {gutterSplit[1]}
-            </Text>
+            {searchQuery ? (
+              renderHighlightedLine(
+                gutterSplit[1],
+                searchQuery,
+                isActiveLine,
+                lineStyle.color,
+                lineStyle.dimColor,
+              )
+            ) : (
+              <Text color={lineStyle.color} dimColor={lineStyle.dimColor}>
+                {gutterSplit[1]}
+              </Text>
+            )}
           </>
+        ) : searchQuery ? (
+          renderHighlightedLine(
+            entry.text,
+            searchQuery,
+            isActiveLine,
+            lineStyle.color,
+            lineStyle.dimColor,
+          )
         ) : (
           <Text color={lineStyle.color} dimColor={lineStyle.dimColor}>
             {entry.text}

--- a/src/ui/DetailViewPanel.tsx
+++ b/src/ui/DetailViewPanel.tsx
@@ -12,10 +12,10 @@
  *   highlighters. Goal is structural cues (added vs removed,
  *   prose vs code), not real syntax highlighting — keeps the
  *   dependency surface tiny and the renderer fast.
- * - Scroll-only overlay: `↑/↓/j/k` to scroll, `Esc/q/↵` to close.
- *   No find/search/copy — Ink's text rendering would have to
- *   reimplement them and they're easily available outside the
- *   TUI.
+ * - Navigation: `↑/↓/j/k` + `Ctrl+U/D` scroll, `Esc/q/↵` close,
+ *   and `/` opens a less-style in-body search (jump to first
+ *   match, `n`/`N` next/prev, matched spans highlighted via
+ *   `matchRanges`). Copy is still left to outside the TUI.
  *
  * Gotcha:
  * - Indentation and whitespace inside code and diff bodies must

--- a/src/ui/HelpPanel.tsx
+++ b/src/ui/HelpPanel.tsx
@@ -76,6 +76,9 @@ const SECTIONS: HelpSection[] = [
     rows: [
       ["↑ ↓ / k j", "Scroll"],
       ["↵ / Esc / q", "Close"],
+      ["/", "Open search (jump to first match; body unchanged)"],
+      ["n / N", "Next / previous match (while search is open)"],
+      ["Esc", "Close search (stay in detail view)"],
     ],
   },
   {

--- a/src/ui/HelpPanel.tsx
+++ b/src/ui/HelpPanel.tsx
@@ -75,10 +75,10 @@ const SECTIONS: HelpSection[] = [
     title: "Detail view",
     rows: [
       ["↑ ↓ / k j", "Scroll"],
-      ["↵ / Esc / q", "Close"],
+      ["↵ / q", "Close"],
+      ["Esc", "Close (or close search if open, staying in detail view)"],
       ["/", "Open search (jump to first match; body unchanged)"],
-      ["n / N", "Next / previous match (while search is open)"],
-      ["Esc", "Close search (stay in detail view)"],
+      ["n / N", "Next / prev match (after ↵ to commit the query)"],
     ],
   },
   {

--- a/src/ui/HelpPanel.tsx
+++ b/src/ui/HelpPanel.tsx
@@ -56,6 +56,10 @@ const SECTIONS: HelpSection[] = [
       ],
       ["Tab", "Switch focus to activity viewer"],
       ["r", "Refresh now"],
+      [
+        "/",
+        "Narrow-finder: type to filter; ↑↓ select hit; ↵ select session (viewer follows); Esc cancel",
+      ],
     ],
   },
   {

--- a/src/ui/HelpPanel.tsx
+++ b/src/ui/HelpPanel.tsx
@@ -69,6 +69,10 @@ const SECTIONS: HelpSection[] = [
       ["↵", "Open detail view for selected activity"],
       ["f", "Cycle filter preset (set in config.yaml)"],
       ["Tab", "Switch focus to project tree"],
+      [
+        "/",
+        "Narrow-finder: type to filter; ↑↓ select; ↵ jump to activity; Esc cancel",
+      ],
     ],
   },
   {

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -43,6 +43,7 @@ import {
   getInnerWidth,
   truncateByWidth,
 } from "./constants.js";
+import { matchRanges } from "./search/matcher.js";
 
 export interface SessionTreePanelProps {
   projects: ProjectNode[];
@@ -75,6 +76,59 @@ export interface SessionTreePanelProps {
    * `(N active)` hidden alert is preserved as long as possible.
    */
   census?: TreeCensus;
+  /** Active search query for the tree narrow-finder; when set, matched
+   * spans are highlighted in session/project rows. */
+  searchQuery?: string;
+  /** Id of the currently-selected search hit (the row ↑/↓ points at);
+   * that row gets an extra emphasis to distinguish it from the tree
+   * selection highlight. */
+  searchHitId?: string;
+}
+
+/**
+ * Render `text` with matched substrings highlighted (yellow, bold).
+ * Falls back to plain `<Text>{text}</Text>` when there are no ranges or
+ * no query. Accepts `dim` so callers can propagate their dim state.
+ */
+function HighlightedText({
+  text,
+  query,
+  dim,
+}: {
+  text: string;
+  query?: string;
+  dim?: boolean;
+}): React.ReactElement {
+  if (!query) return <Text dimColor={dim}>{text}</Text>;
+  const ranges = matchRanges(text, query);
+  if (ranges.length === 0) return <Text dimColor={dim}>{text}</Text>;
+
+  const parts: React.ReactElement[] = [];
+  let cursor = 0;
+  for (let i = 0; i < ranges.length; i++) {
+    const { start, end } = ranges[i];
+    if (start > cursor) {
+      parts.push(
+        <Text key={`pre-${i}`} dimColor={dim}>
+          {text.slice(cursor, start)}
+        </Text>,
+      );
+    }
+    parts.push(
+      <Text key={`match-${i}`} color="yellow" bold>
+        {text.slice(start, end)}
+      </Text>,
+    );
+    cursor = end;
+  }
+  if (cursor < text.length) {
+    parts.push(
+      <Text key="tail" dimColor={dim}>
+        {text.slice(cursor)}
+      </Text>,
+    );
+  }
+  return <>{parts}</>;
 }
 
 /**
@@ -155,6 +209,8 @@ interface SessionRowProps {
   hasFocus: boolean;
   prefix: string;
   contentWidth: number;
+  searchQuery?: string;
+  isSearchHit?: boolean;
 }
 
 function formatProjectPath(projectPath: string): string {
@@ -171,6 +227,8 @@ function SessionRow({
   hasFocus,
   prefix,
   contentWidth,
+  searchQuery,
+  isSearchHit,
 }: SessionRowProps): React.ReactElement {
   const isParent = prefix === "    ";
   const { text: badge, color: badgeColor } = getBadge(session);
@@ -284,7 +342,8 @@ function SessionRow({
 
   const focused = isSelected && hasFocus;
   const muted = isSelected && !hasFocus;
-  const showBg = focused || muted;
+  const showBg = focused || muted || isSearchHit;
+  const bgColor = focused || isSearchHit ? "blue" : muted ? "blue" : undefined;
   // Dim everything that isn't "active" so the bold-bright rows match
   // the active count (hot + warm). cool/cold are recent-but-idle —
   // cool stays expanded and visible (unlike collapsed cold) but
@@ -297,17 +356,26 @@ function SessionRow({
     <Text>
       {BOX.v}{" "}
       <Text
-        backgroundColor={showBg ? "blue" : undefined}
-        bold={focused}
-        dimColor={shouldDim && !focused}
+        backgroundColor={showBg ? bgColor : undefined}
+        bold={focused || isSearchHit}
+        dimColor={shouldDim && !focused && !isSearchHit}
       >
-        <Text dimColor={shouldDim && !focused}>{prefix}</Text>
-        <Text bold={!shouldDim}>{rawName}</Text>
+        <Text dimColor={shouldDim && !focused && !isSearchHit}>{prefix}</Text>
+        <Text bold={!shouldDim || isSearchHit}>{rawName}</Text>
         {shortIdDisplay ? <Text dimColor>{shortIdDisplay}</Text> : null}
         <Text> </Text>
         {session.hidden ? <Text dimColor>{"⊘ "}</Text> : null}
         <Text color={badgeColor}>{badge}</Text>
-        {middleText ? <Text dimColor>{middleSection}</Text> : null}
+        {middleText ? searchQuery ? <Text> </Text> : null : null}
+        {middleText && searchQuery ? (
+          <HighlightedText
+            text={middleText}
+            query={searchQuery}
+            dim={shouldDim && !focused && !isSearchHit}
+          />
+        ) : middleText ? (
+          <Text dimColor>{middleSection}</Text>
+        ) : null}
         <Text>{gap}</Text>
         <Text dimColor>{elapsed}</Text>
         {ctxTag ? <Text color={ctxColor}>{` ${ctxTag}`}</Text> : null}
@@ -919,6 +987,8 @@ export function SessionTreePanel({
   spinner = "",
   scopeLabel,
   census,
+  searchQuery,
+  searchHitId,
 }: SessionTreePanelProps): React.ReactElement {
   const innerWidth = getInnerWidth(width);
   const contentWidth = innerWidth - 1; // account for space after │
@@ -1083,6 +1153,10 @@ export function SessionTreePanel({
         hasFocus={hasFocus}
         prefix={row.prefix}
         contentWidth={contentWidth}
+        searchQuery={searchQuery}
+        isSearchHit={
+          searchHitId !== undefined && row.session.id === searchHitId
+        }
       />
     ) : row.kind === "subagent-summary" ? (
       <SubagentSummaryRow

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -1123,11 +1123,23 @@ export function SessionTreePanel({
     return false;
   });
 
-  // Compute scrollTop so the selected tail row stays visible.
+  // When search is active, anchor the scroll window on the search hit
+  // (searchHitId) so the highlighted row stays on-screen, rather than
+  // the regular selection which may be elsewhere.
+  const searchHitRestIndex =
+    searchHitId !== undefined
+      ? restRows.findIndex(
+          (row) => row.kind === "session" && row.session.id === searchHitId,
+        )
+      : -1;
+  const anchorRestIndex =
+    searchHitRestIndex >= 0 ? searchHitRestIndex : selectedRestIndex;
+
+  // Compute scrollTop so the anchor tail row stays visible.
   const treeVisibleCount = Math.max(1, visibleCount - pinnedRows.length);
   let scrollTop = 0;
-  if (restTotal > treeVisibleCount && selectedRestIndex >= 0) {
-    scrollTop = Math.max(0, selectedRestIndex - treeVisibleCount + 1);
+  if (restTotal > treeVisibleCount && anchorRestIndex >= 0) {
+    scrollTop = Math.max(0, anchorRestIndex - treeVisibleCount + 1);
     scrollTop = Math.min(scrollTop, Math.max(0, restTotal - treeVisibleCount));
   }
 

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -343,7 +343,7 @@ function SessionRow({
   const focused = isSelected && hasFocus;
   const muted = isSelected && !hasFocus;
   const showBg = focused || muted || isSearchHit;
-  const bgColor = focused || isSearchHit ? "blue" : muted ? "blue" : undefined;
+  const bgColor = showBg ? "blue" : undefined;
   // Dim everything that isn't "active" so the bold-bright rows match
   // the active count (hot + warm). cool/cold are recent-but-idle —
   // cool stays expanded and visible (unlike collapsed cold) but

--- a/src/ui/hooks/useHotkeys.ts
+++ b/src/ui/hooks/useHotkeys.ts
@@ -198,6 +198,10 @@ export function useHotkeys({
     }
 
     if (detailMode) {
+      if (input === "/" && !key.ctrl) {
+        onOpenSearch();
+        return;
+      }
       if (key.ctrl && input === "u") {
         onDetailScrollHalfPageUp();
         return;

--- a/src/ui/hooks/useHotkeys.ts
+++ b/src/ui/hooks/useHotkeys.ts
@@ -55,6 +55,28 @@ interface UseHotkeysOptions {
   onToggleShowHidden?: () => void;
   filterLabel: string; // e.g. "all", "response", "commit"
   trackingOn?: boolean;
+  /** True while the in-pane search input is open. */
+  searchActive: boolean;
+  /** Called when the user presses `/` to open search. */
+  onOpenSearch: () => void;
+  /** Called for every keystroke while searchActive is true. */
+  onSearchKey: (
+    input: string,
+    key: {
+      upArrow: boolean;
+      downArrow: boolean;
+      tab: boolean;
+      pageUp: boolean;
+      pageDown: boolean;
+      return: boolean;
+      ctrl: boolean;
+      escape?: boolean;
+      leftArrow?: boolean;
+      rightArrow?: boolean;
+      backspace?: boolean;
+      delete?: boolean;
+    },
+  ) => void;
 }
 
 export interface UseHotkeysResult {
@@ -71,6 +93,8 @@ export interface UseHotkeysResult {
       escape?: boolean;
       leftArrow?: boolean;
       rightArrow?: boolean;
+      backspace?: boolean;
+      delete?: boolean;
     },
   ) => void;
   statusBarItems: string[];
@@ -107,6 +131,9 @@ export function useHotkeys({
   onToggleShowHidden,
   filterLabel,
   trackingOn = false,
+  searchActive,
+  onOpenSearch,
+  onSearchKey,
 }: UseHotkeysOptions): UseHotkeysResult {
   const handleInput = (
     input: string,
@@ -121,8 +148,16 @@ export function useHotkeys({
       escape?: boolean;
       leftArrow?: boolean;
       rightArrow?: boolean;
+      backspace?: boolean;
+      delete?: boolean;
     },
   ) => {
+    // Search mode swallows every key and routes it to the search handler.
+    if (searchActive) {
+      onSearchKey(input, key);
+      return;
+    }
+
     if (helpMode) {
       if (key.return || key.escape || input === "q" || input === "?") {
         onHelp(); // toggle = close
@@ -188,6 +223,10 @@ export function useHotkeys({
 
     if (input === "q") {
       onQuit();
+      return;
+    }
+    if (input === "/" && !key.ctrl) {
+      onOpenSearch();
       return;
     }
     if (key.tab) {

--- a/src/ui/search/SearchInput.tsx
+++ b/src/ui/search/SearchInput.tsx
@@ -1,0 +1,19 @@
+import { Text } from "ink";
+import type React from "react";
+
+/** One-line search prompt shown in the status area: `/query   3/12`.
+ * `total` 0 renders `0/0`; `current` is 1-based for display. */
+export function SearchInput(props: {
+  query: string;
+  current: number; // 1-based; 0 when no matches
+  total: number;
+}): React.ReactElement {
+  const count = props.total === 0 ? "0/0" : `${props.current}/${props.total}`;
+  return (
+    <Text>
+      <Text color="cyan">/</Text>
+      {props.query}
+      <Text dimColor>{`   ${count}`}</Text>
+    </Text>
+  );
+}

--- a/src/ui/search/activityMatch.ts
+++ b/src/ui/search/activityMatch.ts
@@ -1,0 +1,18 @@
+import type { ActivityEntry } from "../../types/index.js";
+import { hasMatch } from "./matcher.js";
+
+/** Indices of activities whose label or one-line detail match `query`
+ * (smart-case). The multi-line detailBody is intentionally NOT searched
+ * here — that is the Detail View's job. Empty for an empty query. */
+export function activityMatches(
+  activities: ActivityEntry[],
+  query: string,
+): number[] {
+  if (!query) return [];
+  const out: number[] = [];
+  for (let i = 0; i < activities.length; i++) {
+    const a = activities[i];
+    if (hasMatch(a.label, query) || hasMatch(a.detail, query)) out.push(i);
+  }
+  return out;
+}

--- a/src/ui/search/detailMatches.ts
+++ b/src/ui/search/detailMatches.ts
@@ -1,0 +1,12 @@
+import { hasMatch } from "./matcher.js";
+
+/** Indices of body lines that contain a match for `query`, in order.
+ * Drives the Detail View's `n`/`N` jump. Empty for an empty query. */
+export function detailMatchLines(lines: string[], query: string): number[] {
+  if (!query) return [];
+  const out: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (hasMatch(lines[i], query)) out.push(i);
+  }
+  return out;
+}

--- a/src/ui/search/edgeScroll.ts
+++ b/src/ui/search/edgeScroll.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helper for fzf-style edge-scrolling of a search hit window.
+ *
+ * Design decisions:
+ * - Stateless pure function: all callers must persist `prevStart` themselves
+ *   (via React state or ref) so the window moves smoothly rather than
+ *   re-anchoring on every keystroke.
+ * - Edge-only scroll: the window only moves when `selected` crosses the
+ *   top or bottom boundary; it is otherwise stable regardless of which hit
+ *   inside the window is active.
+ */
+
+/**
+ * Compute the next window-start position using edge-scroll semantics.
+ *
+ * - Selection moves freely within `[prevStart, prevStart + visibleRows)`.
+ * - If `selected < prevStart` → scroll up so the selected hit is the first
+ *   visible row (newStart = selected).
+ * - If `selected >= prevStart + visibleRows` → scroll down so the selected
+ *   hit is the last visible row (newStart = selected - visibleRows + 1).
+ * - Otherwise keep prevStart unchanged.
+ * - Result is always clamped to `[0, max(0, total - visibleRows)]`.
+ * - When `total <= visibleRows` the result is always 0.
+ */
+export function edgeScrollWindowStart(
+  prevStart: number,
+  selected: number,
+  visibleRows: number,
+  total: number,
+): number {
+  if (total <= 0 || visibleRows <= 0) return 0;
+  if (total <= visibleRows) return 0;
+
+  const maxStart = total - visibleRows;
+  // Clamp prevStart defensively (caller may pass an out-of-range value).
+  const clampedPrev = Math.max(0, Math.min(prevStart, maxStart));
+
+  let newStart: number;
+  if (selected < clampedPrev) {
+    // Selected crossed the top edge → bring it into view as the first row.
+    newStart = selected;
+  } else if (selected >= clampedPrev + visibleRows) {
+    // Selected crossed the bottom edge → bring it into view as the last row.
+    newStart = selected - visibleRows + 1;
+  } else {
+    // Selection is within the current window → keep it stable.
+    newStart = clampedPrev;
+  }
+
+  return Math.max(0, Math.min(newStart, maxStart));
+}

--- a/src/ui/search/matcher.ts
+++ b/src/ui/search/matcher.ts
@@ -1,0 +1,40 @@
+/**
+ * Substring matching with smart-case for the in-pane search. Returns
+ * highlight ranges so callers can render matches; never fuzzy, never
+ * regex — the query is matched literally.
+ */
+
+export interface MatchRange {
+  start: number; // inclusive
+  end: number; // exclusive (half-open)
+}
+
+/** Smart-case: case-sensitive iff the query contains an uppercase letter. */
+export function isCaseSensitive(query: string): boolean {
+  return /[A-Z]/.test(query);
+}
+
+/** All non-overlapping match ranges of `query` in `text`, left to right.
+ * Empty when the query is empty or there is no match. */
+export function matchRanges(text: string, query: string): MatchRange[] {
+  if (!query) return [];
+  const cs = isCaseSensitive(query);
+  const hay = cs ? text : text.toLowerCase();
+  const needle = cs ? query : query.toLowerCase();
+  const out: MatchRange[] = [];
+  let i = hay.indexOf(needle);
+  while (i !== -1) {
+    out.push({ start: i, end: i + needle.length });
+    i = hay.indexOf(needle, i + needle.length); // non-overlapping
+  }
+  return out;
+}
+
+/** Whether `query` occurs in `text` (smart-case). False for an empty query. */
+export function hasMatch(text: string, query: string): boolean {
+  if (!query) return false;
+  const cs = isCaseSensitive(query);
+  return (cs ? text : text.toLowerCase()).includes(
+    cs ? query : query.toLowerCase(),
+  );
+}

--- a/src/ui/search/searchKey.ts
+++ b/src/ui/search/searchKey.ts
@@ -43,8 +43,15 @@ export function applyDetailSearchKey(
   if (key.escape) return null;
 
   // Backspace / delete: remove last character, return to uncommitted.
+  // Reset index to 0 so the display jumps to the first match in the
+  // shorter query — the old index is stale after a character is removed.
   if (key.backspace || key.delete) {
-    return { ...state, query: state.query.slice(0, -1), committed: false };
+    return {
+      ...state,
+      query: state.query.slice(0, -1),
+      committed: false,
+      index: 0,
+    };
   }
 
   // Enter: commit if not yet committed; no-op if already committed.

--- a/src/ui/search/searchKey.ts
+++ b/src/ui/search/searchKey.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure reducer for detail-surface search key transitions (less-style two-phase model).
+ *
+ * Design decisions:
+ * - While uncommitted (typing), every printable character (including n/N) appends
+ *   to the query and jumps to index 0 (first match). This unblocks queries containing
+ *   common identifiers like "function", "const", "return", "import".
+ * - Enter commits: subsequent n/N navigate forward/backward through matches.
+ * - Any printable char or backspace after commit re-enters the typing phase
+ *   (uncommitted=true, index=0), so editing mid-navigation is natural.
+ * - Esc returns null — the signal to close search entirely.
+ * - Ctrl combos are ignored so terminal shortcuts pass through untouched.
+ */
+
+export type SearchSurface = "tree" | "viewer" | "detail";
+
+export interface SearchState {
+  surface: SearchSurface;
+  query: string;
+  index: number; // current match index (detail: line-match #; lists: selected match row)
+  committed: boolean; // true after Enter; false while typing
+}
+
+export interface SearchKey {
+  return?: boolean;
+  backspace?: boolean;
+  delete?: boolean;
+  ctrl?: boolean;
+  escape?: boolean;
+}
+
+/**
+ * Compute the next SearchState for a single keystroke in detail search.
+ * Returns `null` to signal "exit search" (Esc).
+ * Returns the current state unchanged when the key is irrelevant (e.g. ctrl-chord).
+ */
+export function applyDetailSearchKey(
+  state: SearchState,
+  input: string,
+  key: SearchKey,
+): SearchState | null {
+  // Esc always exits search.
+  if (key.escape) return null;
+
+  // Backspace / delete: remove last character, return to uncommitted.
+  if (key.backspace || key.delete) {
+    return { ...state, query: state.query.slice(0, -1), committed: false };
+  }
+
+  // Enter: commit if not yet committed; no-op if already committed.
+  if (key.return) {
+    if (state.committed) return state;
+    return { ...state, committed: true };
+  }
+
+  // Ignore ctrl combos and non-printable / empty input.
+  if (!input || key.ctrl || input.length !== 1) return state;
+
+  // Committed phase: n/N navigate; any other printable char re-enters typing.
+  if (state.committed) {
+    if (input === "n") return { ...state, index: state.index + 1 };
+    if (input === "N") return { ...state, index: state.index - 1 };
+    // Any other char appends and un-commits.
+    return { ...state, query: state.query + input, committed: false, index: 0 };
+  }
+
+  // Uncommitted phase: all printable chars (incl. n/N) append to query.
+  return { ...state, query: state.query + input, index: 0 };
+}

--- a/src/ui/search/treeSearch.ts
+++ b/src/ui/search/treeSearch.ts
@@ -1,0 +1,71 @@
+/**
+ * Hierarchical narrow-finder helpers for the Session Tree search surface.
+ *
+ * Design decisions:
+ * - A project-name match keeps ALL of its sessions (not just matching ones),
+ *   mirroring how a user thinks of "search within project beta".
+ * - Sub-agent matches bubble up to keep the ancestor chain visible so the
+ *   user can see which project/session the match belongs to.
+ * - `treeSearchHits` returns only session/sub-agent ids (not project sentinels)
+ *   because ↑/↓ should land on selectable rows that open activity in the viewer.
+ */
+
+import type {
+  ProjectNode,
+  SessionNode,
+  SessionTree,
+} from "../../types/index.js";
+import { hasMatch } from "./matcher.js";
+
+function sessionText(s: SessionNode): string {
+  return `${s.firstUserPrompt ?? ""} ${s.id} ${s.agentId ?? ""}`;
+}
+
+function filterSession(s: SessionNode, q: string): SessionNode | null {
+  const subs = s.subAgents
+    .map((sa) => filterSession(sa, q))
+    .filter(Boolean) as SessionNode[];
+  if (hasMatch(sessionText(s), q) || subs.length > 0)
+    return { ...s, subAgents: subs };
+  return null;
+}
+
+function filterProject(p: ProjectNode, q: string): ProjectNode | null {
+  if (hasMatch(p.name, q)) return p; // project-name hit keeps all sessions
+  const sessions = p.sessions
+    .map((s) => filterSession(s, q))
+    .filter(Boolean) as SessionNode[];
+  return sessions.length > 0 ? { ...p, sessions } : null;
+}
+
+/** Hierarchically narrow the tree to nodes that match `query` (smart-case),
+ * keeping ancestors of any match. Empty query returns the tree unchanged. */
+export function filterTreeBySearch(
+  tree: SessionTree,
+  query: string,
+): SessionTree {
+  if (!query) return tree;
+  const narrow = (projects: ProjectNode[]) =>
+    projects
+      .map((p) => filterProject(p, query))
+      .filter(Boolean) as ProjectNode[];
+  return {
+    ...tree,
+    projects: narrow(tree.projects),
+    coldProjects: narrow(tree.coldProjects),
+  };
+}
+
+/** Ids of matching session/sub-agent nodes in display order (for ↑/↓ selection). */
+export function treeSearchHits(tree: SessionTree, query: string): string[] {
+  if (!query) return [];
+  const out: string[] = [];
+  const walk = (s: SessionNode) => {
+    if (hasMatch(sessionText(s), query)) out.push(s.id);
+    s.subAgents.forEach(walk);
+  };
+  for (const grp of [tree.projects, tree.coldProjects]) {
+    for (const p of grp) p.sessions.forEach(walk);
+  }
+  return out;
+}

--- a/src/ui/viewerCursor.ts
+++ b/src/ui/viewerCursor.ts
@@ -25,6 +25,10 @@
  *   a `useEffect` and applies the result to setViewerCursorLine /
  *   setIsLive / setScrollOffset / setNewCount. Tests run as plain
  *   unit tests with no React surface.
+ * - `scrollOffsetForCursor` computes the scrollOffset needed to
+ *   place a search hit at cursorLine 0 (bottom of viewport) in
+ *   PAUSED mode. Used by the viewer search Enter handler so the
+ *   selected match is always visible, not just highlighted off-screen.
  */
 
 export interface AdjustViewerCursorArgs {
@@ -100,4 +104,22 @@ export function adjustViewerCursorOnNewActivities(
     autoPause: true,
     scrollDelta: delta - upwardRoom,
   };
+}
+
+/**
+ * Compute the scrollOffset that places the activity at `hitIndex`
+ * (0 = oldest, total-1 = newest) at cursorLine 0 (the bottom of the
+ * viewport). Caller must also set viewerCursorLine = 0.
+ *
+ * Derivation: PAUSED slice → absolute cursor index = total - scrollOffset - 1 - cursorLine.
+ * At cursorLine = 0: scrollOffset = total - 1 - hitIndex.
+ * Clamped to [0, max(0, total - viewerRows)] so we never scroll past the oldest.
+ */
+export function scrollOffsetForCursor(
+  total: number,
+  hitIndex: number,
+  viewerRows: number,
+): number {
+  const raw = total - 1 - hitIndex;
+  return Math.max(0, Math.min(raw, Math.max(0, total - viewerRows)));
 }

--- a/tests/ui/HelpPanel.test.tsx
+++ b/tests/ui/HelpPanel.test.tsx
@@ -33,7 +33,7 @@ describe("HelpPanel", () => {
   });
 
   it("documents config file locations", () => {
-    const { lastFrame } = render(<HelpPanel width={80} height={50} />);
+    const { lastFrame } = render(<HelpPanel width={80} height={60} />);
     const out = lastFrame() ?? "";
     expect(out).toContain("~/.agenthud/config.yaml");
     expect(out).toContain("~/.agenthud/state.yaml");

--- a/tests/ui/hooks/useHotkeys.test.ts
+++ b/tests/ui/hooks/useHotkeys.test.ts
@@ -68,6 +68,7 @@ function makeOptions(overrides = {}) {
     focus: "tree" as const,
     detailMode: false,
     helpMode: false,
+    searchActive: false,
     onSwitchFocus: vi.fn(),
     onScrollUp: vi.fn(),
     onScrollDown: vi.fn(),
@@ -88,6 +89,8 @@ function makeOptions(overrides = {}) {
     onDetailScrollHalfPageDown: vi.fn(),
     onFilter: vi.fn(),
     onHelp: vi.fn(),
+    onOpenSearch: vi.fn(),
+    onSearchKey: vi.fn(),
     filterLabel: "all",
     ...overrides,
   };
@@ -665,6 +668,28 @@ describe("useHotkeys", () => {
       );
       act(() => result.current.handleInput("d", { ...noopKey, ctrl: true }));
       expect(onDetailScrollHalfPageDown).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("search mode", () => {
+    it("routes all keys to onSearchKey while searchActive, before other modes", () => {
+      const onSearchKey = vi.fn();
+      const onQuit = vi.fn();
+      const { result } = renderHook(() =>
+        useHotkeys(makeOptions({ searchActive: true, onSearchKey, onQuit })),
+      );
+      act(() => result.current.handleInput("q", noopKey));
+      expect(onSearchKey).toHaveBeenCalledWith("q", expect.any(Object));
+      expect(onQuit).not.toHaveBeenCalled(); // search swallows it
+    });
+
+    it("'/' opens search for the focused surface when not active", () => {
+      const onOpenSearch = vi.fn();
+      const { result } = renderHook(() =>
+        useHotkeys(makeOptions({ searchActive: false, onOpenSearch })),
+      );
+      act(() => result.current.handleInput("/", noopKey));
+      expect(onOpenSearch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/ui/hooks/useHotkeys.test.ts
+++ b/tests/ui/hooks/useHotkeys.test.ts
@@ -691,5 +691,26 @@ describe("useHotkeys", () => {
       act(() => result.current.handleInput("/", noopKey));
       expect(onOpenSearch).toHaveBeenCalledTimes(1);
     });
+
+    it("'/' opens search while detailMode is active", () => {
+      // The detailMode block returns early before reaching the main-section
+      // '/' handler, so this test verifies the fix that adds '/' interception
+      // inside the detailMode block itself.
+      const onOpenSearch = vi.fn();
+      const onDetailClose = vi.fn();
+      const { result } = renderHook(() =>
+        useHotkeys(
+          makeOptions({
+            detailMode: true,
+            searchActive: false,
+            onOpenSearch,
+            onDetailClose,
+          }),
+        ),
+      );
+      act(() => result.current.handleInput("/", noopKey));
+      expect(onOpenSearch).toHaveBeenCalledTimes(1);
+      expect(onDetailClose).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/ui/search/activityMatch.test.ts
+++ b/tests/ui/search/activityMatch.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { ActivityEntry } from "../../../src/types/index.js";
+import { activityMatches } from "../../../src/ui/search/activityMatch.js";
+
+const a = (label: string, detail: string): ActivityEntry => ({
+  timestamp: new Date(0),
+  type: "tool",
+  icon: "$",
+  label,
+  detail,
+});
+
+describe("activityMatches", () => {
+  const acts = [
+    a("Bash", "npm test"),
+    a("Read", "auth.ts"),
+    a("Edit", "main.ts"),
+  ];
+  it("matches label or one-line detail (smart-case)", () => {
+    expect(activityMatches(acts, "auth")).toEqual([1]); // detail
+    expect(activityMatches(acts, "edit")).toEqual([2]); // label
+  });
+  it("empty query → no matches", () => {
+    expect(activityMatches(acts, "")).toEqual([]);
+  });
+});

--- a/tests/ui/search/detailMatches.test.ts
+++ b/tests/ui/search/detailMatches.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { detailMatchLines } from "../../../src/ui/search/detailMatches.js";
+
+describe("detailMatchLines", () => {
+  const lines = ["import foo", "const x = 1", "foo(x)", "done"];
+  it("returns indices of lines containing the query (smart-case)", () => {
+    expect(detailMatchLines(lines, "foo")).toEqual([0, 2]);
+  });
+  it("empty query → no matches", () => {
+    expect(detailMatchLines(lines, "")).toEqual([]);
+  });
+  it("uppercase query is case-sensitive", () => {
+    expect(detailMatchLines(["Foo", "foo"], "Foo")).toEqual([0]);
+  });
+});

--- a/tests/ui/search/edgeScroll.test.ts
+++ b/tests/ui/search/edgeScroll.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { edgeScrollWindowStart } from "../../../src/ui/search/edgeScroll.js";
+
+describe("edgeScrollWindowStart", () => {
+  // total=10, visibleRows=5 → max valid start = 5
+  const total = 10;
+  const visibleRows = 5;
+
+  it("keeps start stable when selection moves within the window", () => {
+    // prevStart=2, window shows [2..6], selected=3 (inside) → stay at 2
+    expect(edgeScrollWindowStart(2, 3, visibleRows, total)).toBe(2);
+    expect(edgeScrollWindowStart(2, 4, visibleRows, total)).toBe(2);
+    expect(edgeScrollWindowStart(2, 6, visibleRows, total)).toBe(2);
+  });
+
+  it("advances start by 1 when selection moves past the bottom edge", () => {
+    // prevStart=2, window shows [2..6], selected=7 (just past bottom edge index 6) → newStart=3
+    expect(edgeScrollWindowStart(2, 7, visibleRows, total)).toBe(3);
+  });
+
+  it("advances start minimally (not jump to selected) on each step down", () => {
+    // Simulate holding ↓: each press selected advances by 1
+    let start = 0;
+    // selected 0..4 (inside window [0..4]) → stays at 0
+    for (let s = 0; s <= 4; s++) {
+      start = edgeScrollWindowStart(start, s, visibleRows, total);
+      expect(start).toBe(0);
+    }
+    // selected=5 → bottom edge exceeded → newStart=1
+    start = edgeScrollWindowStart(start, 5, visibleRows, total);
+    expect(start).toBe(1);
+    // selected=6 → newStart=2
+    start = edgeScrollWindowStart(start, 6, visibleRows, total);
+    expect(start).toBe(2);
+  });
+
+  it("sets start = selected when selection moves above the top edge", () => {
+    // prevStart=5, window shows [5..9], selected=3 (above top) → newStart=3
+    expect(edgeScrollWindowStart(5, 3, visibleRows, total)).toBe(3);
+  });
+
+  it("clamps start at 0 when selected is 0", () => {
+    expect(edgeScrollWindowStart(0, 0, visibleRows, total)).toBe(0);
+    // Wrap from last to first (modulo navigation)
+    expect(edgeScrollWindowStart(5, 0, visibleRows, total)).toBe(0);
+  });
+
+  it("clamps start at max (total - visibleRows) when selected is at the last item", () => {
+    // total=10, visibleRows=5, max start=5
+    expect(edgeScrollWindowStart(4, 9, visibleRows, total)).toBe(5);
+  });
+
+  it("returns 0 when total <= visibleRows", () => {
+    expect(edgeScrollWindowStart(0, 2, 10, 5)).toBe(0);
+    expect(edgeScrollWindowStart(3, 4, 10, 8)).toBe(0);
+    expect(edgeScrollWindowStart(0, 0, 5, 5)).toBe(0);
+  });
+
+  it("handles a jump (wrap from last to first via modulo) by re-anchoring to 0", () => {
+    // User was at last item (selected=9, start=5), then wraps to selected=0
+    expect(edgeScrollWindowStart(5, 0, visibleRows, total)).toBe(0);
+  });
+
+  it("handles a jump from first to last (wrap down)", () => {
+    // User was at first item (selected=0, start=0), then wraps to selected=9
+    // selected=9 >= start(0) + visibleRows(5)=5 → newStart = 9 - 5 + 1 = 5 (clamped to max 5)
+    expect(edgeScrollWindowStart(0, 9, visibleRows, total)).toBe(5);
+  });
+
+  it("is a no-op when start is already valid and selection is at top edge", () => {
+    // prevStart=3, window [3..7], selected=3 (top edge, inside) → stay at 3
+    expect(edgeScrollWindowStart(3, 3, visibleRows, total)).toBe(3);
+  });
+
+  it("is a no-op when start is already valid and selection is at bottom edge", () => {
+    // prevStart=3, window [3..7], selected=7 (bottom edge, inside) → stay at 3
+    expect(edgeScrollWindowStart(3, 7, visibleRows, total)).toBe(3);
+  });
+
+  it("clamps an out-of-range prevStart before logic runs", () => {
+    // prevStart=8 is out of range (max=5), should be clamped first, then logic applied
+    // clamped prevStart=5, window [5..9], selected=4 (above) → newStart=4
+    expect(edgeScrollWindowStart(8, 4, visibleRows, total)).toBe(4);
+  });
+
+  it("handles single-item list", () => {
+    expect(edgeScrollWindowStart(0, 0, 5, 1)).toBe(0);
+  });
+
+  it("handles empty list (total=0)", () => {
+    expect(edgeScrollWindowStart(0, 0, 5, 0)).toBe(0);
+  });
+});

--- a/tests/ui/search/matcher.test.ts
+++ b/tests/ui/search/matcher.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasMatch,
+  isCaseSensitive,
+  matchRanges,
+} from "../../../src/ui/search/matcher.js";
+
+describe("isCaseSensitive (smart-case)", () => {
+  it("all-lowercase query → case-insensitive (false)", () => {
+    expect(isCaseSensitive("auth")).toBe(false);
+  });
+  it("any uppercase → case-sensitive (true)", () => {
+    expect(isCaseSensitive("Auth")).toBe(true);
+  });
+});
+
+describe("matchRanges", () => {
+  it("empty query → no ranges", () => {
+    expect(matchRanges("anything", "")).toEqual([]);
+  });
+  it("smart-case: lowercase query matches any case", () => {
+    expect(matchRanges("Auth and AUTH", "auth")).toEqual([
+      { start: 0, end: 4 },
+      { start: 9, end: 13 },
+    ]);
+  });
+  it("smart-case: uppercase query is case-sensitive", () => {
+    expect(matchRanges("Auth and auth", "Auth")).toEqual([
+      { start: 0, end: 4 },
+    ]);
+  });
+  it("returns non-overlapping ranges left to right", () => {
+    expect(matchRanges("aaaa", "aa")).toEqual([
+      { start: 0, end: 2 },
+      { start: 2, end: 4 },
+    ]);
+  });
+  it("no match → empty", () => {
+    expect(matchRanges("abc", "xyz")).toEqual([]);
+  });
+});
+
+describe("hasMatch", () => {
+  it("true on substring hit, false on miss/empty", () => {
+    expect(hasMatch("activityParser", "Parser")).toBe(true); // smart-case sensitive
+    expect(hasMatch("activityParser", "parser")).toBe(true); // insensitive
+    expect(hasMatch("activityParser", "zzz")).toBe(false);
+    expect(hasMatch("x", "")).toBe(false);
+  });
+});

--- a/tests/ui/search/searchKey.test.ts
+++ b/tests/ui/search/searchKey.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { SearchState } from "../../../src/ui/search/searchKey.js";
+import { applyDetailSearchKey } from "../../../src/ui/search/searchKey.js";
+
+/** Convenience builder for an uncommitted detail search state. */
+function uncommitted(query: string, index = 0): SearchState {
+  return { surface: "detail", query, index, committed: false };
+}
+
+/** Convenience builder for a committed detail search state. */
+function committed(query: string, index = 0): SearchState {
+  return { surface: "detail", query, index, committed: true };
+}
+
+describe("applyDetailSearchKey — detail surface", () => {
+  // ── Typing phase (uncommitted) ────────────────────────────────────────
+  it("appends printable chars while uncommitted", () => {
+    const s = uncommitted("");
+    const r = applyDetailSearchKey(s, "f", {});
+    expect(r).toMatchObject({ query: "f", committed: false });
+  });
+
+  it("appends 'n' while uncommitted (n is NOT treated as next)", () => {
+    const s = uncommitted("f");
+    const r = applyDetailSearchKey(s, "n", {});
+    expect(r).toMatchObject({ query: "fn", committed: false });
+  });
+
+  it("appends 'N' while uncommitted (N is NOT treated as prev)", () => {
+    const s = uncommitted("fu");
+    const r = applyDetailSearchKey(s, "N", {});
+    expect(r).toMatchObject({ query: "fuN", committed: false });
+  });
+
+  it("typing resets index to 0 (jump to first match)", () => {
+    const s = uncommitted("fn", 3);
+    const r = applyDetailSearchKey(s, "c", {});
+    expect(r).toMatchObject({ query: "fnc", index: 0, committed: false });
+  });
+
+  it("backspace removes last char and stays uncommitted", () => {
+    const s = uncommitted("fn");
+    const r = applyDetailSearchKey(s, "", { backspace: true });
+    expect(r).toMatchObject({ query: "f", committed: false });
+  });
+
+  it("delete key also removes last char", () => {
+    const s = uncommitted("fn");
+    const r = applyDetailSearchKey(s, "", { delete: true });
+    expect(r).toMatchObject({ query: "f", committed: false });
+  });
+
+  it("backspace on empty query keeps empty and stays uncommitted", () => {
+    const s = uncommitted("");
+    const r = applyDetailSearchKey(s, "", { backspace: true });
+    expect(r).toMatchObject({ query: "", committed: false });
+  });
+
+  it("Return commits (sets committed true, keeps query and index)", () => {
+    const s = uncommitted("fn", 2);
+    const r = applyDetailSearchKey(s, "", { return: true });
+    expect(r).toMatchObject({ query: "fn", index: 2, committed: true });
+  });
+
+  // ── Committed phase ───────────────────────────────────────────────────
+  it("after commit 'n' advances index (next match)", () => {
+    const s = committed("fn", 0);
+    const r = applyDetailSearchKey(s, "n", {});
+    expect(r).toMatchObject({ index: 1, committed: true, query: "fn" });
+  });
+
+  it("after commit 'N' decrements index (prev match)", () => {
+    const s = committed("fn", 2);
+    const r = applyDetailSearchKey(s, "N", {});
+    expect(r).toMatchObject({ index: 1, committed: true, query: "fn" });
+  });
+
+  it("after commit a printable char appends and un-commits", () => {
+    const s = committed("fn", 3);
+    const r = applyDetailSearchKey(s, "c", {});
+    expect(r).toMatchObject({ query: "fnc", committed: false, index: 0 });
+  });
+
+  it("after commit backspace edits query and un-commits", () => {
+    const s = committed("fn", 3);
+    const r = applyDetailSearchKey(s, "", { backspace: true });
+    expect(r).toMatchObject({ query: "f", committed: false });
+  });
+
+  it("after commit Return is a no-op (already committed)", () => {
+    const s = committed("fn", 1);
+    const r = applyDetailSearchKey(s, "", { return: true });
+    expect(r).toMatchObject({ query: "fn", index: 1, committed: true });
+  });
+
+  // ── Escape exits search (returns null) ────────────────────────────────
+  it("Esc while uncommitted → null (exit search)", () => {
+    const s = uncommitted("fn");
+    const r = applyDetailSearchKey(s, "", { escape: true });
+    expect(r).toBeNull();
+  });
+
+  it("Esc while committed → null (exit search)", () => {
+    const s = committed("fn", 2);
+    const r = applyDetailSearchKey(s, "", { escape: true });
+    expect(r).toBeNull();
+  });
+
+  // ── Ctrl-key combos are ignored ───────────────────────────────────────
+  it("ctrl-char is ignored (no mutation)", () => {
+    const s = uncommitted("fn");
+    const r = applyDetailSearchKey(s, "c", { ctrl: true });
+    expect(r).toEqual(s);
+  });
+});

--- a/tests/ui/search/searchKey.test.ts
+++ b/tests/ui/search/searchKey.test.ts
@@ -81,10 +81,10 @@ describe("applyDetailSearchKey — detail surface", () => {
     expect(r).toMatchObject({ query: "fnc", committed: false, index: 0 });
   });
 
-  it("after commit backspace edits query and un-commits", () => {
+  it("after commit backspace edits query and un-commits, resetting index to 0", () => {
     const s = committed("fn", 3);
     const r = applyDetailSearchKey(s, "", { backspace: true });
-    expect(r).toMatchObject({ query: "f", committed: false });
+    expect(r).toMatchObject({ query: "f", committed: false, index: 0 });
   });
 
   it("after commit Return is a no-op (already committed)", () => {

--- a/tests/ui/search/treeSearch.test.ts
+++ b/tests/ui/search/treeSearch.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ProjectNode,
+  SessionNode,
+  SessionTree,
+} from "../../../src/types/index.js";
+import {
+  filterTreeBySearch,
+  treeSearchHits,
+} from "../../../src/ui/search/treeSearch.js";
+
+const sess = (
+  id: string,
+  prompt: string,
+  subs: SessionNode[] = [],
+): SessionNode => ({
+  id,
+  hideKey: id,
+  filePath: `/x/${id}.jsonl`,
+  projectPath: "/x",
+  projectName: "x",
+  lastModifiedMs: 0,
+  status: "cold",
+  modelName: null,
+  subAgents: subs,
+  nonInteractive: false,
+  firstUserPrompt: prompt,
+  liveState: null,
+});
+const proj = (name: string, sessions: SessionNode[]): ProjectNode => ({
+  name,
+  projectPath: `/${name}`,
+  sessions,
+  hotness: "cold",
+});
+const tree = (projects: ProjectNode[]): SessionTree => ({
+  projects,
+  coldProjects: [],
+  totalCount: 0,
+  timestamp: new Date().toISOString(),
+  hiddenStats: { total: 0, active: 0 },
+});
+
+describe("filterTreeBySearch", () => {
+  it("keeps a matching session and its parent project; drops the rest", () => {
+    const t = tree([
+      proj("alpha", [sess("s1", "add auth flow"), sess("s2", "fix css")]),
+      proj("beta", [sess("s3", "refactor db")]),
+    ]);
+    const out = filterTreeBySearch(t, "auth");
+    expect(out.projects.map((p) => p.name)).toEqual(["alpha"]);
+    expect(out.projects[0].sessions.map((s) => s.id)).toEqual(["s1"]);
+  });
+  it("matches on project name (keeps the project, all its sessions)", () => {
+    const t = tree([proj("beta", [sess("s3", "refactor db")])]);
+    expect(filterTreeBySearch(t, "beta").projects).toHaveLength(1);
+  });
+  it("matches a sub-agent → keeps its parent session + project", () => {
+    const t = tree([
+      proj("alpha", [sess("s1", "top", [sess("sa1", "run auth tests")])]),
+    ]);
+    const out = filterTreeBySearch(t, "auth");
+    expect(out.projects[0].sessions[0].subAgents.map((s) => s.id)).toEqual([
+      "sa1",
+    ]);
+  });
+  it("empty query → tree unchanged", () => {
+    const t = tree([proj("alpha", [sess("s1", "x")])]);
+    expect(filterTreeBySearch(t, "")).toEqual(t);
+  });
+});
+
+describe("treeSearchHits", () => {
+  it("returns matching node ids in display order", () => {
+    const t = tree([
+      proj("alpha", [sess("s1", "add auth"), sess("s2", "auth bug")]),
+    ]);
+    expect(treeSearchHits(t, "auth")).toEqual(["s1", "s2"]);
+  });
+});

--- a/tests/ui/viewerCursor.test.ts
+++ b/tests/ui/viewerCursor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { adjustViewerCursorOnNewActivities } from "../../src/ui/viewerCursor.js";
+import { adjustViewerCursorOnNewActivities, scrollOffsetForCursor } from "../../src/ui/viewerCursor.js";
 
 describe("adjustViewerCursorOnNewActivities", () => {
   // Contract reminder: viewerCursorLine counts rows from the LIVE EDGE
@@ -169,5 +169,41 @@ describe("adjustViewerCursorOnNewActivities", () => {
         viewerRows: 1,
       }),
     ).toEqual({ cursorLine: 0, autoPause: false, scrollDelta: 0 });
+  });
+});
+
+describe("scrollOffsetForCursor", () => {
+  it("places a mid-history hit: raw = total - 1 - hitIndex, clamped to total - viewerRows", () => {
+    // 100 activities, viewerRows = 20, hitIndex = 10 (deep in history)
+    // raw = 100 - 1 - 10 = 89; max = max(0, 100 - 20) = 80; clamped to 80
+    expect(scrollOffsetForCursor(100, 10, 20)).toBe(80);
+  });
+
+  it("clamps to max(0, total - viewerRows) when hitIndex is very old", () => {
+    // 100 activities, viewerRows = 20, hitIndex = 0 (oldest)
+    // raw = 99, max = 80 → clamped to 80
+    expect(scrollOffsetForCursor(100, 0, 20)).toBe(80);
+  });
+
+  it("returns 0 when hit is in the live-edge window (near newest)", () => {
+    // 100 activities, viewerRows = 20, hitIndex = 99 (newest)
+    // raw = 0 → scrollOffset = 0 (live edge)
+    expect(scrollOffsetForCursor(100, 99, 20)).toBe(0);
+  });
+
+  it("returns 0 when hit is within the live window", () => {
+    // hitIndex = 85 in a 100-item list with viewerRows = 20
+    // raw = 14; max = 80; 14 <= 80 → 14
+    expect(scrollOffsetForCursor(100, 85, 20)).toBe(14);
+  });
+
+  it("handles total < viewerRows (history shorter than viewport)", () => {
+    // 5 activities, viewerRows = 20, hitIndex = 0
+    // raw = 4; max(0, 5-20) = 0 → clamped to 0
+    expect(scrollOffsetForCursor(5, 0, 20)).toBe(0);
+  });
+
+  it("handles hitIndex = total - 1 (the newest entry)", () => {
+    expect(scrollOffsetForCursor(50, 49, 10)).toBe(0);
   });
 });

--- a/tests/ui/viewerCursor.test.ts
+++ b/tests/ui/viewerCursor.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { adjustViewerCursorOnNewActivities, scrollOffsetForCursor } from "../../src/ui/viewerCursor.js";
+import {
+  adjustViewerCursorOnNewActivities,
+  scrollOffsetForCursor,
+} from "../../src/ui/viewerCursor.js";
 
 describe("adjustViewerCursorOnNewActivities", () => {
   // Contract reminder: viewerCursorLine counts rows from the LIVE EDGE

--- a/tests/ui/viewerCursor.test.ts
+++ b/tests/ui/viewerCursor.test.ts
@@ -194,9 +194,9 @@ describe("scrollOffsetForCursor", () => {
     expect(scrollOffsetForCursor(100, 99, 20)).toBe(0);
   });
 
-  it("returns 0 when hit is within the live window", () => {
+  it("returns a non-zero within-window offset when hit is near (but not at) the live edge", () => {
     // hitIndex = 85 in a 100-item list with viewerRows = 20
-    // raw = 14; max = 80; 14 <= 80 → 14
+    // raw = 100 - 1 - 85 = 14; max = max(0, 100 - 20) = 80; 14 <= 80 → 14
     expect(scrollOffsetForCursor(100, 85, 20)).toBe(14);
   });
 


### PR DESCRIPTION
## What

Adds **`/` text search**, scoped to the focused pane and distinct from the `f` type-filter:

- **Session Tree & Activity Viewer** — transient fzf-style **narrow-finders**: type → live narrow to matches, `↑`/`↓` select, `↵` jumps to the selected node/activity and restores the full list, `Esc` cancels.
- **Detail View** — less-style **jump**: type → first match, `↵` commits then `n`/`N` cycle, `Esc` exits (stays in detail).

Substring + **smart-case**, matched spans highlighted, bottom status line `/query  current/total`. The Viewer search composes (AND) with the `f` filter. Scope is the current TUI only — no global/cross-session search, no fuzzy, no regex (all explicit non-goals).

## How

Pure, well-tested core; thin UI integration:
- `src/ui/search/matcher.ts` (substring+smart-case, highlight ranges) — the single match source for all surfaces.
- Per-surface pure helpers: `detailMatches.ts`, `activityMatch.ts`, `treeSearch.ts` (hierarchical narrow), `searchKey.ts` (detail two-phase reducer), `viewerCursor.ts` (`scrollOffsetForCursor`).
- `useHotkeys` gains a search mode (`/` opens for the focused surface; all keys route to the search handler while active). App owns a small ephemeral `search` state; `SearchInput` renders the status line.

## Process

Issue → spec → plan → **5 TDD tasks via subagent-driven development** (fresh implementer + independent task reviewer each) → final whole-branch review (**READY TO MERGE**). Two issues caught and fixed in review:
- **Critical:** detail queries containing `n`/`N` were untypeable → two-phase commit model (`searchKey.ts` reducer).
- **Important:** viewer `Enter` left deep-history matches off-screen → `scrollOffsetForCursor`.

874 tests / `tsc` / `biome` all green. Docs synced (`getHelp()`, `HelpPanel`, `FEATURES.md`, `CHANGELOG.md`). Follow-up (`KeyFlags` extraction) parked on the board.

Spec: `docs/superpowers/specs/2026-06-21-search-design.md` · Plan: `docs/superpowers/plans/2026-06-21-search.md`

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added in-pane text search using `/` across the session tree, activity viewer, and detail view.
  * Search narrows results with substring matching and smart-case behavior, and composes with the existing `f` type filter in the activity viewer.
  * Detail view supports jump-to-match, with `n/N` to move through matches.
  * Matched text is highlighted; navigation restores the full view and keeps the active match visible.

* **Documentation**
  * Updated help/keybinding text to document `/` behavior, cancel/escape handling, and match navigation in each view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->