### PR TITLE
fix(activity): parse Skill tool detail (name + args)

### DIFF
--- a/src/data/toolDetails.ts
+++ b/src/data/toolDetails.ts
@@ -63,6 +63,9 @@ export interface ToolInput {
   status?: string;
   // AskUserQuestion: one or more questions, each with selectable options.
   questions?: AskQuestion[];
+  // Skill: the invoked skill name (may be `plugin:skill`) + optional args.
+  skill?: string;
+  args?: string;
 }
 
 interface PatchHunk {
@@ -199,6 +202,12 @@ export function summarizeToolDetail(
     return `${qs.length} questions: ${labels}`;
   }
 
+  if (name === "Skill") {
+    const skill = input?.skill;
+    if (!skill) return "";
+    return input?.args ? `${skill} — ${input.args}` : skill;
+  }
+
   return getToolDetail(name, input);
 }
 
@@ -267,6 +276,11 @@ export function buildToolDetailBody(
     const text = formatAskBody(input?.questions);
     if (text) return { text, kind: "code" };
     return null;
+  }
+  // Skill: surface the args (the prompt handed to the skill) in the detail
+  // view. No args → null; the one-liner already shows the skill name.
+  if (name === "Skill") {
+    return input?.args ? { text: input.args, kind: "code" } : null;
   }
   // Write intentionally shows the written file content (more useful to read
   // than an all-additions diff); the row summary still uses patch stats.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -177,6 +177,7 @@ export const ICONS = {
   Task: "»",
   TodoWrite: "~",
   AskUserQuestion: "?",
+  Skill: "✦",
   Commit: "◆",
   Default: "$",
 } as const;

--- a/tests/data/toolDetails.test.ts
+++ b/tests/data/toolDetails.test.ts
@@ -229,6 +229,33 @@ describe("summarizeToolDetail", () => {
     ).toBe("");
     expect(summarizeToolDetail("AskUserQuestion", {}, undefined)).toBe("");
   });
+
+  it("Skill: name only when no args", () => {
+    expect(
+      summarizeToolDetail("Skill", { skill: "add-issue" }, undefined),
+    ).toBe("add-issue");
+    expect(
+      summarizeToolDetail(
+        "Skill",
+        { skill: "superpowers:brainstorming" },
+        undefined,
+      ),
+    ).toBe("superpowers:brainstorming");
+  });
+
+  it("Skill: name — args when args present", () => {
+    expect(
+      summarizeToolDetail(
+        "Skill",
+        { skill: "loop", args: "do stuff" },
+        undefined,
+      ),
+    ).toBe("loop — do stuff");
+  });
+
+  it("Skill: no skill yields empty detail", () => {
+    expect(summarizeToolDetail("Skill", {}, undefined)).toBe("");
+  });
 });
 
 describe("buildToolDetailBody", () => {
@@ -530,5 +557,22 @@ describe("buildToolDetailBody", () => {
       buildToolDetailBody("AskUserQuestion", { questions: [] }, undefined),
     ).toBeNull();
     expect(buildToolDetailBody("AskUserQuestion", {}, undefined)).toBeNull();
+  });
+
+  it("Skill: shows the args as a code body", () => {
+    expect(
+      buildToolDetailBody(
+        "Skill",
+        { skill: "loop", args: "line1\nline2" },
+        undefined,
+      ),
+    ).toEqual({ text: "line1\nline2", kind: "code" });
+  });
+
+  it("Skill: no args returns null (the one-liner name is enough)", () => {
+    expect(
+      buildToolDetailBody("Skill", { skill: "add-issue" }, undefined),
+    ).toBeNull();
+    expect(buildToolDetailBody("Skill", {}, undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

Claude Code's **`Skill`** tool (skill invocation) rendered as a bare `Skill` row with **empty detail** and an **empty Detail View** — `src/data/toolDetails.ts` had no branch for it (same class as the AskUserQuestion bug #185), so `summarizeToolDetail` fell through to `getToolDetail` (empty) and `buildToolDetailBody` returned null.

## Real shape (verified from JSONL)

`tool_use` name `Skill`, `input: { skill: string, args?: string }` — `skill` may be namespaced (`superpowers:brainstorming`); `args` can be long / multi-line.

## Fix

- One-liner: skill name, or `<skill> — <args>` when args present.
- Detail body: the `args` as a `code` block (null when no args — the name is enough).
- `ICONS.Skill` (`✦`) so the row carries a per-tool glyph (looked up at `claude-activity.ts:200`).

## Testing

TDD: failing tests from the real shape first → implement → green. Full suite **894 / tsc / biome** clean. Independent review: **SHIP** (no findings).

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Skill tool type for organizing and displaying skill-related information within the application
  * Skill entries now support optional command arguments that are displayed in both compact summary and expanded detail formats
  * Each Skill tool includes a dedicated visual icon for easy identification in the interface
  * Detailed views present arguments in a formatted code block for improved readability and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->