### PR TITLE
feat(search): persist search state across Enter and Viewer↔Detail round-trips

### DIFF
--- a/docs/superpowers/plans/2026-06-23-search-persistence.md
+++ b/docs/superpowers/plans/2026-06-23-search-persistence.md
@@ -1,0 +1,709 @@
+# Search State Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make in-pane search a persistent state that survives Enter and Viewer↔Detail round-trips, with Enter's meaning on lists driven by whether the user navigated the selection.
+
+**Architecture:** Add a `navigated` flag to `SearchState` and a `savedViewerSearch` slot in `App`. The Viewer/Tree Enter handlers (imperative, in `App.tsx`) branch on `navigated`: no-navigation → filter-confirm (keep search open); navigated → fire the row action (Viewer opens Detail, Tree selects node) while preserving/restoring the search. The Detail surface's existing two-phase model is unchanged.
+
+**Tech Stack:** TypeScript, React, Ink, Vitest, ink-testing-library, Biome.
+
+## Global Constraints
+
+- All source, comments, commit messages, docs in **English**.
+- Run `npx biome check --write <files>` before every commit (CI lints whole-repo Biome).
+- TDD: write the failing test first, see it fail for the right reason, then implement.
+- Never commit to `main` — work on branch `feat/210-search-persistence`.
+- Input reliability in tests: send arrow keys as ANSI escapes (`[B` = down, `[A` = up). In search mode `j`/`k` are typed into the query, not navigation.
+- Test timing: use condition waits (`vi.waitFor`) on committed frames, not fixed ticks. Established markers: viewer-focus footer contains `↵: detail`; an open search prompt renders the count (`0/0`, `2/2`, …).
+- Matching/narrowing logic (`activityMatch`, `treeSearch`, smart-case, panel hit-windowing) is **not** changed.
+
+## Durable Implementation Record (controller protocol, not a code task)
+
+After each task's review comes back clean, the SDD controller appends a 6-field
+entry to a **committed** report log and a ledger line, per the user's global
+workflow. The SDD `task-N-report.md` (under `.git/sdd/`, discarded with the
+worktree) is the *source*; the durable record is committed to the branch.
+
+- File: `docs/superpowers/reports/2026-06-23-search-persistence.md`
+- Per task entry (after clean review): **Intent** (one line from this plan) ·
+  **What was built** · **Key decisions / trade-offs** · **Deviations from the
+  plan** · **Files touched** · **Follow-ups / known gaps**.
+- Running ledger line: `Task N: complete (commits <base7>..<head7>, review clean)`.
+- At finish (PR): synthesize the entries into a one-page feature digest committed
+  with the PR.
+
+Known deviation to record up front: the spec's filter-confirm says "set
+`committed = true`". This plan drives all Viewer/Tree behavior from `navigated`
+and does **not** read `committed` for those surfaces, so it is left untouched
+(YAGNI — no dead state). `committed` remains Detail-only. Record this in Task 1's
+entry.
+
+## File Structure
+
+- `src/ui/search/searchKey.ts` — `SearchState` gains optional `navigated?: boolean`. Detail reducer (`applyDetailSearchKey`) unchanged (it spreads `...state`, so `navigated` carries through harmlessly).
+- `src/ui/App.tsx` — `onOpenSearch` inits `navigated:false`; Viewer search handler (↑/↓ set `navigated`, query-edit resets it, Enter branches); `savedViewerSearch` state; `onDetailClose` restores it; Tree search handler (↑/↓ set `navigated`, Enter branches, stop closing on Enter).
+- `tests/ui/App.test.tsx` — integration tests for each behavior; update the existing `#209` viewer-search test to navigate before Enter.
+
+---
+
+### Task 1: Viewer Enter — filter-confirm vs open-detail (driven by `navigated`)
+
+**Files:**
+- Modify: `src/ui/search/searchKey.ts` (`SearchState` interface)
+- Modify: `src/ui/App.tsx` (`onOpenSearch`; the `search?.surface === "viewer"` block: `key.upArrow`/`key.downArrow`/`key.return`/typing/backspace)
+- Test: `tests/ui/App.test.tsx`
+
+**Interfaces:**
+- Consumes: existing `activityMatches(mergedActivities, query)`, `scrollOffsetForCursor`, `openActivityDetail`, `setSearch`, `viewerSearchWindowStart`, `setViewerSearchWindowStart`, `edgeScrollWindowStart`.
+- Produces: `SearchState.navigated?: boolean` (default-false semantics); Viewer Enter behavior — bare Enter keeps search open (filter-confirm), `↓`/`↑` then Enter opens the selected match's Detail (and, as before this task, closes the viewer search via `setSearch(null)` — the round-trip preservation is added in Task 2).
+
+- [ ] **Step 1: Add `navigated` to `SearchState`**
+
+In `src/ui/search/searchKey.ts`, add the optional field to the interface:
+
+```ts
+export interface SearchState {
+  surface: SearchSurface;
+  query: string;
+  index: number;
+  committed: boolean; // true after Enter; false while typing (Detail surface)
+  navigated?: boolean; // Tree/Viewer: has the user moved the selection with ↑/↓? default false
+}
+```
+
+- [ ] **Step 2: Init `navigated` in `onOpenSearch`**
+
+In `src/ui/App.tsx`, `onOpenSearch`:
+
+```ts
+onOpenSearch: () => {
+  const surface: SearchSurface = detailMode ? "detail" : focus;
+  setSearch({ surface, query: "", index: 0, committed: false, navigated: false });
+  if (!detailMode && focus === "viewer") setViewerSearchWindowStart(0);
+},
+```
+
+- [ ] **Step 3: Write the failing test — bare Enter keeps the viewer search open**
+
+Add to `tests/ui/App.test.tsx` inside the `describe("viewer search → Enter opens Detail View", ...)` block (it already provides `tick`). Two matching activities so the count is `2/2`:
+
+```ts
+it("bare Enter (no arrow) filter-confirms: search stays open, no detail", async () => {
+  mockTree = {
+    projects: [
+      {
+        name: "proj",
+        projectPath: "/tmp/proj",
+        hotness: "hot",
+        sessions: [
+          {
+            id: "s1", hideKey: "proj/s1", filePath: "/tmp/proj/s1.jsonl",
+            projectPath: "/tmp/proj", projectName: "proj",
+            lastModifiedMs: Date.now(), status: "hot", modelName: null,
+            subAgents: [], nonInteractive: false, firstUserPrompt: "do auth",
+            liveState: null,
+          },
+        ],
+      },
+    ],
+    coldProjects: [], totalCount: 1,
+    timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
+  };
+  mockActivities = [
+    { timestamp: new Date(), type: "tool", icon: "○", label: "Read",
+      detail: "auth.ts", detailBody: "READ_MARKER", detailKind: "code" },
+    { timestamp: new Date(), type: "tool", icon: "○", label: "Write",
+      detail: "auth.test.ts", detailBody: "WRITE_MARKER", detailKind: "code" },
+  ];
+
+  const { stdin, lastFrame } = render(<App mode="watch" />);
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("auth.ts"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("\t");
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("/");
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+    timeout: 3000, interval: 25,
+  });
+  for (const ch of "auth") { stdin.write(ch); await tick(); }
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("\r"); // bare Enter — no arrow navigation
+
+  // Filter-confirm: search stays open (count still shown), no Detail opened.
+  await tick();
+  await tick();
+  expect(lastFrame() ?? "").toContain("2/2");
+  expect(lastFrame() ?? "").not.toContain("READ_MARKER");
+  expect(lastFrame() ?? "").not.toContain("WRITE_MARKER");
+});
+```
+
+- [ ] **Step 4: Run it to verify it fails**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "filter-confirms"`
+Expected: FAIL — current code opens the Detail (frame contains a marker) and closes search (no `2/2`).
+
+- [ ] **Step 5: Implement the Enter branch + `navigated` set/reset**
+
+In `src/ui/App.tsx`, in the `if (search?.surface === "viewer")` block:
+
+Set `navigated: true` on both arrow handlers (keep the existing window-scroll calls):
+
+```ts
+if (key.upArrow) {
+  if (hits.length === 0) return;
+  const n = hits.length;
+  const newIndex = (((search.index - 1) % n) + n) % n;
+  setSearch((s) => (s ? { ...s, index: newIndex, navigated: true } : s));
+  setViewerSearchWindowStart((prev) =>
+    edgeScrollWindowStart(prev, newIndex, viewerRows, hits.length));
+  return;
+}
+if (key.downArrow) {
+  if (hits.length === 0) return;
+  const n = hits.length;
+  const newIndex = (search.index + 1) % n;
+  setSearch((s) => (s ? { ...s, index: newIndex, navigated: true } : s));
+  setViewerSearchWindowStart((prev) =>
+    edgeScrollWindowStart(prev, newIndex, viewerRows, hits.length));
+  return;
+}
+```
+
+Replace the `if (key.return)` block with the navigated branch:
+
+```ts
+if (key.return) {
+  if (!search.navigated) {
+    // Filter-confirm: keep the narrowed search open; do NOT open a Detail.
+    return;
+  }
+  // Navigated to a specific match → open its Detail View.
+  if (hits.length > 0) {
+    const safeIndex = ((search.index % hits.length) + hits.length) % hits.length;
+    const hitIndex = hits[safeIndex];
+    if (hitIndex !== undefined) {
+      const newScrollOffset = scrollOffsetForCursor(
+        mergedActivities.length, hitIndex, viewerRows);
+      setViewerCursorLine(0);
+      setIsLive(false);
+      setScrollOffset(newScrollOffset);
+      const act = mergedActivities[hitIndex];
+      if (act) openActivityDetail(act);
+    }
+  }
+  setSearch(null);
+  return;
+}
+```
+
+Reset `navigated: false` on typing and backspace (add to the existing updaters):
+
+```ts
+if (key.delete || key.backspace) {
+  setSearch((s) =>
+    s ? { ...s, query: s.query.slice(0, -1), index: 0, navigated: false } : s);
+  setViewerSearchWindowStart(0);
+  return;
+}
+if (input && !key.ctrl && input.length === 1) {
+  setSearch((s) =>
+    s ? { ...s, query: s.query + input, index: 0, navigated: false } : s);
+  setViewerSearchWindowStart(0);
+  return;
+}
+```
+
+- [ ] **Step 6: Run the new test to verify it passes**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "filter-confirms"`
+Expected: PASS.
+
+- [ ] **Step 7: Update the existing `#209` test to navigate before Enter**
+
+The pre-existing test `opens the matched activity's detail on Enter (not just select+exit)` now requires navigation (bare Enter no longer opens Detail). It uses a single matching activity (`auth.ts`, `DETAIL_BODY_MARKER`). Add a down-arrow before the Enter, and update the comment. Locate:
+
+```ts
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/1"), {
+    timeout: 3000,
+    interval: 25,
+  });
+  stdin.write("\r"); // Enter → open the matched activity's Detail View
+```
+
+Replace with:
+
+```ts
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/1"), {
+    timeout: 3000,
+    interval: 25,
+  });
+  // Navigating the selection (↓) makes Enter a row action; a bare Enter would
+  // now filter-confirm instead of opening the Detail View.
+  stdin.write("[B"); // ↓ — mark the selection as navigated
+  await tick();
+  stdin.write("\r"); // Enter → open the navigated match's Detail View
+```
+
+- [ ] **Step 8: Run the full viewer-search describe + verify GREEN**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "viewer search"`
+Expected: PASS (both the updated `#209` test and the new filter-confirm test).
+
+- [ ] **Step 9: Lint + commit**
+
+```bash
+npx biome check --write src/ui/search/searchKey.ts src/ui/App.tsx tests/ui/App.test.tsx
+git add src/ui/search/searchKey.ts src/ui/App.tsx tests/ui/App.test.tsx
+git commit -m "feat(search): viewer Enter filter-confirms unless a match was navigated (#210)"
+```
+
+---
+
+### Task 2: Viewer ↔ Detail round-trip — preserve & restore the viewer search
+
+**Files:**
+- Modify: `src/ui/App.tsx` (new `savedViewerSearch` state near other `useState`s; the Viewer Enter navigated branch from Task 1; `onDetailClose`)
+- Test: `tests/ui/App.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 1's Viewer navigated-Enter branch; `viewerSearchWindowStart`/`setViewerSearchWindowStart`; `setSearch`; `setDetailMode`.
+- Produces: `savedViewerSearch: { search: SearchState; windowStart: number } | null` state; on navigated-Enter the viewer search is snapshotted before opening Detail; `onDetailClose` restores it (search + hit-window) when present and clears the slot.
+
+- [ ] **Step 1: Write the failing test — round-trip restores the viewer search + matched row**
+
+Add to the same `describe`:
+
+```ts
+it("restores the viewer search and the matched row after Esc out of Detail", async () => {
+  mockTree = {
+    projects: [
+      {
+        name: "proj", projectPath: "/tmp/proj", hotness: "hot",
+        sessions: [
+          {
+            id: "s1", hideKey: "proj/s1", filePath: "/tmp/proj/s1.jsonl",
+            projectPath: "/tmp/proj", projectName: "proj",
+            lastModifiedMs: Date.now(), status: "hot", modelName: null,
+            subAgents: [], nonInteractive: false, firstUserPrompt: "do auth",
+            liveState: null,
+          },
+        ],
+      },
+    ],
+    coldProjects: [], totalCount: 1,
+    timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
+  };
+  mockActivities = [
+    { timestamp: new Date(), type: "tool", icon: "○", label: "Read",
+      detail: "auth.ts", detailBody: "READ_MARKER", detailKind: "code" },
+    { timestamp: new Date(), type: "tool", icon: "○", label: "Write",
+      detail: "auth.test.ts", detailBody: "WRITE_MARKER", detailKind: "code" },
+  ];
+
+  const { stdin, lastFrame } = render(<App mode="watch" />);
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("auth.ts"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("\t");
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("/");
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+    timeout: 3000, interval: 25,
+  });
+  for (const ch of "auth") { stdin.write(ch); await tick(); }
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("[B"); // ↓ → navigate to 2nd match (Write / auth.test.ts)
+  await tick();
+  stdin.write("\r"); // Enter → open that match's Detail
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("WRITE_MARKER"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write(""); // Esc → close Detail, back to viewer
+
+  // Viewer search is restored (count shown again), Detail closed.
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+    timeout: 3000, interval: 25,
+  });
+  expect(lastFrame() ?? "").not.toContain("WRITE_MARKER");
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "restores the viewer search"`
+Expected: FAIL — after Esc the viewer has no search (no `2/2`); Task 1 still calls `setSearch(null)` on navigated-Enter without saving.
+
+- [ ] **Step 3: Add the `savedViewerSearch` state**
+
+In `src/ui/App.tsx`, near the other search-related `useState`s (e.g. just after `const [search, setSearch] = useState<SearchState | null>(null);`), add:
+
+```ts
+// When a Detail is opened from an active viewer search, stash the search so
+// closing the Detail (Esc) drops the user back into the same search with the
+// matched row selected. Null when a Detail was opened without a viewer search.
+const [savedViewerSearch, setSavedViewerSearch] = useState<{
+  search: SearchState;
+  windowStart: number;
+} | null>(null);
+```
+
+- [ ] **Step 4: Snapshot the search in the navigated-Enter branch**
+
+In the Viewer `if (key.return)` navigated branch (from Task 1), add the snapshot just before `openActivityDetail`:
+
+```ts
+  if (hitIndex !== undefined) {
+    const newScrollOffset = scrollOffsetForCursor(
+      mergedActivities.length, hitIndex, viewerRows);
+    setSavedViewerSearch({ search, windowStart: viewerSearchWindowStart });
+    setViewerCursorLine(0);
+    setIsLive(false);
+    setScrollOffset(newScrollOffset);
+    const act = mergedActivities[hitIndex];
+    if (act) openActivityDetail(act);
+  }
+```
+
+- [ ] **Step 5: Restore on Detail close**
+
+Replace `onDetailClose`:
+
+```ts
+onDetailClose: () => {
+  setDetailMode(false);
+  if (savedViewerSearch) {
+    // Came here from a viewer search → restore it with the matched row.
+    setSearch(savedViewerSearch.search);
+    setViewerSearchWindowStart(savedViewerSearch.windowStart);
+    setSavedViewerSearch(null);
+  }
+},
+```
+
+- [ ] **Step 6: Run the round-trip test to verify it passes**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "restores the viewer search"`
+Expected: PASS.
+
+- [ ] **Step 7: Write the layering test — Detail's own search does not clobber the saved viewer search**
+
+```ts
+it("Detail's own search resets on Esc without losing the saved viewer search", async () => {
+  mockTree = {
+    projects: [
+      {
+        name: "proj", projectPath: "/tmp/proj", hotness: "hot",
+        sessions: [
+          {
+            id: "s1", hideKey: "proj/s1", filePath: "/tmp/proj/s1.jsonl",
+            projectPath: "/tmp/proj", projectName: "proj",
+            lastModifiedMs: Date.now(), status: "hot", modelName: null,
+            subAgents: [], nonInteractive: false, firstUserPrompt: "do auth",
+            liveState: null,
+          },
+        ],
+      },
+    ],
+    coldProjects: [], totalCount: 1,
+    timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
+  };
+  mockActivities = [
+    { timestamp: new Date(), type: "tool", icon: "○", label: "Read",
+      detail: "auth.ts", detailBody: "alpha beta gamma", detailKind: "code" },
+    { timestamp: new Date(), type: "tool", icon: "○", label: "Write",
+      detail: "auth.test.ts", detailBody: "alpha beta gamma", detailKind: "code" },
+  ];
+
+  const { stdin, lastFrame } = render(<App mode="watch" />);
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("auth.ts"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("\t");
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("/");
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+    timeout: 3000, interval: 25,
+  });
+  for (const ch of "auth") { stdin.write(ch); await tick(); }
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("[B"); // ↓ navigate
+  await tick();
+  stdin.write("\r"); // open Detail
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("alpha"), {
+    timeout: 3000, interval: 25,
+  });
+
+  // Detail's own body search, then Esc to reset it (stay in Detail).
+  stdin.write("/");
+  await tick();
+  for (const ch of "beta") { stdin.write(ch); await tick(); }
+  await tick();
+  stdin.write(""); // Esc → reset Detail search only (still in Detail)
+  await tick();
+  expect(lastFrame() ?? "").toContain("alpha"); // still in Detail body
+
+  // Esc again → close Detail → viewer search restored.
+  stdin.write("");
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+    timeout: 3000, interval: 25,
+  });
+});
+```
+
+- [ ] **Step 8: Run it (guard test — should pass on Task 2 code)**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "without losing the saved viewer search"`
+Expected: PASS. If it fails, the saved search is being cleared too early — fix `onDetailClose`/snapshot so `savedViewerSearch` is only consumed on the Detail-closing Esc, then re-run.
+
+- [ ] **Step 9: Full suite + lint + commit**
+
+```bash
+npx vitest run
+npx biome check --write src/ui/App.tsx tests/ui/App.test.tsx
+git add src/ui/App.tsx tests/ui/App.test.tsx
+git commit -m "feat(search): preserve & restore viewer search across Detail round-trip (#210)"
+```
+
+Expected: full suite green.
+
+---
+
+### Task 3: Tree Enter — filter-confirm vs select-node, keep search alive
+
+**Files:**
+- Modify: `src/ui/App.tsx` (the `search?.surface === "tree"` block: `key.upArrow`/`key.downArrow`/`key.return`/typing/backspace)
+- Test: `tests/ui/App.test.tsx`
+
+**Interfaces:**
+- Consumes: `treeSearchHits(displayTree, query)`, `setSelectedId`, `stopTracking`, `setSearch`, `SearchState.navigated`.
+- Produces: Tree Enter behavior — bare Enter keeps the tree search open (filter-confirm); `↓`/`↑` then Enter selects/expands the navigated node and keeps the search open. Esc still ends the tree search (unchanged).
+
+- [ ] **Step 1: Write the failing test — tree Enter keeps the search open**
+
+Add a new top-level `describe` in `tests/ui/App.test.tsx` (define a local `tick` as the other search describe does). Two matching sessions so the tree search has a non-trivial hit list:
+
+```ts
+describe("tree search → Enter keeps search alive", () => {
+  const tick = () => new Promise((r) => setTimeout(r, 50));
+
+  it("bare Enter filter-confirms without closing the tree search", async () => {
+    mockTree = {
+      projects: [
+        {
+          name: "proj", projectPath: "/tmp/proj", hotness: "hot",
+          sessions: [
+            {
+              id: "s1", hideKey: "proj/s1", filePath: "/tmp/proj/s1.jsonl",
+              projectPath: "/tmp/proj", projectName: "proj",
+              lastModifiedMs: Date.now(), status: "hot", modelName: null,
+              subAgents: [], nonInteractive: false,
+              firstUserPrompt: "auth login", liveState: null,
+            },
+            {
+              id: "s2", hideKey: "proj/s2", filePath: "/tmp/proj/s2.jsonl",
+              projectPath: "/tmp/proj", projectName: "proj",
+              lastModifiedMs: Date.now(), status: "hot", modelName: null,
+              subAgents: [], nonInteractive: false,
+              firstUserPrompt: "auth logout", liveState: null,
+            },
+          ],
+        },
+      ],
+      coldProjects: [], totalCount: 2,
+      timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
+    };
+    mockActivities = [];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    // Tree is focused at boot ("↵: expand" footer); open tree search directly.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: expand"), {
+      timeout: 3000, interval: 25,
+    });
+    stdin.write("/");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+      timeout: 3000, interval: 25,
+    });
+    for (const ch of "auth") { stdin.write(ch); await tick(); }
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+      timeout: 3000, interval: 25,
+    });
+    stdin.write("\r"); // bare Enter
+
+    // Search stays open (count still rendered), not torn down.
+    await tick();
+    await tick();
+    expect(lastFrame() ?? "").toContain("2/2");
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "filter-confirms without closing the tree"`
+Expected: FAIL — current tree Enter calls `setSearch(null)`, so the count disappears.
+
+- [ ] **Step 3: Implement the tree Enter branch + `navigated`**
+
+In `src/ui/App.tsx`, in the `if (search?.surface === "tree")` block, set `navigated: true` on the arrows:
+
+```ts
+if (key.upArrow) {
+  if (hits.length === 0) return;
+  const n = hits.length;
+  setSearch((s) =>
+    s ? { ...s, index: (((s.index - 1) % n) + n) % n, navigated: true } : s);
+  return;
+}
+if (key.downArrow) {
+  if (hits.length === 0) return;
+  const n = hits.length;
+  setSearch((s) => (s ? { ...s, index: (s.index + 1) % n, navigated: true } : s));
+  return;
+}
+```
+
+Replace the tree `if (key.return)` block:
+
+```ts
+if (key.return) {
+  if (!search.navigated) {
+    // Filter-confirm: keep the narrowed tree search open.
+    return;
+  }
+  // Navigated to a hit → select/expand it, keep the search open.
+  if (hits.length > 0) {
+    const safeIndex = ((search.index % hits.length) + hits.length) % hits.length;
+    const hitId = hits[safeIndex];
+    if (hitId !== undefined) {
+      setSelectedId(hitId);
+      stopTracking();
+    }
+  }
+  return;
+}
+```
+
+Reset `navigated: false` on tree typing and backspace:
+
+```ts
+if (key.delete || key.backspace) {
+  setSearch((s) =>
+    s ? { ...s, query: s.query.slice(0, -1), index: 0, navigated: false } : s);
+  return;
+}
+if (input && !key.ctrl && input.length === 1) {
+  setSearch((s) =>
+    s ? { ...s, query: s.query + input, index: 0, navigated: false } : s);
+  return;
+}
+```
+
+- [ ] **Step 4: Run the tree test to verify it passes**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "filter-confirms without closing the tree"`
+Expected: PASS.
+
+- [ ] **Step 5: Write the navigated-Enter test — select node, search stays**
+
+Add inside the same `describe`:
+
+```ts
+it("↓ then Enter selects the navigated node and keeps the search open", async () => {
+  mockTree = {
+    projects: [
+      {
+        name: "proj", projectPath: "/tmp/proj", hotness: "hot",
+        sessions: [
+          {
+            id: "s1", hideKey: "proj/s1", filePath: "/tmp/proj/s1.jsonl",
+            projectPath: "/tmp/proj", projectName: "proj",
+            lastModifiedMs: Date.now(), status: "hot", modelName: null,
+            subAgents: [], nonInteractive: false,
+            firstUserPrompt: "auth login", liveState: null,
+          },
+          {
+            id: "s2", hideKey: "proj/s2", filePath: "/tmp/proj/s2.jsonl",
+            projectPath: "/tmp/proj", projectName: "proj",
+            lastModifiedMs: Date.now(), status: "hot", modelName: null,
+            subAgents: [], nonInteractive: false,
+            firstUserPrompt: "auth logout", liveState: null,
+          },
+        ],
+      },
+    ],
+    coldProjects: [], totalCount: 2,
+    timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
+  };
+  mockActivities = [];
+
+  const { stdin, lastFrame } = render(<App mode="watch" />);
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: expand"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("/");
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+    timeout: 3000, interval: 25,
+  });
+  for (const ch of "auth") { stdin.write(ch); await tick(); }
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write("[B"); // ↓ navigate
+  await tick();
+  stdin.write("\r"); // Enter → select node
+
+  // Search remains open after the selection.
+  await tick();
+  await tick();
+  expect(lastFrame() ?? "").toContain("2/2");
+});
+```
+
+- [ ] **Step 6: Run it to verify it passes**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "selects the navigated node"`
+Expected: PASS (selection logic unchanged; the only new behavior — not closing search — is already implemented in Step 3).
+
+- [ ] **Step 7: Full suite + lint + commit**
+
+```bash
+npx vitest run
+npx biome check --write src/ui/App.tsx tests/ui/App.test.tsx
+git add src/ui/App.tsx tests/ui/App.test.tsx
+git commit -m "feat(search): tree Enter keeps search alive (filter-confirm / select node) (#210)"
+```
+
+Expected: full suite green.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- State model `navigated` → Task 1 (Step 1–2, 5). `savedViewerSearch` slot → Task 2.
+- Enter (Viewer) filter-confirm vs row-action → Task 1.
+- Enter (Tree) filter-confirm vs select-node → Task 3.
+- Enter (Detail) two-phase unchanged → no task (regression covered by full-suite runs in Tasks 2–3 and existing `searchKey.test.ts`).
+- Esc layering rows 1–2 (Detail's own search reset; Detail close restores viewer search) → Task 2 (round-trip + layering tests). Esc row 3 (base Viewer/Tree search ends on Esc) → unchanged existing behavior; covered implicitly (search blocks still `setSearch(null)` on `key.escape`).
+- Viewer↔Detail round-trip incl. matched-row cursor → Task 2.
+- Detail independent body search → Task 2 Step 7.
+- `committed=true` on filter-confirm → **deviation**: not implemented (YAGNI, nothing reads it for Viewer/Tree); recorded in the Durable Record section + Task 1 entry.
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `navigated?: boolean` defined in Task 1 Step 1; read as `!search.navigated` / `search.navigated` and written `navigated: true|false` consistently in Tasks 1 & 3. `savedViewerSearch` shape `{ search: SearchState; windowStart: number }` defined and consumed consistently in Task 2.

--- a/docs/superpowers/plans/2026-06-23-search-persistence.md
+++ b/docs/superpowers/plans/2026-06-23-search-persistence.md
@@ -22,8 +22,9 @@
 
 After each task's review comes back clean, the SDD controller appends a 6-field
 entry to a **committed** report log and a ledger line, per the user's global
-workflow. The SDD `task-N-report.md` (under `.git/sdd/`, discarded with the
-worktree) is the *source*; the durable record is committed to the branch.
+workflow. The SDD `task-N-report.md` (under `.superpowers/sdd/` in the working
+tree on superpowers ≥6.0.3 — git-ignored scratch, deleted by `git clean -fdx`)
+is the *source*; the durable record is committed to the branch.
 
 - File: `docs/superpowers/reports/2026-06-23-search-persistence.md`
 - Per task entry (after clean review): **Intent** (one line from this plan) ·

--- a/docs/superpowers/plans/2026-06-23-search-persistence.md
+++ b/docs/superpowers/plans/2026-06-23-search-persistence.md
@@ -14,8 +14,9 @@
 - Run `npx biome check --write <files>` before every commit (CI lints whole-repo Biome).
 - TDD: write the failing test first, see it fail for the right reason, then implement.
 - Never commit to `main` — work on branch `feat/210-search-persistence`.
-- Input reliability in tests: send arrow keys as ANSI escapes (`[B` = down, `[A` = up). In search mode `j`/`k` are typed into the query, not navigation.
-- Test timing: use condition waits (`vi.waitFor`) on committed frames, not fixed ticks. Established markers: viewer-focus footer contains `↵: detail`; an open search prompt renders the count (`0/0`, `2/2`, …).
+- **Key escape sequences in tests (verified in this repo's ink-testing-library):** build them from the ESC byte via `String.fromCharCode(27)` — never paste a raw ESC byte into source. At the top of each `describe` that needs them: `const ESC = String.fromCharCode(27); const DOWN = ESC + "[B"; const UP = ESC + "[A";`. Then `stdin.write(DOWN)` / `stdin.write(ESC)`. A bare `"[B"` (no ESC prefix) types two literal characters into the query. In search mode `j`/`k` are typed into the query, not navigation.
+- **Search prompt count is `current/total`, 1-BASED.** Empty query → `0/0`. Two matches at the first selection → `1/2`. After one ↓ → `2/2`. One match → `1/1`. Assert the exact count for the selection you expect, not the match total.
+- Test timing: use condition waits (`vi.waitFor`) on committed frames, not fixed ticks. Footer markers: viewer focus → `↵: detail`; tree focus → `↵: expand`.
 - Matching/narrowing logic (`activityMatch`, `treeSearch`, smart-case, panel hit-windowing) is **not** changed.
 
 ## Durable Implementation Record (controller protocol, not a code task)
@@ -57,7 +58,7 @@ entry.
 
 **Interfaces:**
 - Consumes: existing `activityMatches(mergedActivities, query)`, `scrollOffsetForCursor`, `openActivityDetail`, `setSearch`, `viewerSearchWindowStart`, `setViewerSearchWindowStart`, `edgeScrollWindowStart`.
-- Produces: `SearchState.navigated?: boolean` (default-false semantics); Viewer Enter behavior — bare Enter keeps search open (filter-confirm), `↓`/`↑` then Enter opens the selected match's Detail (and, as before this task, closes the viewer search via `setSearch(null)` — the round-trip preservation is added in Task 2).
+- Produces: `SearchState.navigated?: boolean` (default-false semantics); Viewer Enter behavior — bare Enter keeps search open (filter-confirm), `↓`/`↑` then Enter opens the selected match's Detail (and, as before this task, closes the viewer search via `setSearch(null)` — round-trip preservation is added in Task 2).
 
 - [ ] **Step 1: Add `navigated` to `SearchState`**
 
@@ -85,9 +86,18 @@ onOpenSearch: () => {
 },
 ```
 
-- [ ] **Step 3: Write the failing test — bare Enter keeps the viewer search open**
+- [ ] **Step 3: Add the shared key constants to the viewer-search describe**
 
-Add to `tests/ui/App.test.tsx` inside the `describe("viewer search → Enter opens Detail View", ...)` block (it already provides `tick`). Two matching activities so the count is `2/2`:
+In `tests/ui/App.test.tsx`, in the `describe("viewer search → Enter opens Detail View", ...)` block, add right after the existing `const tick = ...` line:
+
+```ts
+  const ESC = String.fromCharCode(27);
+  const DOWN = ESC + "[B";
+```
+
+- [ ] **Step 4: Write the failing test — bare Enter keeps the viewer search open**
+
+Add inside the same `describe`. Two matching activities so the count is `1/2`:
 
 ```ts
 it("bare Enter (no arrow) filter-confirms: search stays open, no detail", async () => {
@@ -112,10 +122,10 @@ it("bare Enter (no arrow) filter-confirms: search stays open, no detail", async 
     timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
   };
   mockActivities = [
-    { timestamp: new Date(), type: "tool", icon: "○", label: "Read",
-      detail: "auth.ts", detailBody: "READ_MARKER", detailKind: "code" },
-    { timestamp: new Date(), type: "tool", icon: "○", label: "Write",
-      detail: "auth.test.ts", detailBody: "WRITE_MARKER", detailKind: "code" },
+    { timestamp: new Date(2026, 0, 1, 9, 0, 0), type: "tool", icon: "○",
+      label: "Read", detail: "auth.ts", detailBody: "READ_MARKER", detailKind: "code" },
+    { timestamp: new Date(2026, 0, 1, 9, 0, 1), type: "tool", icon: "○",
+      label: "Write", detail: "auth.test.ts", detailBody: "WRITE_MARKER", detailKind: "code" },
   ];
 
   const { stdin, lastFrame } = render(<App mode="watch" />);
@@ -131,7 +141,7 @@ it("bare Enter (no arrow) filter-confirms: search stays open, no detail", async 
     timeout: 3000, interval: 25,
   });
   for (const ch of "auth") { stdin.write(ch); await tick(); }
-  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
     timeout: 3000, interval: 25,
   });
   stdin.write("\r"); // bare Enter — no arrow navigation
@@ -139,20 +149,20 @@ it("bare Enter (no arrow) filter-confirms: search stays open, no detail", async 
   // Filter-confirm: search stays open (count still shown), no Detail opened.
   await tick();
   await tick();
-  expect(lastFrame() ?? "").toContain("2/2");
+  expect(lastFrame() ?? "").toContain("1/2");
   expect(lastFrame() ?? "").not.toContain("READ_MARKER");
   expect(lastFrame() ?? "").not.toContain("WRITE_MARKER");
 });
 ```
 
-- [ ] **Step 4: Run it to verify it fails**
+- [ ] **Step 5: Run it to verify it fails**
 
 Run: `npx vitest run tests/ui/App.test.tsx -t "filter-confirms"`
-Expected: FAIL — current code opens the Detail (frame contains a marker) and closes search (no `2/2`).
+Expected: FAIL — current code opens the Detail (frame contains a marker) and closes search (no `1/2`).
 
-- [ ] **Step 5: Implement the Enter branch + `navigated` set/reset**
+- [ ] **Step 6: Implement the Enter branch + `navigated` set/reset**
 
-In `src/ui/App.tsx`, in the `if (search?.surface === "viewer")` block:
+In `src/ui/App.tsx`, in the `if (search?.surface === "viewer")` block.
 
 Set `navigated: true` on both arrow handlers (keep the existing window-scroll calls):
 
@@ -221,14 +231,14 @@ if (input && !key.ctrl && input.length === 1) {
 }
 ```
 
-- [ ] **Step 6: Run the new test to verify it passes**
+- [ ] **Step 7: Run the new test to verify it passes**
 
 Run: `npx vitest run tests/ui/App.test.tsx -t "filter-confirms"`
 Expected: PASS.
 
-- [ ] **Step 7: Update the existing `#209` test to navigate before Enter**
+- [ ] **Step 8: Update the existing `#209` test to navigate before Enter**
 
-The pre-existing test `opens the matched activity's detail on Enter (not just select+exit)` now requires navigation (bare Enter no longer opens Detail). It uses a single matching activity (`auth.ts`, `DETAIL_BODY_MARKER`). Add a down-arrow before the Enter, and update the comment. Locate:
+The pre-existing test `opens the matched activity's detail on Enter (not just select+exit)` now requires navigation (bare Enter no longer opens Detail). It uses a single matching activity (`auth.ts`, `DETAIL_BODY_MARKER`, count `1/1`). Locate:
 
 ```ts
   await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/1"), {
@@ -238,7 +248,7 @@ The pre-existing test `opens the matched activity's detail on Enter (not just se
   stdin.write("\r"); // Enter → open the matched activity's Detail View
 ```
 
-Replace with:
+Replace with (uses the `DOWN` constant added in Step 3):
 
 ```ts
   await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/1"), {
@@ -246,18 +256,19 @@ Replace with:
     interval: 25,
   });
   // Navigating the selection (↓) makes Enter a row action; a bare Enter would
