### PR TITLE
fix(tree): scroll within a tall live project instead of freezing the top

### DIFF
--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -1101,18 +1101,7 @@ export function SessionTreePanel({
     }
     livePrefixCount++;
   }
-  // Cap the sticky prefix so it can't swallow the whole panel — always
-  // leave at least one row for the scrollable tail.
-  const pinnedCount = needsOverflow
-    ? Math.min(livePrefixCount, Math.max(0, visibleCount - 1))
-    : 0;
-  const pinnedRows = flatRows.slice(0, pinnedCount);
-  const restRows = flatRows.slice(pinnedCount);
-  const restTotal = restRows.length;
-
-  // Index of the selected row within the scrollable tail (pinned rows are
-  // always visible, so a selection there needs no scroll).
-  const selectedRestIndex = restRows.findIndex((row) => {
+  const isSelectedRow = (row: FlatRow) => {
     if (row.kind === "project") return selectedId === row.sentinelId;
     if (row.kind === "session") return row.session.id === selectedId;
     if (row.kind === "subagent-summary")
@@ -1121,17 +1110,44 @@ export function SessionTreePanel({
     if (row.kind === "cold-sessions-summary")
       return selectedId === `__cold-sessions-${row.projectName}__`;
     return false;
-  });
+  };
+  const isSearchHitRow = (row: FlatRow) =>
+    row.kind === "session" && row.session.id === searchHitId;
+
+  // The scroll anchor in the FULL row list (search hit if searching, else the
+  // selection). Used to decide whether pinning the live prefix is appropriate.
+  const anchorFlatIndex =
+    searchHitId !== undefined
+      ? flatRows.findIndex(isSearchHitRow)
+      : flatRows.findIndex(isSelectedRow);
+
+  // Pin the sticky live prefix ONLY when the anchor is BELOW it (browsing the
+  // cold/idle tail) — that is the feature's purpose: keep live work visible
+  // while scrolling cold. When the anchor is INSIDE the live prefix the user is
+  // navigating the active list, so pinning the whole block would freeze the top
+  // and leave a one-row scroll tail (the cursor would appear stuck on the last
+  // row). In that case pin nothing and let the window follow the cursor.
+  const anchorInPrefix =
+    anchorFlatIndex >= 0 && anchorFlatIndex < livePrefixCount;
+  // Cap the sticky prefix so it can't swallow the whole panel — always
+  // leave at least one row for the scrollable tail.
+  const pinnedCount =
+    needsOverflow && !anchorInPrefix
+      ? Math.min(livePrefixCount, Math.max(0, visibleCount - 1))
+      : 0;
+  const pinnedRows = flatRows.slice(0, pinnedCount);
+  const restRows = flatRows.slice(pinnedCount);
+  const restTotal = restRows.length;
+
+  // Index of the selected row within the scrollable tail (pinned rows are
+  // always visible, so a selection there needs no scroll).
+  const selectedRestIndex = restRows.findIndex(isSelectedRow);
 
   // When search is active, anchor the scroll window on the search hit
   // (searchHitId) so the highlighted row stays on-screen, rather than
   // the regular selection which may be elsewhere.
   const searchHitRestIndex =
-    searchHitId !== undefined
-      ? restRows.findIndex(
-          (row) => row.kind === "session" && row.session.id === searchHitId,
-        )
-      : -1;
+    searchHitId !== undefined ? restRows.findIndex(isSearchHitRow) : -1;
   const anchorRestIndex =
     searchHitRestIndex >= 0 ? searchHitRestIndex : selectedRestIndex;
 

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -1238,6 +1238,36 @@ describe("SessionTreePanel — sticky live projects", () => {
     expect(frame).toContain("6 cold"); // the cold tail (selected) scrolled into view
   });
 
+  it("scrolls within a tall live project when the cursor is deep inside it (top not frozen)", () => {
+    // Regression for the reported bug: with more sessions than fit, moving the
+    // cursor down into the active list must scroll the window to follow it. The
+    // sticky live-prefix must NOT pin the whole block when the SELECTION itself
+    // is inside that block — otherwise only the bottom row changes and the top
+    // stays frozen.
+    const sessions = Array.from({ length: 15 }, (_, i) =>
+      makeSession({
+        id: `sess${String(i).padStart(2, "0")}xx`,
+        status: "hot",
+        liveState: i === 0 ? "working" : null, // first session makes the project live
+        firstUserPrompt: i === 0 ? "TOPROW" : i === 10 ? "SELROW" : `row${i}`,
+        projectName: "liveproj",
+      }),
+    );
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[makeProject("liveproj", sessions)]}
+        coldProjects={[]}
+        selectedId="sess10xx"
+        hasFocus={true}
+        width={120}
+        maxRows={8}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("SELROW"); // the deep selected row is visible
+    expect(frame).not.toContain("TOPROW"); // the top row scrolled off (window followed the cursor)
+  });
+
   it("scrolls a selected cold row into view while the live project stays pinned", () => {
     const live = makeSession({
       id: "liveAAAA",


### PR DESCRIPTION
Closes #213

## Bug

In the Project tree, navigating ↓ stopped scrolling once a live project's block filled the pane: the top rows stayed frozen and only the bottom row changed as the cursor moved.

## Root cause

`SessionTreePanel` pins a sticky "live prefix" at the top. `pinnedCount` was `min(livePrefixCount, visibleCount - 1)` regardless of the cursor. When a live project's block was taller than the viewport this pinned `visibleCount - 1` rows, leaving a **one-row** scrollable tail — so moving the cursor only changed that single row.

## Fix

Make pinning cursor-aware. Pin the live prefix **only when the scroll anchor (search hit, else selection) is below it** — that is the feature's actual purpose: keep live work visible while browsing the cold/idle tail. When the anchor is **inside** the live prefix, the user is navigating the active list, so pin nothing and let the window follow the cursor (standard scrolling).

All three existing sticky-prefix tests select the cold sentinel (anchor below the prefix), so they still pin as before.

## Test

Failing-first regression test added (`SessionTreePanel — sticky live projects`): a live project taller than the viewport with the selection deep inside it asserts the selected row is visible and the top row scrolled off. Full suite 906 green, `tsc` clean, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sticky section pinning behavior to properly handle cases where user selection is within the sticky section, ensuring the viewport scrolls with the cursor.

* **Tests**
  * Added regression test for sticky live project scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->