### PR TITLE
fix(search): viewer search Enter opens the matched activity's Detail View

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1062,6 +1062,23 @@ export function App({
     if (tracking) setTracking(false);
   };
 
+  // Open the Detail View for a given activity. Shared by normal viewer Enter
+  // (`onEnter`) and the viewer search-finder Enter so both open detail the
+  // same way (incl. resolving a commit's full `git show` body).
+  const openActivityDetail = (act: ActivityEntry) => {
+    if (act.type === "commit") {
+      const node = allFlatRef.current.find((s) => s.id === selectedId);
+      const detail = node?.projectPath
+        ? (getCommitDetail(node.projectPath, act.label) ?? act.detail)
+        : act.detail;
+      setDetailActivity({ ...act, detail });
+    } else {
+      setDetailActivity(act);
+    }
+    setDetailMode(true);
+    setDetailScrollOffset(0);
+  };
+
   const { handleInput, statusBarItems } = useHotkeys({
     focus,
     detailMode,
@@ -1260,19 +1277,7 @@ export function App({
           viewerRows,
           viewerCursorLine,
         );
-        if (act) {
-          if (act.type === "commit") {
-            const node = allFlatRef.current.find((s) => s.id === selectedId);
-            const detail = node?.projectPath
-              ? (getCommitDetail(node.projectPath, act.label) ?? act.detail)
-              : act.detail;
-            setDetailActivity({ ...act, detail });
-          } else {
-            setDetailActivity(act);
-          }
-          setDetailMode(true);
-          setDetailScrollOffset(0);
-        }
+        if (act) openActivityDetail(act);
         return;
       }
       if (focus !== "tree" || !selectedId) return;
@@ -1553,6 +1558,10 @@ export function App({
               setViewerCursorLine(0);
               setIsLive(false);
               setScrollOffset(newScrollOffset);
+              // Searching was to inspect the match — open its Detail View,
+              // not just position the cursor.
+              const act = mergedActivities[hitIndex];
+              if (act) openActivityDetail(act);
             }
           }
           setSearch(null);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1645,7 +1645,24 @@ export function App({
     },
   });
 
-  useInput((input, key) => handleInput(input, key), { isActive: isWatchMode });
+  // `handleInput` is rebuilt every render with fresh closures over state
+  // (focus, search query/surface, merged activities). Ink's `useInput`
+  // re-subscribes its stdin listener from a `useEffect` that runs AFTER
+  // commit, so for a short window the SUBSCRIBED handler is a previous
+  // render's closure. A keystroke arriving in that window is processed
+  // against stale state — observed on CI as `/` opening a TREE search even
+  // though focus had already committed to the viewer, and typed characters
+  // being dropped. Subscribe a stable callback once and dispatch through a
+  // ref that always points at the latest handler, so input is never handled
+  // by an outdated closure (and per-render listener churn is removed).
+  const handleInputRef = useRef(handleInput);
+  handleInputRef.current = handleInput;
+  const stableHandleInput = useCallback(
+    (input: string, key: Parameters<typeof handleInput>[1]) =>
+      handleInputRef.current(input, key),
+    [],
+  );
+  useInput(stableHandleInput, { isActive: isWatchMode });
 
   // Detail search: derive the raw source lines from the active detail body
   // (split by \n, before wrapping) so detailMatchLines can index into them.

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -2,6 +2,7 @@
 import { render } from "ink-testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  ActivityEntry,
   ProjectNode,
   SessionNode,
   SessionTree,
@@ -30,8 +31,9 @@ vi.mock("../../src/data/sessions.js", () => ({
   getProjectsDir: () => "/tmp/nonexistent-projects-dir",
 }));
 
+let mockActivities: ActivityEntry[] = [];
 vi.mock("../../src/data/sessionHistory.js", () => ({
-  parseSessionHistory: () => [],
+  parseSessionHistory: () => mockActivities,
 }));
 
 const {
@@ -76,6 +78,7 @@ const makeColdProject = (name: string): ProjectNode => ({
 
 beforeEach(() => {
   mockTree = emptyTree();
+  mockActivities = [];
 });
 
 describe("App", () => {
@@ -734,3 +737,77 @@ function sessionStub(id: string) {
     liveState: null,
   };
 }
+
+describe("viewer search → Enter opens Detail View", () => {
+  const tick = () => new Promise((r) => setTimeout(r, 50));
+
+  it("opens the matched activity's detail on Enter (not just select+exit)", async () => {
+    mockTree = {
+      projects: [
+        {
+          name: "proj",
+          projectPath: "/tmp/proj",
+          hotness: "hot",
+          sessions: [
+            {
+              id: "s1",
+              hideKey: "proj/s1",
+              filePath: "/tmp/proj/s1.jsonl",
+              projectPath: "/tmp/proj",
+              projectName: "proj",
+              lastModifiedMs: Date.now(),
+              status: "hot",
+              modelName: null,
+              subAgents: [],
+              nonInteractive: false,
+              firstUserPrompt: "do auth",
+              liveState: null,
+            },
+          ],
+        },
+      ],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
+    };
+    mockActivities = [
+      {
+        timestamp: new Date(),
+        type: "tool",
+        icon: "○",
+        label: "Read",
+        detail: "auth.ts",
+        detailBody: "DETAIL_BODY_MARKER",
+        detailKind: "code",
+      },
+      {
+        timestamp: new Date(),
+        type: "tool",
+        icon: "$",
+        label: "Bash",
+        detail: "npm test",
+      },
+    ];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    await tick();
+    stdin.write("\t"); // focus tree → viewer
+    await tick();
+    stdin.write("/"); // open viewer search
+    await tick();
+    for (const ch of "auth") {
+      stdin.write(ch); // type char-by-char (ink delivers each as length-1 input)
+      await tick();
+    }
+    stdin.write("\r"); // Enter → open the matched activity's Detail View
+
+    // The Detail View renders the matched activity's body — the bug was that
+    // Enter only positioned the cursor + closed search without opening detail.
+    // waitFor polls so the assertion is robust to render-flush timing.
+    await vi.waitFor(
+      () => expect(lastFrame() ?? "").toContain("DETAIL_BODY_MARKER"),
+      { timeout: 3000, interval: 25 },
+    );
+  });
+});

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -791,7 +791,13 @@ describe("viewer search → Enter opens Detail View", () => {
     ];
 
     const { stdin, lastFrame } = render(<App mode="watch" />);
-    await tick();
+    // Activities load asynchronously; wait for the viewer to render them before
+    // interacting. A fixed tick is race-prone under CI load (the search would
+    // have nothing to match, so Enter closes search without opening detail).
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("auth.ts"), {
+      timeout: 3000,
+      interval: 25,
+    });
     stdin.write("\t"); // focus tree → viewer
     await tick();
     stdin.write("/"); // open viewer search
@@ -800,6 +806,13 @@ describe("viewer search → Enter opens Detail View", () => {
       stdin.write(ch); // type char-by-char (ink delivers each as length-1 input)
       await tick();
     }
+    // Wait until the search input reports exactly one match (`/auth   1/1`)
+    // before pressing Enter, so Enter is guaranteed to navigate to the match
+    // rather than firing while hits are still being computed.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/1"), {
+      timeout: 3000,
+      interval: 25,
+    });
     stdin.write("\r"); // Enter → open the matched activity's Detail View
 
     // The Detail View renders the matched activity's body — the bug was that

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -799,9 +799,23 @@ describe("viewer search → Enter opens Detail View", () => {
       interval: 25,
     });
     stdin.write("\t"); // focus tree → viewer
-    await tick();
+    // The `/` handler reads the CURRENT focus to decide the search surface
+    // (tree vs viewer). A fixed tick is race-prone: under CI load the focus
+    // switch from Tab may not have committed, so `/` opens a TREE search whose
+    // Enter only selects a node — it never opens the activity Detail View.
+    // Wait for the viewer footer ("↵: detail") to confirm focus is on the
+    // viewer before opening search. ("↵: expand" is the tree-focus footer.)
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
+      timeout: 3000,
+      interval: 25,
+    });
     stdin.write("/"); // open viewer search
-    await tick();
+    // Wait for the search prompt (empty query renders "0/0") so typed
+    // characters are routed to the search input, not the viewer hotkeys.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+      timeout: 3000,
+      interval: 25,
+    });
     for (const ch of "auth") {
       stdin.write(ch); // type char-by-char (ink delivers each as length-1 input)
       await tick();


### PR DESCRIPTION
## Problem
In the Activity Viewer search, after `/` + typing + `↑/↓` to land on a match, **Enter only moved the cursor and closed search** — the Detail View never opened. Since you searched to *inspect* the activity, Enter not opening detail (and "losing" the search) is surprising.

## Fix
On viewer-search Enter, open the matched activity's **Detail View** (then exit search). Extracted a shared `openActivityDetail(act)` used by both normal viewer `onEnter` and the search handler, so both open detail identically (incl. resolving a commit's full `git show` body).

## Testing
TDD: a driven App test (search → type → Enter → asserts the matched activity's detail body renders), confirmed failing before the fix; uses `vi.waitFor` for render-flush robustness. Full suite **900 / tsc / biome** green (ran twice for stability).

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing Enter in viewer search now reliably opens the matched activity’s Detail View (including the correct resolved details), rather than only closing or repositioning the search.

* **Tests**
  * Expanded UI test coverage for session history activity rendering and viewer search navigation in watch mode.
  * Added a test that types a query, verifies a single match, presses Enter, and confirms the Detail View opens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->