### PR TITLE
feat(activity): drop never-executed (rejected) tool calls

### DIFF
--- a/src/data/providers/claude-activity.ts
+++ b/src/data/providers/claude-activity.ts
@@ -96,6 +96,45 @@ interface JsonlUserEntry {
   timestamp: string;
 }
 
+// Error-result texts that mean the tool call NEVER RAN — harness/permission/
+// user rejections (input validation, permission denial, user cancel, sandbox
+// block, session isolation, symlink refusal, classifier unavailable). Such
+// calls did no work, so their activity rows are dropped (see #222). Errors
+// NOT matching these (Bash non-zero exit, Edit precondition failures, etc.)
+// are kept — the tool ran and genuinely failed, which is real activity worth
+// seeing. Fail-open: an unrecognized error is kept, not hidden.
+const NEVER_EXECUTED_ERROR_PATTERNS = [
+  "InputValidationError:",
+  "Permission for this action was denied",
+  "The user doesn't want to proceed",
+  "Blocked:",
+  "This session is now isolated",
+  "Refusing to write through symlink",
+  "temporarily unavailable, so auto mode cannot determine",
+];
+
+function isNeverExecutedError(text: string): boolean {
+  return NEVER_EXECUTED_ERROR_PATTERNS.some((p) => text.includes(p));
+}
+
+/** A tool_result block's content is either a string or an array of
+ * `{ type: "text", text }` parts; flatten to a single string. */
+function toolResultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((c) =>
+        c &&
+        typeof c === "object" &&
+        typeof (c as { text?: unknown }).text === "string"
+          ? (c as { text: string }).text
+          : "",
+      )
+      .join(" ");
+  }
+  return "";
+}
+
 export function parseActivitiesFromLines(lines: string[]): ParseResult {
   const activities: ActivityEntry[] = [];
   let tokenCount = 0;
@@ -108,6 +147,10 @@ export function parseActivitiesFromLines(lines: string[]): ParseResult {
   // one tool_result per user entry (even for parallel tool calls each result
   // is its own entry), so the entry's single `toolUseResult` covers it.
   const resultsById = new Map<string, ToolUseResult>();
+  // tool_use_id → error text for results flagged `is_error` (the flag and text
+  // live on the tool_result BLOCK, separate from `toolUseResult`, and a
+  // rejected call may have no `toolUseResult` at all — so capture independently).
+  const errorTextById = new Map<string, string>();
   for (const line of lines) {
     let entry: {
       type?: string;
@@ -120,13 +163,21 @@ export function parseActivitiesFromLines(lines: string[]): ParseResult {
       continue;
     }
     if (entry.type !== "user") continue;
-    const tur = entry.toolUseResult;
-    if (!tur || typeof tur !== "object") continue;
     const content = entry.message?.content;
     if (!Array.isArray(content)) continue;
-    for (const b of content as Array<{ type?: string; tool_use_id?: string }>) {
+    const tur = entry.toolUseResult;
+    const turValid = !!tur && typeof tur === "object";
+    for (const b of content as Array<{
+      type?: string;
+      tool_use_id?: string;
+      is_error?: boolean;
+      content?: unknown;
+    }>) {
       if (b?.type === "tool_result" && typeof b.tool_use_id === "string") {
-        resultsById.set(b.tool_use_id, tur as ToolUseResult);
+        if (turValid) resultsById.set(b.tool_use_id, tur as ToolUseResult);
+        if (b.is_error === true) {
+          errorTextById.set(b.tool_use_id, toolResultText(b.content));
+        }
       }
     }
   }
@@ -196,6 +247,9 @@ export function parseActivitiesFromLines(lines: string[]): ParseResult {
             });
           } else if (block.type === "tool_use" && block.name) {
             if (block.name === "TodoWrite") continue;
+            // Drop calls that never ran (harness/permission/user rejection).
+            const errText = block.id ? errorTextById.get(block.id) : undefined;
+            if (errText && isNeverExecutedError(errText)) continue;
             const icon =
               (ICONS as Record<string, string>)[block.name] ?? ICONS.Default;
             const result = block.id ? resultsById.get(block.id) : undefined;

--- a/tests/data/activityParser.test.ts
+++ b/tests/data/activityParser.test.ts
@@ -281,3 +281,84 @@ describe("parseActivitiesFromLines", () => {
     expect(edit?.detailKind).toBeUndefined();
   });
 });
+
+describe("parseActivitiesFromLines — drop never-executed (is_error) tool calls", () => {
+  const assistantTool = (id: string, name: string, input: unknown) =>
+    JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "tool_use", id, name, input }] },
+      timestamp: "2025-01-15T10:00:00.000Z",
+    });
+  const errorResult = (id: string, content: string) =>
+    JSON.stringify({
+      type: "user",
+      toolUseResult: { stdout: "", stderr: "" },
+      message: {
+        content: [
+          { type: "tool_result", tool_use_id: id, is_error: true, content },
+        ],
+      },
+      timestamp: "2025-01-15T10:00:01.000Z",
+    });
+
+  it("drops an AskUserQuestion rejected by InputValidationError", () => {
+    const lines = [
+      assistantTool("t1", "AskUserQuestion", {}),
+      errorResult(
+        "t1",
+        "<tool_use_error>InputValidationError: AskUserQuestion failed due to the following issue:\nThe required parameter `questions` is missing</tool_use_error>",
+      ),
+    ];
+    const { activities } = parseActivitiesFromLines(lines);
+    expect(
+      activities.find((a) => a.label === "AskUserQuestion"),
+    ).toBeUndefined();
+  });
+
+  it("drops a harness-Blocked Bash call", () => {
+    const lines = [
+      assistantTool("t2", "Bash", { command: "sleep 45" }),
+      errorResult(
+        "t2",
+        "<tool_use_error>Blocked: sleep 45 followed by ...</tool_use_error>",
+      ),
+    ];
+    const { activities } = parseActivitiesFromLines(lines);
+    expect(activities.find((a) => a.label === "Bash")).toBeUndefined();
+  });
+
+  it("drops a permission-denied call", () => {
+    const lines = [
+      assistantTool("t2b", "Bash", { command: "rm -rf x" }),
+      errorResult(
+        "t2b",
+        "Permission for this action was denied by the Claude Code auto mode classifier.",
+      ),
+    ];
+    const { activities } = parseActivitiesFromLines(lines);
+    expect(activities.find((a) => a.label === "Bash")).toBeUndefined();
+  });
+
+  it("KEEPS a Bash that executed and failed (exit code)", () => {
+    const lines = [
+      assistantTool("t3", "Bash", { command: "npm test" }),
+      errorResult("t3", "Exit code 1\n5 tests failed"),
+    ];
+    const { activities } = parseActivitiesFromLines(lines);
+    const bash = activities.find((a) => a.label === "Bash");
+    expect(bash).toBeDefined();
+    expect(bash?.detail).toBe("npm test");
+  });
+
+  it("KEEPS an Edit that ran its precondition check and failed", () => {
+    const lines = [
+      assistantTool("t4", "Edit", { file_path: "/src/a.ts" }),
+      errorResult(
+        "t4",
+        "<tool_use_error>String to replace not found in file.</tool_use_error>",
+      ),
+    ];
+    const { activities } = parseActivitiesFromLines(lines);
+    expect(activities.find((a) => a.label === "Edit")).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #222

## Problem

agenthud ignored `is_error` entirely, so tool calls that were **rejected before running** leaked into the activity stream — most visibly an `AskUserQuestion` fired without its required `questions` (→ `InputValidationError`) rendered as a **blank row**.

## Fix

`is_error: true` covers two cases, handled differently:
- **Never executed → dropped.** Harness/permission/user rejections (input validation, permission/auto-mode denial, user cancel, `Blocked:` sandbox, session isolation, symlink refusal, classifier-unavailable). No work happened → not activity.
- **Executed then failed → kept** (unchanged). Bash non-zero exit, Edit precondition failures (`String to replace not found`, …) — the tool ran and genuinely failed; real activity worth seeing in agenthud.

Classification is by error-text deny-list (no clean structural flag — both kinds use the `<tool_use_error>` wrapper). **Fail-open**: an `is_error` result matching no deny-list pattern is kept, not hidden.

Plumbing: the pre-pass now captures `is_error` + error text per `tool_use_id` (the flag/text live on the tool_result *block*, separate from `toolUseResult`, and a rejected call may carry no `toolUseResult`); the main pass skips rows whose error matches the deny-list. On the shared `parseActivitiesFromLines` path, so TUI viewer + `report`/`summary` all drop them consistently.

## Test

TDD: drop AskUserQuestion/InputValidationError, harness-`Blocked` Bash, permission-denied; keep Bash exit-code failure and Edit precondition failure. Full suite 924 green, tsc + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool activity timelines now skip tool calls that never actually ran, reducing misleading entries.
  * Tool failures that did execute are still shown, including cases like command errors and failed checks.
  * Activity parsing is now more accurate when handling error responses from tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->