### PR TITLE
feat(tree): show only running sub-agents individually; group warm too

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -117,6 +117,17 @@ const subSummarySentinel = (parentId: string): SessionNode =>
   makeSentinel(`__sub-${parentId}__`);
 
 /**
+ * A sub-agent is "running" — and so shown individually in the tree — when it
+ * is hot or its live state is working/waiting. Sub-agents are one-shot, so a
+ * finished one (warm/cool/cold and not live) is folded into the summary.
+ * Duplicated in SessionTreePanel (display side); keep the two in sync.
+ */
+const isSubAgentRunning = (sub: SessionNode): boolean =>
+  sub.status === "hot" ||
+  sub.liveState === "working" ||
+  sub.liveState === "waiting";
+
+/**
  * Sentinel row for "N cold sessions" inside an active project.
  * Default collapsed: cold sessions are historical context, not
  * what the user is working on right now. Press Enter on the
@@ -161,16 +172,12 @@ export function appendSubAgentRows(
   if (subAgentsFullyExpanded) {
     result.push(...session.subAgents);
   } else {
-    result.push(
-      ...session.subAgents.filter(
-        (sub) => sub.status === "hot" || sub.status === "warm",
-      ),
-    );
-    if (
-      session.subAgents.some(
-        (sub) => sub.status === "cool" || sub.status === "cold",
-      )
-    ) {
+    // Only RUNNING sub-agents show individually — hot, or live working/waiting.
+    // Sub-agents are one-shot, so a finished one (warm/cool/cold) is clutter;
+    // fold warm in with cool/cold under the summary. Must match
+    // SessionTreePanel's `isSubAgentRunning` split.
+    result.push(...session.subAgents.filter(isSubAgentRunning));
+    if (session.subAgents.some((sub) => !isSubAgentRunning(sub))) {
       result.push(subSummarySentinel(session.id));
     }
   }

--- a/src/ui/SessionTreePanel.tsx
+++ b/src/ui/SessionTreePanel.tsx
@@ -179,6 +179,20 @@ export function isProjectAlive(project: ProjectNode): boolean {
   return false;
 }
 
+/**
+ * A sub-agent is "running" — shown individually in the tree — when it is hot
+ * or live working/waiting. One-shot sub-agents that have finished (warm/cool/
+ * cold and not live) fold into the summary. Mirror of App's `isSubAgentRunning`
+ * (nav side); keep the two in sync.
+ */
+function isSubAgentRunning(sub: SessionNode): boolean {
+  return (
+    sub.status === "hot" ||
+    sub.liveState === "working" ||
+    sub.liveState === "waiting"
+  );
+}
+
 function getStatusColor(status: SessionStatus): string {
   switch (status) {
     case "hot":
@@ -398,6 +412,7 @@ type FlatRow =
   | {
       kind: "subagent-summary";
       parentId: string;
+      warmCount: number;
       coolCount: number;
       coldCount: number;
     }
@@ -425,14 +440,18 @@ function appendSessionRows(
   const subAgentsFullyExpanded =
     expandedIds.has(session.id) ||
     (isCold && expandedIds.has(sessionExpandedKey));
-  const hotWarm = session.subAgents.filter(
-    (s) => s.status === "hot" || s.status === "warm",
+  // Only RUNNING sub-agents (hot or live working/waiting) show individually;
+  // finished ones — warm/cool/cold — fold into the summary. Must match App's
+  // `isSubAgentRunning` (nav side).
+  const running = session.subAgents.filter(isSubAgentRunning);
+  const warm = session.subAgents.filter(
+    (s) => !isSubAgentRunning(s) && s.status === "warm",
   );
   const cool = session.subAgents.filter((s) => s.status === "cool");
   const cold = session.subAgents.filter((s) => s.status === "cold");
 
   if (subAgentsFullyExpanded) {
-    const all = [...hotWarm, ...cool, ...cold];
+    const all = [...running, ...warm, ...cool, ...cold];
     for (let i = 0; i < all.length; i++) {
       const isLast = i === all.length - 1;
       result.push({
@@ -442,12 +461,12 @@ function appendSessionRows(
       });
     }
   } else {
-    const hasSummary = cool.length > 0 || cold.length > 0;
-    for (let i = 0; i < hotWarm.length; i++) {
-      const isLast = i === hotWarm.length - 1 && !hasSummary;
+    const hasSummary = warm.length > 0 || cool.length > 0 || cold.length > 0;
+    for (let i = 0; i < running.length; i++) {
+      const isLast = i === running.length - 1 && !hasSummary;
       result.push({
         kind: "session",
-        session: hotWarm[i],
+        session: running[i],
         prefix: `        ${isLast ? "└─ " : "├─ "}» `,
       });
     }
@@ -455,6 +474,7 @@ function appendSessionRows(
       result.push({
         kind: "subagent-summary",
         parentId: session.id,
+        warmCount: warm.length,
         coolCount: cool.length,
         coldCount: cold.length,
       });
@@ -691,12 +711,14 @@ function ProjectRow({
 }
 
 function SubagentSummaryRow({
+  warmCount,
   coolCount,
   coldCount,
   contentWidth,
   isSelected,
   hasFocus,
 }: {
+  warmCount: number;
   coolCount: number;
   coldCount: number;
   contentWidth: number;
@@ -704,6 +726,7 @@ function SubagentSummaryRow({
   hasFocus: boolean;
 }): React.ReactElement {
   const parts: string[] = [];
+  if (warmCount > 0) parts.push(`${warmCount} warm`);
   if (coolCount > 0) parts.push(`${coolCount} cool`);
   if (coldCount > 0) parts.push(`${coldCount} cold`);
   const baseText = `        └─ ... ${parts.join("  ")}`;
@@ -1189,6 +1212,7 @@ export function SessionTreePanel({
     ) : row.kind === "subagent-summary" ? (
       <SubagentSummaryRow
         key={key}
+        warmCount={row.warmCount}
         coolCount={row.coolCount}
         coldCount={row.coldCount}
         contentWidth={contentWidth}

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -254,7 +254,7 @@ describe("appendSubAgentRows", () => {
     expect(result.map((n) => n.id)).toEqual(["a", "b", "c"]);
   });
 
-  it("alive session default appends hot/warm sub-agents plus a sub-summary sentinel for the rest", () => {
+  it("alive session default shows only running sub-agents + a sub-summary sentinel for the rest", () => {
     const session = sessionWith("s1", "warm", [
       baseSubAgent("a", "hot"),
       baseSubAgent("b", "warm"),
@@ -262,7 +262,8 @@ describe("appendSubAgentRows", () => {
     ]);
     const result: SessionNode[] = [];
     appendSubAgentRows(result, session, new Set());
-    expect(result.map((n) => n.id)).toEqual(["a", "b", "__sub-s1__"]);
+    // Only the running (hot) sub-agent shows; warm + cold fold into the summary.
+    expect(result.map((n) => n.id)).toEqual(["a", "__sub-s1__"]);
   });
 
   it("alive session with session.id in expandedIds appends ALL sub-agents", () => {
@@ -283,6 +284,35 @@ describe("appendSubAgentRows", () => {
     const result: SessionNode[] = [];
     appendSubAgentRows(result, session, new Set(["__collapsed-session-s1"]));
     expect(result).toEqual([]);
+  });
+
+  it("shows only running (hot) sub-agents individually; groups warm under the summary", () => {
+    const session = sessionWith("s1", "hot", [
+      baseSubAgent("run", "hot"),
+      baseSubAgent("done", "warm"),
+      baseSubAgent("old", "cool"),
+    ]);
+    const result: SessionNode[] = [];
+    appendSubAgentRows(result, session, new Set());
+    const ids = result.map((n) => n.id);
+    expect(ids).toContain("run"); // running shown individually
+    expect(ids).not.toContain("done"); // finished (warm) now grouped
+    expect(ids).toContain("__sub-s1__"); // summary present
+  });
+
+  it("keeps a live (working) sub-agent individual even when its status is warm", () => {
+    const live = baseSubAgent("livewarm", "warm");
+    live.liveState = "working";
+    const session = sessionWith("s2", "hot", [
+      live,
+      baseSubAgent("done", "warm"),
+    ]);
+    const result: SessionNode[] = [];
+    appendSubAgentRows(result, session, new Set());
+    const ids = result.map((n) => n.id);
+    expect(ids).toContain("livewarm"); // live → shown despite warm
+    expect(ids).not.toContain("done"); // non-live warm → grouped
+    expect(ids).toContain("__sub-s2__");
   });
 });
 

--- a/tests/ui/SessionTreePanel.test.tsx
+++ b/tests/ui/SessionTreePanel.test.tsx
@@ -171,6 +171,54 @@ describe("SessionTreePanel", () => {
     expect(frame).toContain("2 cool");
   });
 
+  it("groups finished warm sub-agents into the summary (only running shown)", () => {
+    const session = makeSession({
+      subAgents: [
+        makeSession({ id: "run1", projectName: "", status: "hot" }),
+        makeSession({ id: "warm1", projectName: "", status: "warm" }),
+        makeSession({ id: "warm2", projectName: "", status: "warm" }),
+      ],
+    });
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[makeProject("myproject", [session])]}
+        coldProjects={[]}
+        selectedId={null}
+        hasFocus={false}
+        width={80}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("»"); // the running (hot) sub-agent shows individually
+    expect(frame).toContain("2 warm"); // finished warm ones folded into the summary
+  });
+
+  it("keeps a live (working) sub-agent individual even when warm", () => {
+    const session = makeSession({
+      subAgents: [
+        makeSession({
+          id: "livewarm",
+          projectName: "",
+          status: "warm",
+          liveState: "working",
+        }),
+        makeSession({ id: "donewarm", projectName: "", status: "warm" }),
+      ],
+    });
+    const { lastFrame } = render(
+      <SessionTreePanel
+        projects={[makeProject("myproject", [session])]}
+        coldProjects={[]}
+        selectedId={null}
+        hasFocus={false}
+        width={80}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("»"); // the live (working) sub-agent shows
+    expect(frame).toContain("1 warm"); // the finished warm one is grouped
+  });
+
   it("shows a 4-char short session ID for parent sessions with a project name", () => {
     const session = makeSession({ id: "abc12345", projectName: "myproject" });
     const project = makeProject("myproject", [session]);


### PR DESCRIPTION
Closes #219

## Problem

Under a working session, finished one-shot sub-agents still showed individually as `[warm]` (e.g. pain-radar `#9f4e` with ~9 warm rows at 49–59m). The tree listed **hot + warm** individually and only folded cool/cold. #214 shortened the *hot* window but warm sub-agents stayed visible, so nothing actually decluttered.

## Fix

Show only **running** sub-agents individually — `hot`, or `liveState` working/waiting. `warm` now folds in with `cool`/`cold` under the summary, which gains a `N warm` count.

`isSubAgentRunning` is defined on both sides that must agree — App's `appendSubAgentRows` (navigation list) and `SessionTreePanel` (display) — and kept in sync.

## Test

TDD, failing-first:
- `appendSubAgentRows`: running shown / warm grouped; a live (working) warm sub-agent stays individual. Existing "alive default" test updated to the new rule.
- `SessionTreePanel`: warm folded with a `2 warm` summary; live working warm stays shown.

Full suite 915 green, tsc + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)