-  // now filter-confirm instead of opening the Detail View.
-  stdin.write("[B"); // ↓ — mark the selection as navigated
+  // now filter-confirm instead of opening the Detail View. With one match the
+  // count stays 1/1; the ↓ only sets the navigated flag.
+  stdin.write(DOWN); // ↓ — mark the selection as navigated
   await tick();
   stdin.write("\r"); // Enter → open the navigated match's Detail View
 ```
 
-- [ ] **Step 8: Run the full viewer-search describe + verify GREEN**
+- [ ] **Step 9: Run the full viewer-search describe + verify GREEN**
 
 Run: `npx vitest run tests/ui/App.test.tsx -t "viewer search"`
 Expected: PASS (both the updated `#209` test and the new filter-confirm test).
 
-- [ ] **Step 9: Lint + commit**
+- [ ] **Step 10: Lint + commit**
 
 ```bash
 npx biome check --write src/ui/search/searchKey.ts src/ui/App.tsx tests/ui/App.test.tsx
@@ -274,12 +285,12 @@ git commit -m "feat(search): viewer Enter filter-confirms unless a match was nav
 - Test: `tests/ui/App.test.tsx`
 
 **Interfaces:**
-- Consumes: Task 1's Viewer navigated-Enter branch; `viewerSearchWindowStart`/`setViewerSearchWindowStart`; `setSearch`; `setDetailMode`.
+- Consumes: Task 1's Viewer navigated-Enter branch; the `ESC`/`DOWN` constants added to the viewer-search describe in Task 1 Step 3; `viewerSearchWindowStart`/`setViewerSearchWindowStart`; `setSearch`; `setDetailMode`.
 - Produces: `savedViewerSearch: { search: SearchState; windowStart: number } | null` state; on navigated-Enter the viewer search is snapshotted before opening Detail; `onDetailClose` restores it (search + hit-window) when present and clears the slot.
 
 - [ ] **Step 1: Write the failing test — round-trip restores the viewer search + matched row**
 
-Add to the same `describe`:
+Add to the same `describe("viewer search → Enter opens Detail View", ...)` block (uses `tick`, `ESC`, `DOWN` from Task 1). Two matching activities, distinct timestamps so `Write` is index 1:
 
 ```ts
 it("restores the viewer search and the matched row after Esc out of Detail", async () => {
@@ -302,10 +313,10 @@ it("restores the viewer search and the matched row after Esc out of Detail", asy
     timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
   };
   mockActivities = [
-    { timestamp: new Date(), type: "tool", icon: "○", label: "Read",
-      detail: "auth.ts", detailBody: "READ_MARKER", detailKind: "code" },
-    { timestamp: new Date(), type: "tool", icon: "○", label: "Write",
-      detail: "auth.test.ts", detailBody: "WRITE_MARKER", detailKind: "code" },
+    { timestamp: new Date(2026, 0, 1, 9, 0, 0), type: "tool", icon: "○",
+      label: "Read", detail: "auth.ts", detailBody: "READ_MARKER", detailKind: "code" },
+    { timestamp: new Date(2026, 0, 1, 9, 0, 1), type: "tool", icon: "○",
+      label: "Write", detail: "auth.test.ts", detailBody: "WRITE_MARKER", detailKind: "code" },
   ];
 
   const { stdin, lastFrame } = render(<App mode="watch" />);
@@ -321,18 +332,20 @@ it("restores the viewer search and the matched row after Esc out of Detail", asy
     timeout: 3000, interval: 25,
   });
   for (const ch of "auth") { stdin.write(ch); await tick(); }
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write(DOWN); // ↓ → navigate to 2nd match (Write / auth.test.ts)
   await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
     timeout: 3000, interval: 25,
   });
