### PR TITLE
fix(claude): resolve project path from session cwd, not folder name

### DIFF
--- a/src/data/providers/claude.ts
+++ b/src/data/providers/claude.ts
@@ -187,6 +187,25 @@ export function readClaudeVersion(tailLines: string[]): string | undefined {
   return version;
 }
 
+/**
+ * The authoritative project path = the `cwd` from the first entry that
+ * carries one. Claude stamps `cwd` on message entries; reading it avoids
+ * the lossy folder-name decode (`decodeProjectPath` turns every `-` into
+ * `/`, so a real dir like `meta-claude` would become `meta/claude`).
+ * Returns undefined when no entry has a cwd. Pure — unit-tested.
+ */
+export function readSessionCwd(lines: string[]): string | undefined {
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+      if (typeof entry.cwd === "string" && entry.cwd) return entry.cwd;
+    } catch {
+      // skip non-JSON lines
+    }
+  }
+  return undefined;
+}
+
 /** Test hook: total entries across the per-file caches (bound check). */
 export function claudeFileCacheEntryCount(): number {
   return (
@@ -686,9 +705,6 @@ export function discoverSessions(
 
   for (const encodedDir of projectDirs) {
     const projectDir = join(projectsDir, encodedDir);
-    const decodedPath = decodeProjectPath(encodedDir);
-    if (scope !== null && decodedPath !== scope) continue;
-    const projectName = basename(decodedPath);
 
     let files: string[];
     try {
@@ -698,6 +714,26 @@ export function discoverSessions(
     } catch {
       continue;
     }
+
+    // Prefer the authoritative `cwd` from a session over the lossy
+    // folder-name decode — `decodeProjectPath` turns every `-` into `/`,
+    // so a real dir like `meta-claude` would show as `meta/claude`.
+    let projectPath = decodeProjectPath(encodedDir);
+    for (const f of files) {
+      try {
+        const cwd = readSessionCwd(
+          readHeadText(join(projectDir, f), HEAD_READ_BYTES).split("\n"),
+        );
+        if (cwd) {
+          projectPath = cwd;
+          break;
+        }
+      } catch {
+        // unreadable session file — try the next one
+      }
+    }
+    if (scope !== null && projectPath !== scope) continue;
+    const projectName = basename(projectPath);
 
     for (const file of files) {
       const id = file.replace(/\.jsonl$/, "");
@@ -717,7 +753,7 @@ export function discoverSessions(
           id,
           hideKey,
           filePath,
-          projectPath: decodedPath,
+          projectPath,
           projectName,
           lastModifiedMs: stat.mtimeMs,
           status: getSessionStatus(stat.mtimeMs),

--- a/tests/data/providers/claude-cwd.test.ts
+++ b/tests/data/providers/claude-cwd.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { readSessionCwd } from "../../../src/data/providers/claude.js";
+
+describe("readSessionCwd", () => {
+  it("returns the cwd from the first entry that carries one", () => {
+    const lines = [
+      JSON.stringify({ type: "summary" }), // no cwd
+      JSON.stringify({ type: "user", cwd: "/Users/neo/proj" }),
+    ];
+    expect(readSessionCwd(lines)).toBe("/Users/neo/proj");
+  });
+
+  it("preserves a hyphen in the real directory name (the #204 bug)", () => {
+    // The folder-name encoding would decode this to .../meta/claude; the
+    // authoritative cwd keeps `meta-claude` intact.
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        cwd: "/Users/neo/WestbrookAI/meta-claude",
+      }),
+    ];
+    expect(readSessionCwd(lines)).toBe("/Users/neo/WestbrookAI/meta-claude");
+  });
+
+  it("returns undefined when no entry has a cwd, or on non-JSON", () => {
+    expect(
+      readSessionCwd([JSON.stringify({ type: "summary" })]),
+    ).toBeUndefined();
+    expect(readSessionCwd(["not json"])).toBeUndefined();
+    expect(readSessionCwd([])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem
The Projects tree showed `meta-claude` as **`meta/claude`**. `decodeProjectPath` reverses Claude's dir-name encoding (`/` → `-`) with `replace(/-/g, "/")`, which is **lossy** — a real directory name containing a hyphen is indistinguishable from a path separator.

## Fix
Read the authoritative `cwd` from a session's JSONL (`readSessionCwd`, present on message entries, e.g. `"/Users/neo/WestbrookAI/meta-claude"`) and use it as `projectPath` (and `projectName = basename`). Fall back to the folder-name decode only when no session carries a cwd (empty/odd files). `--cwd` scope now matches the real cwd too.

## Testing
- TDD: `readSessionCwd` pure helper (first entry with a cwd; **hyphen preserved**; undefined on none/non-JSON).
- Smoke against real `~/.claude/projects`: `meta-claude`, `skill-reseacher`, `pain-radar`, `back-to-work` all resolve with hyphens intact (previously mangled).
- 897 tests / tsc / biome green.

Note: `hideKey` for a hyphenated project now uses its correct name — a hidden-session config keyed off the old mangled name would need re-hiding (the old key was wrong).

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session discovery to read working directory information directly from session files, providing more accurate project path identification compared to folder-name-based detection.

* **Tests**
  * Added comprehensive test coverage for working directory detection logic, including scenarios with special characters and missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->