### PR TITLE
feat(tree): collapse a revealed session from its child (← and Enter)

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -554,6 +554,45 @@ export function findParentTarget(
 }
 
 /**
+ * When the tree selection sits on a sub-agent that is only visible because
+ * its parent session is expanded (a cold session opened via Enter, or an
+ * alive session whose cool/cold sub-agents were revealed), return the parent
+ * id plus an `expandedIds` set with that reveal collapsed. Used by `←` and by
+ * Enter-on-a-child so the user can re-hide the revealed (cold) rows from where
+ * the cursor landed after expanding — otherwise Enter on a leaf sub-agent is a
+ * no-op and the only way back is to navigate up to the session row first.
+ *
+ * Returns null when the selection is not such a child, or when nothing extra
+ * is revealed (so the caller falls back to plain jump-to-parent / no-op).
+ */
+export function collapseTargetForChild(
+  selectedId: string,
+  tree: SessionTree,
+  expandedIds: Set<string>,
+): { parentId: string; nextExpandedIds: Set<string> } | null {
+  const allSessions = [
+    ...tree.projects.flatMap((p) => p.sessions),
+    ...tree.coldProjects.flatMap((p) => p.sessions),
+  ];
+  const parent = allSessions.find((s) =>
+    s.subAgents.some((sa) => sa.id === selectedId),
+  );
+  if (!parent) return null;
+
+  const isCold = parent.status === "cold";
+  const expandKey = `__expanded-session-${parent.id}`;
+  // Mirrors appendSubAgentRows' "subAgentsFullyExpanded" rule.
+  const fullyExpanded =
+    expandedIds.has(parent.id) || (isCold && expandedIds.has(expandKey));
+  if (!fullyExpanded) return null;
+
+  const next = new Set(expandedIds);
+  next.delete(parent.id); // alive: back to the cool/cold summary
+  next.delete(expandKey); // cold: hide the sub-agents again
+  return { parentId: parent.id, nextExpandedIds: next };
+}
+
+/**
  * Keep the tree selection on a row that is actually visible. The
  * `selectedId` is a stable id, but the flattened view it points into
  * changes underneath it — a refresh that cools the selected session into
@@ -1121,6 +1160,19 @@ export function App({
       if (focus !== "tree") return;
       stopTracking();
       if (!selectedId) return;
+      // On a revealed sub-agent, ← first collapses the parent's expansion
+      // (hiding the cold rows) and lands on the parent; only jump to the
+      // parent when there's nothing expanded to collapse.
+      const collapse = collapseTargetForChild(
+        selectedId,
+        displayTree,
+        expandedIds,
+      );
+      if (collapse) {
+        setExpandedIds(collapse.nextExpandedIds);
+        setSelectedId(collapse.parentId);
+        return;
+      }
       const target = findParentTarget(selectedId, displayTree, allFlat);
       if (target && target !== selectedId) setSelectedId(target);
     },
@@ -1423,6 +1475,20 @@ export function App({
           return next;
         });
         return;
+      }
+
+      // Enter on a leaf sub-agent that was revealed by expanding its parent:
+      // collapse that reveal (hide the cold rows) and return to the parent —
+      // the same as ← from here. Without this, Enter on a child is a no-op and
+      // the cold rows can't be re-hidden from where the cursor landed.
+      const collapse = collapseTargetForChild(
+        selectedId,
+        displayTree,
+        expandedIds,
+      );
+      if (collapse) {
+        setExpandedIds(collapse.nextExpandedIds);
+        setSelectedId(collapse.parentId);
       }
     },
     onHide: () => {

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -49,6 +49,7 @@ const {
   App,
   appendSubAgentRows,
   findParentTarget,
+  collapseTargetForChild,
   initialSelectedId,
   initialExpandedIds,
   filterTreeByHidden,
@@ -283,6 +284,90 @@ describe("appendSubAgentRows", () => {
     const result: SessionNode[] = [];
     appendSubAgentRows(result, session, new Set(["__collapsed-session-s1"]));
     expect(result).toEqual([]);
+  });
+});
+
+describe("collapseTargetForChild", () => {
+  const node = (
+    id: string,
+    status: SessionNode["status"],
+    subAgents: SessionNode[] = [],
+  ): SessionNode => ({
+    id,
+    hideKey: `p/${id}`,
+    filePath: `/tmp/${id}.jsonl`,
+    projectPath: "/tmp/p",
+    projectName: "p",
+    lastModifiedMs: 0,
+    status,
+    modelName: null,
+    subAgents,
+    nonInteractive: false,
+    firstUserPrompt: null,
+    liveState: null,
+  });
+  const treeWith = (
+    activeSessions: SessionNode[],
+    coldSessions: SessionNode[],
+  ): SessionTree => ({
+    projects: activeSessions.length
+      ? [
+          {
+            name: "p",
+            projectPath: "/tmp/p",
+            sessions: activeSessions,
+            hotness: "hot",
+          },
+        ]
+      : [],
+    coldProjects: coldSessions.length
+      ? [
+          {
+            name: "cp",
+            projectPath: "/tmp/cp",
+            sessions: coldSessions,
+            hotness: "cold",
+          },
+        ]
+      : [],
+    totalCount: activeSessions.length + coldSessions.length,
+    timestamp: new Date().toISOString(),
+    hiddenStats: { total: 0, active: 0 },
+  });
+
+  it("collapses a cold session's `__expanded-session-` reveal from a child sub-agent", () => {
+    const parent = node("p1", "cold", [node("a", "cold")]);
+    const tree = treeWith([], [parent]);
+    const result = collapseTargetForChild(
+      "a",
+      tree,
+      new Set(["__expanded-session-p1"]),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.parentId).toBe("p1");
+    expect(result?.nextExpandedIds.has("__expanded-session-p1")).toBe(false);
+  });
+
+  it("collapses an alive session's cool/cold reveal (bare id key) from a child", () => {
+    const parent = node("p2", "hot", [node("b", "cool")]);
+    const tree = treeWith([parent], []);
+    const result = collapseTargetForChild("b", tree, new Set(["p2"]));
+    expect(result?.parentId).toBe("p2");
+    expect(result?.nextExpandedIds.has("p2")).toBe(false);
+  });
+
+  it("returns null when the parent is not expanded (nothing extra to hide)", () => {
+    const parent = node("p3", "cold", [node("c", "cold")]);
+    const tree = treeWith([], [parent]);
+    expect(collapseTargetForChild("c", tree, new Set())).toBeNull();
+  });
+
+  it("returns null when the selected row is not a sub-agent", () => {
+    const parent = node("p4", "cold", [node("d", "cold")]);
+    const tree = treeWith([], [parent]);
+    expect(
+      collapseTargetForChild("p4", tree, new Set(["__expanded-session-p4"])),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #215

## Problem

Expanding a session reveals its sub-agents (including cold ones) and moves the selection onto the first child. From there:
- **Enter** on a leaf sub-agent was a no-op.
- **←** only jumped to the parent without collapsing.

So once expanded, there was no way to re-hide the cold rows from where the cursor landed.

## Fix

New pure helper `collapseTargetForChild(selectedId, tree, expandedIds)`: when the selection is a sub-agent whose parent session is currently revealing its sub-agents, it returns `{ parentId, nextExpandedIds }` with the reveal collapsed (mirrors `appendSubAgentRows` keys — bare `id` for alive sessions, `__expanded-session-<id>` for cold). Returns null otherwise.

Wired into both gestures (per the chosen "both"):
- **←** (`onJumpToParent`) collapses the parent's reveal and selects the parent; falls back to plain jump-to-parent when nothing is expanded.
- **Enter** (`onEnter`) collapses from a leaf child (previously a no-op).

## Test

TDD: `collapseTargetForChild` unit tests (cold reveal, alive cool/cold reveal, not-expanded → null, non-child → null) added failing-first. Full suite 915 green, tsc + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)