-  stdin.write("[B"); // ↓ → navigate to 2nd match (Write / auth.test.ts)
-  await tick();
   stdin.write("\r"); // Enter → open that match's Detail
   await vi.waitFor(() => expect(lastFrame() ?? "").toContain("WRITE_MARKER"), {
     timeout: 3000, interval: 25,
   });
-  stdin.write(""); // Esc → close Detail, back to viewer
+  stdin.write(ESC); // Esc → close Detail, back to viewer
 
-  // Viewer search is restored (count shown again), Detail closed.
+  // Viewer search restored at the navigated selection (2/2), Detail closed.
   await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
     timeout: 3000, interval: 25,
   });
@@ -420,10 +433,10 @@ it("Detail's own search resets on Esc without losing the saved viewer search", a
     timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
   };
   mockActivities = [
-    { timestamp: new Date(), type: "tool", icon: "○", label: "Read",
-      detail: "auth.ts", detailBody: "alpha beta gamma", detailKind: "code" },
-    { timestamp: new Date(), type: "tool", icon: "○", label: "Write",
-      detail: "auth.test.ts", detailBody: "alpha beta gamma", detailKind: "code" },
+    { timestamp: new Date(2026, 0, 1, 9, 0, 0), type: "tool", icon: "○",
+      label: "Read", detail: "auth.ts", detailBody: "alpha beta gamma", detailKind: "code" },
+    { timestamp: new Date(2026, 0, 1, 9, 0, 1), type: "tool", icon: "○",
+      label: "Write", detail: "auth.test.ts", detailBody: "alpha beta gamma", detailKind: "code" },
   ];
 
   const { stdin, lastFrame } = render(<App mode="watch" />);
