### PR TITLE
feat(tree): sub-agents use a 5-minute hot window (not 30)

### DIFF
--- a/src/data/providers/claude.ts
+++ b/src/data/providers/claude.ts
@@ -51,7 +51,11 @@ import type {
   SessionStatus,
   SessionTree,
 } from "../../types/index.js";
-import { ONE_HOUR_MS, THIRTY_MINUTES_MS } from "../../utils/timeConstants.js";
+import {
+  FIVE_MINUTES_MS,
+  ONE_HOUR_MS,
+  THIRTY_MINUTES_MS,
+} from "../../utils/timeConstants.js";
 import { detectLiveState } from "../sessionLiveness.js";
 import { parseActivitiesFromLines, parseModelName } from "./claude-activity.js";
 import type { DiscoverOptions, SessionProvider } from "./types.js";
@@ -72,10 +76,16 @@ export function decodeProjectPath(encoded: string): string {
   return encoded.replace(/-/g, "/");
 }
 
-function getSessionStatus(mtimeMs: number): SessionStatus {
-  const now = Date.now();
+// Classify staleness from mtime. `hotThresholdMs` is the only axis that
+// differs between top-level sessions and sub-agents (see the two wrappers
+// below); warm/cool/cold are shared. `now` is injectable for tests.
+function classifyStatus(
+  mtimeMs: number,
+  hotThresholdMs: number,
+  now: number,
+): SessionStatus {
   const age = now - mtimeMs;
-  if (age < THIRTY_MINUTES_MS) return "hot";
+  if (age < hotThresholdMs) return "hot";
   if (age < ONE_HOUR_MS) return "warm";
 
   // Use UTC date comparison for timezone-consistent behavior.
@@ -89,6 +99,23 @@ function getSessionStatus(mtimeMs: number): SessionStatus {
     return "cool";
   }
   return "cold";
+}
+
+export function getSessionStatus(
+  mtimeMs: number,
+  now: number = Date.now(),
+): SessionStatus {
+  return classifyStatus(mtimeMs, THIRTY_MINUTES_MS, now);
+}
+
+// Sub-agents are typically one-shot: a finished sub-agent shouldn't read as
+// "hot" for half an hour. Give them a short (5-min) hot window; warm/cool/cold
+// thresholds match sessions.
+export function getSubAgentStatus(
+  mtimeMs: number,
+  now: number = Date.now(),
+): SessionStatus {
+  return classifyStatus(mtimeMs, FIVE_MINUTES_MS, now);
 }
 
 // Generous safety cap to keep arbitrarily long sub-agent task headers or
@@ -591,7 +618,7 @@ function buildSubAgents(
             projectPath: "",
             projectName: "",
             lastModifiedMs: stat.mtimeMs,
-            status: getSessionStatus(stat.mtimeMs),
+            status: getSubAgentStatus(stat.mtimeMs),
             modelName,
             subAgents: [],
             agentId: agentId ?? undefined,

--- a/src/utils/timeConstants.ts
+++ b/src/utils/timeConstants.ts
@@ -6,5 +6,6 @@
  * Keeping them here avoids a data → ui import.
  */
 
+export const FIVE_MINUTES_MS = 5 * 60 * 1000;
 export const THIRTY_MINUTES_MS = 30 * 60 * 1000;
 export const ONE_HOUR_MS = 60 * 60 * 1000;

--- a/tests/data/providers/claude-status.test.ts
+++ b/tests/data/providers/claude-status.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSessionStatus,
+  getSubAgentStatus,
+} from "../../../src/data/providers/claude.js";
+
+// Fixed "now" at UTC noon so same-day (cool) vs cold comparisons are stable.
+const NOW = Date.UTC(2026, 5, 23, 12, 0, 0);
+const minutesAgo = (m: number) => NOW - m * 60_000;
+
+describe("getSubAgentStatus — sub-agents use a short (5-min) hot window", () => {
+  it("is hot only within 5 minutes", () => {
+    expect(getSubAgentStatus(minutesAgo(2), NOW)).toBe("hot");
+    expect(getSubAgentStatus(minutesAgo(4), NOW)).toBe("hot");
+  });
+
+  it("is warm (not hot) once past 5 minutes — where a session would still be hot", () => {
+    expect(getSubAgentStatus(minutesAgo(10), NOW)).toBe("warm");
+    expect(getSubAgentStatus(minutesAgo(45), NOW)).toBe("warm");
+  });
+
+  it("falls to cool/cold by date after an hour, same as sessions", () => {
+    expect(getSubAgentStatus(minutesAgo(90), NOW)).toBe("cool"); // earlier same UTC day
+    expect(getSubAgentStatus(minutesAgo(60 * 30), NOW)).toBe("cold"); // 30h ago
+  });
+});
+
+describe("getSessionStatus — top-level sessions keep the 30-min hot window", () => {
+  it("stays hot up to 30 minutes", () => {
+    expect(getSessionStatus(minutesAgo(10), NOW)).toBe("hot");
+    expect(getSessionStatus(minutesAgo(29), NOW)).toBe("hot");
+  });
+
+  it("becomes warm between 30 and 60 minutes", () => {
+    expect(getSessionStatus(minutesAgo(45), NOW)).toBe("warm");
+  });
+});


### PR DESCRIPTION
Closes #214

## Problem

`getSessionStatus(mtimeMs)` applied the same thresholds to sessions and sub-agents (`<30min → hot`). Sub-agents are typically one-shot, so a finished sub-agent showed "hot" (green) for 30 minutes, overstating activity.

## Fix

Split the shared mtime classifier into a parameterized hot threshold:
- `getSessionStatus` — 30-min hot window (unchanged).
- `getSubAgentStatus` — **5-min** hot window; `warm` (<1h) / `cool` (same UTC day) / `cold` unchanged.

`buildSubAgents` now uses `getSubAgentStatus`. `now` is injectable on both for deterministic tests. `FIVE_MINUTES_MS` added to `timeConstants`.

## Test

New `tests/data/providers/claude-status.test.ts` (TDD, failing-first): sub-agent hot only <5min, warm at 10/45min (where a session is still hot), cool/cold by date; sessions still hot to 30min. Full suite 910 green, tsc + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)