### PR TITLE
fix(search): viewer empty query shows full list (no blank on /)

### DIFF
--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -333,8 +333,10 @@ export function ActivityViewerPanel({
   const innerWidth = getInnerWidth(width);
   const contentWidth = innerWidth - 1;
 
-  // Narrow-finder mode: when searchHits is provided, render only matched rows.
-  if (searchHits !== undefined && searchQuery !== undefined) {
+  // Narrow-finder mode: only narrow once there's a query. An empty query
+  // (search just opened, nothing typed) shows the full list — narrowing to
+  // zero rows on the first `/` keystroke would blank the viewer.
+  if (searchHits !== undefined && searchQuery) {
     const safeSelected =
       searchHits.length > 0
         ? (((searchSelected ?? 0) % searchHits.length) + searchHits.length) %

--- a/tests/ui/ActivityViewerPanel.test.tsx
+++ b/tests/ui/ActivityViewerPanel.test.tsx
@@ -278,3 +278,41 @@ describe("ActivityViewerPanel — row width alignment", () => {
     for (const l of lines) expect([...l].length).toBe(W);
   });
 });
+
+describe("ActivityViewerPanel search", () => {
+  const acts = [
+    makeActivity("Read", 0),
+    makeActivity("Bash", 1),
+    makeActivity("Edit", 2),
+  ];
+
+  it("empty query shows the full list (no narrow)", () => {
+    const { lastFrame } = render(
+      <ActivityViewerPanel
+        {...baseProps}
+        activities={acts}
+        searchQuery=""
+        searchHits={[]}
+        searchSelected={0}
+      />,
+    );
+    const f = lastFrame() ?? "";
+    expect(f).toContain("Read");
+    expect(f).toContain("Bash");
+    expect(f).toContain("Edit");
+    expect(f).not.toContain("No matches");
+  });
+
+  it("non-empty query with zero matches narrows to empty", () => {
+    const { lastFrame } = render(
+      <ActivityViewerPanel
+        {...baseProps}
+        activities={acts}
+        searchQuery="zzz"
+        searchHits={[]}
+        searchSelected={0}
+      />,
+    );
+    expect(lastFrame() ?? "").toContain("No matches");
+  });
+});


### PR DESCRIPTION
## Problem
In the Activity Viewer, pressing `/` opened search with an empty query and the list **went blank immediately** — the narrow-finder rendered only `searchHits`, which is `[]` for an empty query. Expected (and per spec "empty query → full set"): the full list stays visible until you type.

## Fix
Narrow only when the query is non-empty (`searchHits !== undefined && searchQuery`). An empty query falls through to the normal full-list render; the Tree finder was already correct (`filterTreeBySearch("")` returns the tree unchanged).

## Test
Render test: empty query → full list (Read/Bash/Edit visible, no "No matches"); non-empty query with zero matches → "No matches". 896 tests / tsc / biome green.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)