@@ -439,11 +452,13 @@ it("Detail's own search resets on Esc without losing the saved viewer search", a
     timeout: 3000, interval: 25,
   });
   for (const ch of "auth") { stdin.write(ch); await tick(); }
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write(DOWN); // ↓ navigate to 2nd match
   await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
     timeout: 3000, interval: 25,
   });
-  stdin.write("[B"); // ↓ navigate
-  await tick();
   stdin.write("\r"); // open Detail
   await vi.waitFor(() => expect(lastFrame() ?? "").toContain("alpha"), {
     timeout: 3000, interval: 25,
@@ -454,12 +469,12 @@ it("Detail's own search resets on Esc without losing the saved viewer search", a
   await tick();
   for (const ch of "beta") { stdin.write(ch); await tick(); }
   await tick();
-  stdin.write(""); // Esc → reset Detail search only (still in Detail)
+  stdin.write(ESC); // Esc → reset Detail search only (still in Detail)
   await tick();
   expect(lastFrame() ?? "").toContain("alpha"); // still in Detail body
 
   // Esc again → close Detail → viewer search restored.
-  stdin.write("");
+  stdin.write(ESC);
   await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
     timeout: 3000, interval: 25,
   });
@@ -496,38 +511,42 @@ Expected: full suite green.
 
 - [ ] **Step 1: Write the failing test — tree Enter keeps the search open**
 
-Add a new top-level `describe` in `tests/ui/App.test.tsx` (define a local `tick` as the other search describe does). Two matching sessions so the tree search has a non-trivial hit list:
+Add a new top-level `describe` in `tests/ui/App.test.tsx`. Two matching sessions so the tree search has 2 hits:
 
 ```ts
 describe("tree search → Enter keeps search alive", () => {
   const tick = () => new Promise((r) => setTimeout(r, 50));
+  const ESC = String.fromCharCode(27);
+  const DOWN = ESC + "[B";
+
+  const twoMatchingSessions = (): SessionTree => ({
+    projects: [
+      {
+        name: "proj", projectPath: "/tmp/proj", hotness: "hot",
+        sessions: [
+          {
+            id: "s1", hideKey: "proj/s1", filePath: "/tmp/proj/s1.jsonl",
+            projectPath: "/tmp/proj", projectName: "proj",
+            lastModifiedMs: Date.now(), status: "hot", modelName: null,
+            subAgents: [], nonInteractive: false,
+            firstUserPrompt: "auth login", liveState: null,
+          },
+          {
+            id: "s2", hideKey: "proj/s2", filePath: "/tmp/proj/s2.jsonl",
+            projectPath: "/tmp/proj", projectName: "proj",
+            lastModifiedMs: Date.now(), status: "hot", modelName: null,
+            subAgents: [], nonInteractive: false,
+            firstUserPrompt: "auth logout", liveState: null,
+          },
+        ],
+      },
+    ],
+    coldProjects: [], totalCount: 2,
+    timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
+  });
 
   it("bare Enter filter-confirms without closing the tree search", async () => {
-    mockTree = {
-      projects: [
-        {
-          name: "proj", projectPath: "/tmp/proj", hotness: "hot",
-          sessions: [
-            {
-              id: "s1", hideKey: "proj/s1", filePath: "/tmp/proj/s1.jsonl",
-              projectPath: "/tmp/proj", projectName: "proj",
-              lastModifiedMs: Date.now(), status: "hot", modelName: null,
-              subAgents: [], nonInteractive: false,
-              firstUserPrompt: "auth login", liveState: null,
-            },
-            {
-              id: "s2", hideKey: "proj/s2", filePath: "/tmp/proj/s2.jsonl",
-              projectPath: "/tmp/proj", projectName: "proj",
-              lastModifiedMs: Date.now(), status: "hot", modelName: null,
-              subAgents: [], nonInteractive: false,
-              firstUserPrompt: "auth logout", liveState: null,
-            },
-          ],
-        },
-      ],
-      coldProjects: [], totalCount: 2,
-      timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
-    };
+    mockTree = twoMatchingSessions();
     mockActivities = [];
 
     const { stdin, lastFrame } = render(<App mode="watch" />);
@@ -540,7 +559,7 @@ describe("tree search → Enter keeps search alive", () => {
       timeout: 3000, interval: 25,
     });
     for (const ch of "auth") { stdin.write(ch); await tick(); }
-    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
       timeout: 3000, interval: 25,
     });
     stdin.write("\r"); // bare Enter
@@ -548,7 +567,7 @@ describe("tree search → Enter keeps search alive", () => {
     // Search stays open (count still rendered), not torn down.
     await tick();
     await tick();
-    expect(lastFrame() ?? "").toContain("2/2");
+    expect(lastFrame() ?? "").toContain("1/2");
   });
 });
 ```
@@ -625,31 +644,7 @@ Add inside the same `describe`:
 
 ```ts
 it("↓ then Enter selects the navigated node and keeps the search open", async () => {
-  mockTree = {
-    projects: [
-      {
-        name: "proj", projectPath: "/tmp/proj", hotness: "hot",
-        sessions: [
-          {
-            id: "s1", hideKey: "proj/s1", filePath: "/tmp/proj/s1.jsonl",
-            projectPath: "/tmp/proj", projectName: "proj",
-            lastModifiedMs: Date.now(), status: "hot", modelName: null,
-            subAgents: [], nonInteractive: false,
-            firstUserPrompt: "auth login", liveState: null,
-          },
-          {
-            id: "s2", hideKey: "proj/s2", filePath: "/tmp/proj/s2.jsonl",
-            projectPath: "/tmp/proj", projectName: "proj",
-            lastModifiedMs: Date.now(), status: "hot", modelName: null,
-            subAgents: [], nonInteractive: false,
-            firstUserPrompt: "auth logout", liveState: null,
-          },
-        ],
-      },
-    ],
-    coldProjects: [], totalCount: 2,
-    timestamp: new Date().toISOString(), hiddenStats: { total: 0, active: 0 },
-  };
+  mockTree = twoMatchingSessions();
   mockActivities = [];
 
   const { stdin, lastFrame } = render(<App mode="watch" />);
@@ -661,14 +656,16 @@ it("↓ then Enter selects the navigated node and keeps the search open", async 
     timeout: 3000, interval: 25,
   });
   for (const ch of "auth") { stdin.write(ch); await tick(); }
+  await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
+    timeout: 3000, interval: 25,
+  });
+  stdin.write(DOWN); // ↓ navigate
   await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
     timeout: 3000, interval: 25,
   });
-  stdin.write("[B"); // ↓ navigate
-  await tick();
   stdin.write("\r"); // Enter → select node
 
-  // Search remains open after the selection.
+  // Search remains open after the selection (count still at the navigated 2/2).
   await tick();
   await tick();
   expect(lastFrame() ?? "").toContain("2/2");
@@ -696,11 +693,11 @@ Expected: full suite green.
 ## Self-Review
 
 **Spec coverage:**
-- State model `navigated` → Task 1 (Step 1–2, 5). `savedViewerSearch` slot → Task 2.
+- State model `navigated` → Task 1 (Steps 1–2, 6). `savedViewerSearch` slot → Task 2.
 - Enter (Viewer) filter-confirm vs row-action → Task 1.
 - Enter (Tree) filter-confirm vs select-node → Task 3.
 - Enter (Detail) two-phase unchanged → no task (regression covered by full-suite runs in Tasks 2–3 and existing `searchKey.test.ts`).
-- Esc layering rows 1–2 (Detail's own search reset; Detail close restores viewer search) → Task 2 (round-trip + layering tests). Esc row 3 (base Viewer/Tree search ends on Esc) → unchanged existing behavior; covered implicitly (search blocks still `setSearch(null)` on `key.escape`).
+- Esc layering rows 1–2 (Detail's own search reset; Detail close restores viewer search) → Task 2 (round-trip + layering tests). Esc row 3 (base Viewer/Tree search ends on Esc) → unchanged existing behavior; the search blocks still `setSearch(null)` on `key.escape`.
 - Viewer↔Detail round-trip incl. matched-row cursor → Task 2.
 - Detail independent body search → Task 2 Step 7.
 - `committed=true` on filter-confirm → **deviation**: not implemented (YAGNI, nothing reads it for Viewer/Tree); recorded in the Durable Record section + Task 1 entry.
@@ -708,3 +705,5 @@ Expected: full suite green.
 **Placeholder scan:** none — every step has concrete code/commands.
 
 **Type consistency:** `navigated?: boolean` defined in Task 1 Step 1; read as `!search.navigated` / `search.navigated` and written `navigated: true|false` consistently in Tasks 1 & 3. `savedViewerSearch` shape `{ search: SearchState; windowStart: number }` defined and consumed consistently in Task 2.
+
+**Test-mechanics consistency:** all arrow/Esc sends use `String.fromCharCode(27)`-built `DOWN`/`ESC` constants; all count assertions are 1-based (`0/0` empty, `1/2` first of two, `2/2` after one ↓, `1/1` single match). No raw ESC bytes in source.

--- a/docs/superpowers/reports/2026-06-23-search-persistence.md
+++ b/docs/superpowers/reports/2026-06-23-search-persistence.md
@@ -1,0 +1,53 @@
+# Search State Persistence — implementation record
+
+> Issue: #210 · Branch: `feat/210-search-persistence` ·
+> Plan: [`../plans/2026-06-23-search-persistence.md`](../plans/2026-06-23-search-persistence.md)
+
+A durable, committed record of why each task was built the way it was —
+decisions and deviations a diff cannot show. Per-task entries are appended after
+a clean review; a one-page digest is synthesized at PR time.
+
+## Ledger
+
+- Task 1: complete (commits d75a75c..813dea9, review clean — Approved)
+
+---
+
+## Task 1 — Viewer Enter: filter-confirm vs open-detail (driven by `navigated`)
+
+**Intent:** Make viewer Enter keep the search open, branching on whether the user
+navigated the selection: bare Enter filter-confirms (matches-only stays), ↓/↑
+then Enter opens the matched row's Detail.
+
+**What was built:** Added `navigated?: boolean` to `SearchState`
+(`src/ui/search/searchKey.ts`). In `App.tsx`: `onOpenSearch` inits
+`navigated:false`; viewer ↑/↓ set `navigated:true`; typing/backspace reset it to
+`false`; the viewer Enter handler returns early (no Detail, no close) when
+`!navigated`, and otherwise opens the selected match's Detail (still
+`setSearch(null)` for now — round-trip preservation is Task 2). New test
+`bare Enter … filter-confirms`; the existing #209 test updated to press ↓ before
+Enter.
+
+**Key decisions / trade-offs:**
+- `navigated` is **optional** (`navigated?: boolean`) so existing `SearchState`
+  literals don't break; read as `!search.navigated` / `search.navigated`.
+- Reset `navigated` on every query edit so a fresh query always filter-confirms
+  on a bare Enter (matches the "did you move the selection?" rule).
+- Test mechanics proven this session: arrow/Esc built from
+  `String.fromCharCode(27)` (no raw ESC bytes); search count is 1-based
+  (`1/2` = first of two). These were baked into the plan after a pre-flight
+  probe caught wrong `"[B"`/`"2/2"` values.
+
+**Deviations from the plan:** None in behavior. The spec's filter-confirm
+"set `committed = true`" is intentionally **not** implemented for the viewer
+(nothing reads it; YAGNI) — `committed` stays Detail-only. Recorded as agreed.
+
+**Files touched:** `src/ui/search/searchKey.ts`, `src/ui/App.tsx`,
+`tests/ui/App.test.tsx`.
+
+**Follow-ups / known gaps:**
+- Review Minor: filter-confirm test asserts via two `tick()`s rather than
+  `vi.waitFor` (intentional — asserting *absence* of a transition); could carry
+  an inline note.
+- Pre-existing (not a regression): a navigated Enter with `hits.length === 0`
+  still closes the search without opening Detail.

--- a/docs/superpowers/reports/2026-06-23-search-persistence.md
+++ b/docs/superpowers/reports/2026-06-23-search-persistence.md
@@ -115,7 +115,14 @@ then a second Esc closes Detail and restores it).
   `search=null` (viewer search stashed) — its `/` opens a fresh detail-surface
   search; the layering test is a guard, not RED-first (passes on Task 2 code).
 
-**Deviations from the plan:** None.
+**Deviations from the plan:** None in behavior. Post-merge-review fix: the
+layering test's detail-search steps originally used fixed `tick()`s (as the plan
+showed) and flaked on CI macos-22 (the second Esc raced the search-reset commit
+and was re-routed into the still-open detail search, so the viewer search never
+restored). Converted those steps to condition-waits (`0/0` → `1/1` →
+`↵/Esc: close` → `2/2`); the `↵/Esc: close` detail footer only renders when
+detailMode is on and no search is active, so it confirms the reset committed
+before the next Esc. Test-only; no product change.
 
 **Files touched:** `src/ui/App.tsx`, `tests/ui/App.test.tsx`.
 

--- a/docs/superpowers/reports/2026-06-23-search-persistence.md
+++ b/docs/superpowers/reports/2026-06-23-search-persistence.md
@@ -10,6 +10,7 @@ a clean review; a one-page digest is synthesized at PR time.
 ## Ledger
 
 - Task 1: complete (commits d75a75c..813dea9, review clean — Approved)
+- Task 2: complete (commits 3bc0682..a147940, review clean — Approved)
 
 ---
 
@@ -51,3 +52,36 @@ Enter.
   an inline note.
 - Pre-existing (not a regression): a navigated Enter with `hits.length === 0`
   still closes the search without opening Detail.
+
+---
+
+## Task 2 — Viewer ↔ Detail round-trip: preserve & restore the viewer search
+
+**Intent:** Opening a Detail from a viewer-search row, then Esc-ing back, should
+land in the same viewer search with the cursor on the matched row; the Detail's
+own body search must be independent.
+
+**What was built:** Added `savedViewerSearch: { search; windowStart } | null`
+state in `App.tsx` (right after `search`). The viewer navigated-Enter branch
+snapshots `{ search, windowStart: viewerSearchWindowStart }` into it *before*
+opening the Detail (then still `setSearch(null)`). `onDetailClose` restores the
+snapshot (`setSearch` + `setViewerSearchWindowStart`) and clears the slot when
+present. Two tests: the round-trip restore (RED→GREEN) and a layering guard
+(Detail's own `/` search resets on Esc without losing the saved viewer search,
+then a second Esc closes Detail and restores it).
+
+**Key decisions / trade-offs:**
+- Snapshot captures the render-closure `search` by value before `setSearch(null)`
+  runs; React batches event-handler updates so the snapshot is never clobbered.
+- Restore is guarded by `if (savedViewerSearch)`, so a Detail opened by a plain
+  Enter (no active search) closes normally with no stale-search resurrection
+  (verified by the reviewer as the key risk).
+- Detail's independent body search "just works" because entering Detail sets
+  `search=null` (viewer search stashed) — its `/` opens a fresh detail-surface
+  search; the layering test is a guard, not RED-first (passes on Task 2 code).
+
+**Deviations from the plan:** None.
+
+**Files touched:** `src/ui/App.tsx`, `tests/ui/App.test.tsx`.
+
+**Follow-ups / known gaps:** None. (`committed` still Detail-only, as agreed.)

--- a/docs/superpowers/reports/2026-06-23-search-persistence.md
+++ b/docs/superpowers/reports/2026-06-23-search-persistence.md
@@ -11,6 +11,7 @@ a clean review; a one-page digest is synthesized at PR time.
 
 - Task 1: complete (commits d75a75c..813dea9, review clean — Approved)
 - Task 2: complete (commits 3bc0682..a147940, review clean — Approved)
+- Task 3: complete (commits ecbaec1..6c20039, review clean — Approved)
 
 ---
 
@@ -85,3 +86,31 @@ then a second Esc closes Detail and restores it).
 **Files touched:** `src/ui/App.tsx`, `tests/ui/App.test.tsx`.
 
 **Follow-ups / known gaps:** None. (`committed` still Detail-only, as agreed.)
+
+---
+
+## Task 3 — Tree Enter: filter-confirm vs select-node, keep search alive
+
+**Intent:** Apply the same `navigated`-driven Enter to the tree surface: bare
+Enter filter-confirms (keeps the narrowed tree search), ↓/↑ then Enter
+selects/expands the node — both keep the search open; Esc still ends it.
+
+**What was built:** In `App.tsx`'s `if (search?.surface === "tree")` block: ↑/↓
+now set `navigated:true`; typing/backspace reset `navigated:false`; the Enter
+handler returns early when `!navigated` (filter-confirm) and otherwise
+`setSelectedId` + `stopTracking` **without** the old `setSearch(null)`. The
+`key.escape → setSearch(null)` path is untouched (Esc still exits search). New
+top-level describe `tree search → Enter keeps search alive` with two tests
+(bare-Enter filter-confirm; ↓+Enter selects node, search stays), each RED→GREEN.
+
+**Key decisions / trade-offs:**
+- Mirrors the viewer surface exactly (same `navigated` semantics), so the three
+  list surfaces behave consistently.
+- Tree tests open `/` directly (tree is focused at boot; `↵: expand` footer
+  confirms) — no Tab needed, unlike the viewer tests.
+
+**Deviations from the plan:** None.
+
+**Files touched:** `src/ui/App.tsx`, `tests/ui/App.test.tsx`.
+
+**Follow-ups / known gaps:** None.

--- a/docs/superpowers/reports/2026-06-23-search-persistence.md
+++ b/docs/superpowers/reports/2026-06-23-search-persistence.md
@@ -7,6 +7,40 @@ A durable, committed record of why each task was built the way it was —
 decisions and deviations a diff cannot show. Per-task entries are appended after
 a clean review; a one-page digest is synthesized at PR time.
 
+## Feature digest (PR catch-up)
+
+In-pane search is now a **persistent state** instead of a transient finder that
+closed on Enter. One new flag drives it: `SearchState.navigated` — set by ↑/↓,
+reset by any query edit.
+
+- **Enter on a list (Viewer/Tree):** no navigation → *filter-confirm* (the
+  matches-only view stays, search remains open); after ↑/↓ → *row action*
+  (Viewer opens the match's Detail; Tree selects/expands the node) and search
+  stays alive.
+- **Viewer → Detail → back:** a navigated-Enter snapshots the viewer search into
+  `savedViewerSearch` (query + selection + hit-window) before opening the Detail;
+  closing the Detail restores it with the cursor on the matched row. The Detail's
+  own `/` body search is independent — resetting it doesn't touch the snapshot.
+- **Esc is layered:** inside Detail it clears the Detail's own search first, then
+  a second Esc closes the Detail (restoring the viewer search); a base list-search
+  Esc still ends the search and restores the full view.
+
+Detail's existing two-phase (type → Enter commit → n/N) model is unchanged.
+Matching/narrowing logic is untouched.
+
+**Built across 3 TDD tasks** (each implemented + independently reviewed):
+Task 1 viewer Enter (`d75a75c..813dea9`), Task 2 round-trip restore
+(`3bc0682..a147940`), Task 3 tree Enter (`ecbaec1..6c20039`). 905 tests green,
+tsc clean, Biome clean. Final whole-branch review: **Ready to merge**.
+
+**Deliberate deviation:** the spec's filter-confirm "set `committed = true`" is
+not implemented for Viewer/Tree — nothing reads it there (YAGNI); `committed`
+stays Detail-only.
+
+**Known follow-up (not in this PR):** a viewer navigated-Enter when the hit list
+has shrunk to zero (live update under a fixed query) still ends the search,
+whereas Tree keeps it — a small viewer/tree asymmetry to align in a follow-up.
+
 ## Ledger
 
 - Task 1: complete (commits d75a75c..813dea9, review clean — Approved)

--- a/docs/superpowers/specs/2026-06-22-search-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-22-search-persistence-design.md
@@ -1,0 +1,172 @@
+# Search state persistence — design
+
+> Issue: #210 · Branch: `feat/210-search-persistence`
+>
+> Amends the list-search interaction defined in
+> [`2026-06-21-search-design.md`](2026-06-21-search-design.md): lists are no
+> longer a *transient* finder that closes on Enter. Search becomes a
+> **persistent state** that survives Enter and Viewer↔Detail round-trips.
+
+## Context
+
+AgentHUD has in-pane text search (`/`) on three surfaces:
+
+- **Session Tree** (top): projects → sessions → sub-agents.
+- **Activity Viewer** (bottom): the selected session's activity stream.
+- **Detail View** (overlay): one activity's full body.
+
+Today, search is a single state object
+`search = { surface, query, index, committed } | null`, but the three surfaces
+behave inconsistently on Enter:
+
+| Surface | Enter (current) |
+|---|---|
+| Tree | select node + **close search** (`setSearch(null)`) |
+| Viewer | open matched row's Detail + **close search** (`setSearch(null)`) |
+| Detail | commit (`committed=true`); search **persists**, `n`/`N` navigate |
+
+Both Tree and Viewer already **narrow to matches** while typing
+(`filterTreeBySearch` / hit-windowing in `ActivityViewerPanel`). The problem is
+purely that Enter tears the search down, and that opening a Detail from a Viewer
+search discards the Viewer search entirely — so returning (Esc) lands in a
+viewer with no search and no matched-row context.
+
+## Goals
+
+1. Enter no longer closes search on any surface.
+2. Enter's meaning on Tree/Viewer depends on whether the user navigated the
+   selection with ↑/↓ during the search session.
+3. Esc peels exactly one layer (it is not a blanket "kill all search").
+4. A Viewer search survives a Viewer → Detail → back round-trip, including the
+   matched-row cursor; the Detail's own body search is independent.
+
+Out of scope: cross-session/global search; changing the matching algorithm
+(substring + smart-case stays); the Detail two-phase model (kept as-is).
+
+## State model
+
+Extend `SearchState`:
+
+```ts
+interface SearchState {
+  surface: "tree" | "viewer" | "detail";
+  query: string;
+  index: number;
+  committed: boolean;  // existing
+  navigated: boolean;  // NEW: has the user moved the selection with ↑/↓?
+}
+```
+
+`navigated` lifecycle:
+
+- `false` when search opens (`/`).
+- `false` after any query edit (printable char append, Backspace/Delete) —
+  editing the query resets the selection to the first match.
+- `true` when ↑/↓ (Viewer/Tree) is pressed to move the selection.
+
+Add a **saved-search slot** for the Viewer↔Detail round-trip:
+
+```ts
+savedSearch: {
+  search: SearchState;        // the Viewer search snapshot
+  cursorLine: number;         // viewerCursorLine
+  scrollOffset: number;       // scrollOffset
+} | null
+```
+
+`savedSearch` is set when a Detail is opened **from an active Viewer search**,
+and consumed (restored, then cleared) when that Detail is closed.
+
+## Behavior
+
+### Enter — Tree / Viewer
+
+| `navigated` | Behavior |
+|---|---|
+| `false` (typed, no arrow) | **Filter-confirm**: keep only matched results visible, keep search open, set `committed = true`. No row action. |
+| `true` (↑/↓ to a row) | **Row action**, then keep search alive: Viewer → open that row's Detail (and snapshot the Viewer search into `savedSearch`); Tree → select/expand that node. |
+
+Notes:
+
+- Because both lists already narrow while typing, filter-confirm is mostly a
+  *state* change (search stays open, search bar switches to its committed
+  indicator). The visible row set does not change at the moment of Enter.
+- After filter-confirm, pressing Enter again with `navigated` still `false` is a
+  no-op; the user moves with ↑/↓ (which sets `navigated = true`) to act on a row.
+
+### Enter — Detail
+
+Unchanged from the existing two-phase model: type → Enter commits → `n`/`N`
+navigate. Detail has no row action, so the `navigated` rule does not apply.
+
+### Esc — layered pop (innermost active layer only)
+
+| Situation | Esc does |
+|---|---|
+| Detail open **and** Detail's own search active | Reset only the Detail search (stay in Detail). `savedSearch` (the Viewer search) is untouched. |
+| Detail open **and** no Detail search | Close Detail → return to Viewer; **restore** `savedSearch` (Viewer search + matched-row cursor/scroll), then clear `savedSearch`. |
+| No Detail **and** Viewer/Tree search active | End that search; restore the full (un-narrowed) view. This is the sole exit from search. |
+| Nothing active | No-op. |
+
+### Viewer ↔ Detail round-trip (the headline case)
+
+1. Viewer search, user ↑/↓ to a matched row, presses Enter.
+2. Snapshot the Viewer search → `savedSearch`; open the row's Detail.
+3. (Optional) In Detail, `/` runs an **independent** body-text search; `n`/`N`
+   navigate; Esc resets it — `savedSearch` is not affected.
+4. Esc out of Detail (no Detail search) → restore `savedSearch`: the Viewer is
+   in its prior search state with the cursor on the originally matched row.
+5. A further Esc in the Viewer ends the search (full view).
+
+If a Detail is opened **without** an active Viewer search (a normal row Enter,
+no search), `savedSearch` stays `null` and Esc simply closes the Detail.
+
+## Components affected
+
+- `src/ui/search/searchKey.ts` — add `navigated` to `SearchState`; the Detail
+  reducer is unchanged. (Tree/Viewer keys are handled imperatively in `App.tsx`,
+  not by this reducer.)
+- `src/ui/App.tsx` —
+  - `onOpenSearch`: initialize `navigated: false`.
+  - Viewer/Tree search key handlers: set `navigated` on ↑/↓; reset on query
+    edit; rewrite Enter to branch on `navigated`; **stop calling
+    `setSearch(null)` on Enter**.
+  - `openActivityDetail` (or the Viewer Enter path): when invoked from an active
+    Viewer search, populate `savedSearch`.
+  - `onDetailClose`: when `savedSearch` is present and the Detail had no active
+    search, restore it (search + cursor/scroll) and clear the slot.
+- `src/ui/search/SearchInput.tsx` / status surfaces — committed vs typing
+  indicator already exists for Detail; reuse it for Tree/Viewer committed state.
+
+No change to matching (`activityMatch`, `treeSearch`, smart-case) or to the
+panel narrowing logic.
+
+## Edge cases
+
+- **Query edit after filter-confirm**: typing/Backspace sets `navigated = false`
+  and `committed = false` (back to typing), so the next bare Enter filter-confirms
+  again.
+- **Empty query + Enter**: no matches semantics already show the full list while
+  typing; bare Enter on an empty query is a no-op (nothing to confirm/act on).
+- **Match list shrinks under live updates** while committed: `index` is clamped
+  mod hit-count (existing behavior); the cursor stays on a valid match.
+- **Detail opened from Tree?** Tree Enter selects a node, it does not open a
+  Detail, so the Viewer↔Detail save/restore path is Viewer-only.
+- **`navigated = true` but zero matches**: Enter is a no-op (no row to act on),
+  consistent with the existing `hits.length > 0` guard.
+
+## Testing (TDD)
+
+Per surface and per transition, written failing-first:
+
+- Viewer: bare Enter → search stays open, matches-only view, `committed`.
+- Viewer: ↓ then Enter → Detail opens for the *navigated* row; `savedSearch` set.
+- Viewer↔Detail: search → ↓ → Enter → Esc → Viewer search restored with cursor
+  on the matched row.
+- Viewer↔Detail: search → ↓ → Enter → `/` in Detail → Esc (resets Detail search,
+  stays in Detail, Viewer snapshot intact) → Esc (Detail closes, Viewer search
+  restored).
+- Tree: bare Enter → search stays; ↓ then Enter → node selected, search stays.
+- Esc layering: each row of the Esc table above as a discrete test.
+- Regression: existing in-pane search tests still pass (matching, narrowing,
+  smart-case, Detail `n`/`N`).

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -684,6 +684,14 @@ export function App({
   // In-pane search state. null = search closed.
   const [search, setSearch] = useState<SearchState | null>(null);
 
+  // When a Detail is opened from an active viewer search, stash the search so
+  // closing the Detail (Esc) drops the user back into the same search with the
+  // matched row selected. Null when a Detail was opened without a viewer search.
+  const [savedViewerSearch, setSavedViewerSearch] = useState<{
+    search: SearchState;
+    windowStart: number;
+  } | null>(null);
+
   // Persisted window-start for viewer narrow-finder edge-scroll. Reset to 0
   // when search opens or query resets (index → 0 on query change). Updated
   // via edgeScrollWindowStart on every ↑/↓ in viewer search mode.
@@ -1252,6 +1260,12 @@ export function App({
     },
     onDetailClose: () => {
       setDetailMode(false);
+      if (savedViewerSearch) {
+        // Came here from a viewer search → restore it with the matched row.
+        setSearch(savedViewerSearch.search);
+        setViewerSearchWindowStart(savedViewerSearch.windowStart);
+        setSavedViewerSearch(null);
+      }
     },
     onDetailScrollUp: () => {
       setDetailScrollOffset((o) => Math.max(0, o - 1));
@@ -1570,6 +1584,10 @@ export function App({
                 hitIndex,
                 viewerRows,
               );
+              setSavedViewerSearch({
+                search,
+                windowStart: viewerSearchWindowStart,
+              });
               setViewerCursorLine(0);
               setIsLive(false);
               setScrollOffset(newScrollOffset);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1636,17 +1636,26 @@ export function App({
           if (hits.length === 0) return;
           const n = hits.length;
           setSearch((s) =>
-            s ? { ...s, index: (((s.index - 1) % n) + n) % n } : s,
+            s
+              ? { ...s, index: (((s.index - 1) % n) + n) % n, navigated: true }
+              : s,
           );
           return;
         }
         if (key.downArrow) {
           if (hits.length === 0) return;
           const n = hits.length;
-          setSearch((s) => (s ? { ...s, index: (s.index + 1) % n } : s));
+          setSearch((s) =>
+            s ? { ...s, index: (s.index + 1) % n, navigated: true } : s,
+          );
           return;
         }
         if (key.return) {
+          if (!search.navigated) {
+            // Filter-confirm: keep the narrowed tree search open.
+            return;
+          }
+          // Navigated to a hit → select/expand it, keep the search open.
           if (hits.length > 0) {
             const safeIndex =
               ((search.index % hits.length) + hits.length) % hits.length;
@@ -1656,18 +1665,26 @@ export function App({
               stopTracking();
             }
           }
-          setSearch(null);
           return;
         }
         if (key.delete || key.backspace) {
           setSearch((s) =>
-            s ? { ...s, query: s.query.slice(0, -1), index: 0 } : s,
+            s
+              ? {
+                  ...s,
+                  query: s.query.slice(0, -1),
+                  index: 0,
+                  navigated: false,
+                }
+              : s,
           );
           return;
         }
         if (input && !key.ctrl && input.length === 1) {
           setSearch((s) =>
-            s ? { ...s, query: s.query + input, index: 0 } : s,
+            s
+              ? { ...s, query: s.query + input, index: 0, navigated: false }
+              : s,
           );
           return;
         }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1511,7 +1511,13 @@ export function App({
     searchActive: search !== null,
     onOpenSearch: () => {
       const surface: SearchSurface = detailMode ? "detail" : focus;
-      setSearch({ surface, query: "", index: 0, committed: false });
+      setSearch({
+        surface,
+        query: "",
+        index: 0,
+        committed: false,
+        navigated: false,
+      });
       if (!detailMode && focus === "viewer") setViewerSearchWindowStart(0);
     },
     onSearchKey: (input, key) => {
@@ -1528,7 +1534,9 @@ export function App({
           if (hits.length === 0) return;
           const n = hits.length;
           const newIndex = (((search.index - 1) % n) + n) % n;
-          setSearch((s) => (s ? { ...s, index: newIndex } : s));
+          setSearch((s) =>
+            s ? { ...s, index: newIndex, navigated: true } : s,
+          );
           setViewerSearchWindowStart((prev) =>
             edgeScrollWindowStart(prev, newIndex, viewerRows, hits.length),
           );
@@ -1538,13 +1546,20 @@ export function App({
           if (hits.length === 0) return;
           const n = hits.length;
           const newIndex = (search.index + 1) % n;
-          setSearch((s) => (s ? { ...s, index: newIndex } : s));
+          setSearch((s) =>
+            s ? { ...s, index: newIndex, navigated: true } : s,
+          );
           setViewerSearchWindowStart((prev) =>
             edgeScrollWindowStart(prev, newIndex, viewerRows, hits.length),
           );
           return;
         }
         if (key.return) {
+          if (!search.navigated) {
+            // Filter-confirm: keep the narrowed search open; do NOT open a Detail.
+            return;
+          }
+          // Navigated to a specific match → open its Detail View.
           if (hits.length > 0) {
             const safeIndex =
               ((search.index % hits.length) + hits.length) % hits.length;
@@ -1558,8 +1573,6 @@ export function App({
               setViewerCursorLine(0);
               setIsLive(false);
               setScrollOffset(newScrollOffset);
-              // Searching was to inspect the match — open its Detail View,
-              // not just position the cursor.
               const act = mergedActivities[hitIndex];
               if (act) openActivityDetail(act);
             }
@@ -1569,14 +1582,23 @@ export function App({
         }
         if (key.delete || key.backspace) {
           setSearch((s) =>
-            s ? { ...s, query: s.query.slice(0, -1), index: 0 } : s,
+            s
+              ? {
+                  ...s,
+                  query: s.query.slice(0, -1),
+                  index: 0,
+                  navigated: false,
+                }
+              : s,
           );
           setViewerSearchWindowStart(0);
           return;
         }
         if (input && !key.ctrl && input.length === 1) {
           setSearch((s) =>
-            s ? { ...s, query: s.query + input, index: 0 } : s,
+            s
+              ? { ...s, query: s.query + input, index: 0, navigated: false }
+              : s,
           );
           setViewerSearchWindowStart(0);
           return;

--- a/src/ui/search/searchKey.ts
+++ b/src/ui/search/searchKey.ts
@@ -18,7 +18,8 @@ export interface SearchState {
   surface: SearchSurface;
   query: string;
   index: number; // current match index (detail: line-match #; lists: selected match row)
-  committed: boolean; // true after Enter; false while typing
+  committed: boolean; // true after Enter; false while typing (Detail surface)
+  navigated?: boolean; // Tree/Viewer: has the user moved the selection with ↑/↓? default false
 }
 
 export interface SearchKey {

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -36,6 +36,15 @@ vi.mock("../../src/data/sessionHistory.js", () => ({
   parseSessionHistory: () => mockActivities,
 }));
 
+// The search integration tests drive many sequential keystrokes, each gated on
+// a condition wait. On slow CI runners (notably Windows) the *sum* of those
+// steps can exceed Vitest's default 5s per-test budget — the layering test died
+// at ~5082ms there while passing on macOS/Linux. Raise the ceiling for the whole
+// file; fast tests are unaffected (a higher cap doesn't slow a quick test), and
+// each `vi.waitFor` keeps its own 3s timeout so a genuinely stuck condition
+// still fails fast.
+vi.setConfig({ testTimeout: 20000 });
+
 const {
   App,
   appendSubAgentRows,

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -845,6 +845,103 @@ describe("viewer search → Enter opens Detail View", () => {
     );
   });
 
+  it("restores the viewer search and the matched row after Esc out of Detail", async () => {
+    mockTree = {
+      projects: [
+        {
+          name: "proj",
+          projectPath: "/tmp/proj",
+          hotness: "hot",
+          sessions: [
+            {
+              id: "s1",
+              hideKey: "proj/s1",
+              filePath: "/tmp/proj/s1.jsonl",
+              projectPath: "/tmp/proj",
+              projectName: "proj",
+              lastModifiedMs: Date.now(),
+              status: "hot",
+              modelName: null,
+              subAgents: [],
+              nonInteractive: false,
+              firstUserPrompt: "do auth",
+              liveState: null,
+            },
+          ],
+        },
+      ],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
+    };
+    mockActivities = [
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 0),
+        type: "tool",
+        icon: "○",
+        label: "Read",
+        detail: "auth.ts",
+        detailBody: "READ_MARKER",
+        detailKind: "code",
+      },
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 1),
+        type: "tool",
+        icon: "○",
+        label: "Write",
+        detail: "auth.test.ts",
+        detailBody: "WRITE_MARKER",
+        detailKind: "code",
+      },
+    ];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("auth.ts"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\t");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("/");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    for (const ch of "auth") {
+      stdin.write(ch);
+      await tick();
+    }
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write(DOWN); // ↓ → navigate to 2nd match (Write / auth.test.ts)
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\r"); // Enter → open that match's Detail
+    await vi.waitFor(
+      () => expect(lastFrame() ?? "").toContain("WRITE_MARKER"),
+      {
+        timeout: 3000,
+        interval: 25,
+      },
+    );
+    stdin.write(ESC); // Esc → close Detail, back to viewer
+
+    // Viewer search restored at the navigated selection (2/2), Detail closed.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    expect(lastFrame() ?? "").not.toContain("WRITE_MARKER");
+  });
+
   it("bare Enter (no arrow) filter-confirms: search stays open, no detail", async () => {
     mockTree = {
       projects: [
@@ -927,5 +1024,110 @@ describe("viewer search → Enter opens Detail View", () => {
     expect(lastFrame() ?? "").toContain("1/2");
     expect(lastFrame() ?? "").not.toContain("READ_MARKER");
     expect(lastFrame() ?? "").not.toContain("WRITE_MARKER");
+  });
+
+  it("Detail's own search resets on Esc without losing the saved viewer search", async () => {
+    mockTree = {
+      projects: [
+        {
+          name: "proj",
+          projectPath: "/tmp/proj",
+          hotness: "hot",
+          sessions: [
+            {
+              id: "s1",
+              hideKey: "proj/s1",
+              filePath: "/tmp/proj/s1.jsonl",
+              projectPath: "/tmp/proj",
+              projectName: "proj",
+              lastModifiedMs: Date.now(),
+              status: "hot",
+              modelName: null,
+              subAgents: [],
+              nonInteractive: false,
+              firstUserPrompt: "do auth",
+              liveState: null,
+            },
+          ],
+        },
+      ],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
+    };
+    mockActivities = [
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 0),
+        type: "tool",
+        icon: "○",
+        label: "Read",
+        detail: "auth.ts",
+        detailBody: "alpha beta gamma",
+        detailKind: "code",
+      },
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 1),
+        type: "tool",
+        icon: "○",
+        label: "Write",
+        detail: "auth.test.ts",
+        detailBody: "alpha beta gamma",
+        detailKind: "code",
+      },
+    ];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("auth.ts"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\t");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("/");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    for (const ch of "auth") {
+      stdin.write(ch);
+      await tick();
+    }
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write(DOWN); // ↓ navigate to 2nd match
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\r"); // open Detail
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("alpha"), {
+      timeout: 3000,
+      interval: 25,
+    });
+
+    // Detail's own body search, then Esc to reset it (stay in Detail).
+    stdin.write("/");
+    await tick();
+    for (const ch of "beta") {
+      stdin.write(ch);
+      await tick();
+    }
+    await tick();
+    stdin.write(ESC); // Esc → reset Detail search only (still in Detail)
+    await tick();
+    expect(lastFrame() ?? "").toContain("alpha"); // still in Detail body
+
+    // Esc again → close Detail → viewer search restored.
+    stdin.write(ESC);
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
   });
 });

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -740,6 +740,8 @@ function sessionStub(id: string) {
 
 describe("viewer search → Enter opens Detail View", () => {
   const tick = () => new Promise((r) => setTimeout(r, 50));
+  const ESC = String.fromCharCode(27);
+  const DOWN = `${ESC}[B`;
 
   it("opens the matched activity's detail on Enter (not just select+exit)", async () => {
     mockTree = {
@@ -827,7 +829,12 @@ describe("viewer search → Enter opens Detail View", () => {
       timeout: 3000,
       interval: 25,
     });
-    stdin.write("\r"); // Enter → open the matched activity's Detail View
+    // Navigating the selection (↓) makes Enter a row action; a bare Enter would
+    // now filter-confirm instead of opening the Detail View. With one match the
+    // count stays 1/1; the ↓ only sets the navigated flag.
+    stdin.write(DOWN); // ↓ — mark the selection as navigated
+    await tick();
+    stdin.write("\r"); // Enter → open the navigated match's Detail View
 
     // The Detail View renders the matched activity's body — the bug was that
     // Enter only positioned the cursor + closed search without opening detail.
@@ -836,5 +843,89 @@ describe("viewer search → Enter opens Detail View", () => {
       () => expect(lastFrame() ?? "").toContain("DETAIL_BODY_MARKER"),
       { timeout: 3000, interval: 25 },
     );
+  });
+
+  it("bare Enter (no arrow) filter-confirms: search stays open, no detail", async () => {
+    mockTree = {
+      projects: [
+        {
+          name: "proj",
+          projectPath: "/tmp/proj",
+          hotness: "hot",
+          sessions: [
+            {
+              id: "s1",
+              hideKey: "proj/s1",
+              filePath: "/tmp/proj/s1.jsonl",
+              projectPath: "/tmp/proj",
+              projectName: "proj",
+              lastModifiedMs: Date.now(),
+              status: "hot",
+              modelName: null,
+              subAgents: [],
+              nonInteractive: false,
+              firstUserPrompt: "do auth",
+              liveState: null,
+            },
+          ],
+        },
+      ],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
+    };
+    mockActivities = [
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 0),
+        type: "tool",
+        icon: "○",
+        label: "Read",
+        detail: "auth.ts",
+        detailBody: "READ_MARKER",
+        detailKind: "code",
+      },
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 1),
+        type: "tool",
+        icon: "○",
+        label: "Write",
+        detail: "auth.test.ts",
+        detailBody: "WRITE_MARKER",
+        detailKind: "code",
+      },
+    ];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("auth.ts"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\t");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("/");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    for (const ch of "auth") {
+      stdin.write(ch);
+      await tick();
+    }
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\r"); // bare Enter — no arrow navigation
+
+    // Filter-confirm: search stays open (count still shown), no Detail opened.
+    await tick();
+    await tick();
+    expect(lastFrame() ?? "").toContain("1/2");
+    expect(lastFrame() ?? "").not.toContain("READ_MARKER");
+    expect(lastFrame() ?? "").not.toContain("WRITE_MARKER");
   });
 });

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -738,6 +738,122 @@ function sessionStub(id: string) {
   };
 }
 
+describe("tree search → Enter keeps search alive", () => {
+  const tick = () => new Promise((r) => setTimeout(r, 50));
+  const ESC = String.fromCharCode(27);
+  const DOWN = ESC + "[B";
+
+  const twoMatchingSessions = (): SessionTree => ({
+    projects: [
+      {
+        name: "proj",
+        projectPath: "/tmp/proj",
+        hotness: "hot",
+        sessions: [
+          {
+            id: "s1",
+            hideKey: "proj/s1",
+            filePath: "/tmp/proj/s1.jsonl",
+            projectPath: "/tmp/proj",
+            projectName: "proj",
+            lastModifiedMs: Date.now(),
+            status: "hot",
+            modelName: null,
+            subAgents: [],
+            nonInteractive: false,
+            firstUserPrompt: "auth login",
+            liveState: null,
+          },
+          {
+            id: "s2",
+            hideKey: "proj/s2",
+            filePath: "/tmp/proj/s2.jsonl",
+            projectPath: "/tmp/proj",
+            projectName: "proj",
+            lastModifiedMs: Date.now(),
+            status: "hot",
+            modelName: null,
+            subAgents: [],
+            nonInteractive: false,
+            firstUserPrompt: "auth logout",
+            liveState: null,
+          },
+        ],
+      },
+    ],
+    coldProjects: [],
+    totalCount: 2,
+    timestamp: new Date().toISOString(),
+    hiddenStats: { total: 0, active: 0 },
+  });
+
+  it("bare Enter filter-confirms without closing the tree search", async () => {
+    mockTree = twoMatchingSessions();
+    mockActivities = [];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    // Tree is focused at boot ("↵: expand" footer); open tree search directly.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: expand"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("/");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    for (const ch of "auth") {
+      stdin.write(ch);
+      await tick();
+    }
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\r"); // bare Enter
+
+    // Search stays open (count still rendered), not torn down.
+    await tick();
+    await tick();
+    expect(lastFrame() ?? "").toContain("1/2");
+  });
+
+  it("↓ then Enter selects the navigated node and keeps the search open", async () => {
+    mockTree = twoMatchingSessions();
+    mockActivities = [];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: expand"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("/");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    for (const ch of "auth") {
+      stdin.write(ch);
+      await tick();
+    }
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write(DOWN); // ↓ navigate
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\r"); // Enter → select node
+
+    // Search remains open after the selection (count still at the navigated 2/2).
+    await tick();
+    await tick();
+    expect(lastFrame() ?? "").toContain("2/2");
+  });
+});
+
 describe("viewer search → Enter opens Detail View", () => {
   const tick = () => new Promise((r) => setTimeout(r, 50));
   const ESC = String.fromCharCode(27);

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -889,22 +889,29 @@ describe("viewer search → Enter opens Detail View", () => {
       timestamp: new Date().toISOString(),
       hiddenStats: { total: 0, active: 0 },
     };
+    // Two activities both matching "auth", distinct timestamps so the second
+    // (carrying DETAIL_BODY_MARKER) is index 1. Navigating ↓ to it makes the
+    // count change 1/2 → 2/2, which is observable — so the test can wait for the
+    // navigation to commit before pressing Enter (a single match would leave the
+    // count at 1/1, giving nothing to wait on and racing the navigated flag).
     mockActivities = [
       {
-        timestamp: new Date(),
+        timestamp: new Date(2026, 0, 1, 9, 0, 0),
         type: "tool",
         icon: "○",
         label: "Read",
         detail: "auth.ts",
-        detailBody: "DETAIL_BODY_MARKER",
+        detailBody: "FIRST_MARKER",
         detailKind: "code",
       },
       {
-        timestamp: new Date(),
+        timestamp: new Date(2026, 0, 1, 9, 0, 1),
         type: "tool",
-        icon: "$",
-        label: "Bash",
-        detail: "npm test",
+        icon: "○",
+        label: "Read",
+        detail: "auth.test.ts",
+        detailBody: "DETAIL_BODY_MARKER",
+        detailKind: "code",
       },
     ];
 
@@ -938,18 +945,19 @@ describe("viewer search → Enter opens Detail View", () => {
       stdin.write(ch); // type char-by-char (ink delivers each as length-1 input)
       await tick();
     }
-    // Wait until the search input reports exactly one match (`/auth   1/1`)
-    // before pressing Enter, so Enter is guaranteed to navigate to the match
-    // rather than firing while hits are still being computed.
-    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/1"), {
+    // Wait until both matches are computed (`/auth   1/2`) before navigating.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
       timeout: 3000,
       interval: 25,
     });
     // Navigating the selection (↓) makes Enter a row action; a bare Enter would
-    // now filter-confirm instead of opening the Detail View. With one match the
-    // count stays 1/1; the ↓ only sets the navigated flag.
-    stdin.write(DOWN); // ↓ — mark the selection as navigated
-    await tick();
+    // now filter-confirm instead of opening the Detail View. Wait for the count
+    // to advance to 2/2 so the navigated flag is committed before Enter.
+    stdin.write(DOWN); // ↓ → second match (carries DETAIL_BODY_MARKER)
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
     stdin.write("\r"); // Enter → open the navigated match's Detail View
 
     // The Detail View renders the matched activity's body — the bug was that

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -1228,15 +1228,34 @@ describe("viewer search → Enter opens Detail View", () => {
     });
 
     // Detail's own body search, then Esc to reset it (stay in Detail).
+    // Condition-wait each transition: a fixed tick is race-prone under CI load,
+    // and if the search-reset has not committed when the second Esc arrives, that
+    // Esc is routed back into the (still-open) detail search instead of closing
+    // the Detail — so the viewer search is never restored.
     stdin.write("/");
-    await tick();
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+      timeout: 3000,
+      interval: 25,
+    });
     for (const ch of "beta") {
       stdin.write(ch);
       await tick();
     }
-    await tick();
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/1"), {
+      timeout: 3000,
+      interval: 25,
+    });
     stdin.write(ESC); // Esc → reset Detail search only (still in Detail)
-    await tick();
+    // Detail search cleared but still in Detail: the detail footer ("↵/Esc:
+    // close") only renders when detailMode is on AND no search is active, so it
+    // confirms the reset committed before we send the next Esc.
+    await vi.waitFor(
+      () => expect(lastFrame() ?? "").toContain("↵/Esc: close"),
+      {
+        timeout: 3000,
+        interval: 25,
+      },
+    );
     expect(lastFrame() ?? "").toContain("alpha"); // still in Detail body
 
     // Esc again → close Detail → viewer search restored.


### PR DESCRIPTION
Closes #210

## What & why

In-pane search was a transient finder that tore down on Enter and was lost when round-tripping Viewer → Detail → back. This makes search a **persistent state**.

A single new flag — `SearchState.navigated` (set by ↑/↓, reset by any query edit) — drives Enter's meaning on the lists:

- **Bare Enter (no ↑/↓)** → *filter-confirm*: the matches-only view stays, search remains open.
- **↑/↓ then Enter** → *row action*: Viewer opens the matched row's Detail; Tree selects/expands the node — and search stays alive.

**Viewer ↔ Detail round-trip:** a navigated-Enter snapshots the viewer search (query + selection + hit-window) into `savedViewerSearch` before opening the Detail; closing the Detail restores it with the cursor on the matched row. The Detail's own `/` body search is independent — resetting it doesn't touch the snapshot.

**Esc is layered:** inside Detail it clears the Detail's own search first; a second Esc closes the Detail (restoring the viewer search); a base list-search Esc still ends the search and restores the full view.

Detail's two-phase (type → Enter commit → n/N) model is unchanged. Matching/narrowing logic is untouched.

## How it was built

Spec → plan → 3 TDD tasks, each implemented by a fresh subagent and independently reviewed, plus a final whole-branch review (**Ready to merge**):
- Task 1 — viewer Enter (filter-confirm vs open-detail)
- Task 2 — Viewer↔Detail round-trip preserve/restore
- Task 3 — tree Enter (filter-confirm vs select-node)

Docs in this PR: spec (`docs/superpowers/specs/2026-06-22-…`), plan (`docs/superpowers/plans/2026-06-23-…`), and the per-task implementation record + feature digest (`docs/superpowers/reports/2026-06-23-…`).

## Verification

905 tests passing, `tsc --noEmit` clean, Biome clean.

## Deliberate deviation

The spec's filter-confirm "set `committed = true`" is not implemented for Viewer/Tree — nothing reads it there (YAGNI); `committed` stays Detail-only.

## Known follow-up (not in this PR)

A viewer navigated-Enter when the hit list has shrunk to zero (live update under a fixed query) still ends the search, whereas Tree keeps it — a small viewer/tree asymmetry to align in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search state now persists when navigating between Viewer and Detail views, with automatic restoration upon Detail closure.
  * Enter key behavior refined: bare Enter filter-confirms search; navigated Enter (after arrow selection) opens the matched Detail view.
  * Esc key behavior updated with layered navigation: clears Detail body search first, then restores prior Viewer search state.

* **Tests**
  * Added comprehensive coverage for search persistence across Viewer↔Detail round-trips and tree/viewer Enter key behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->