### PR TITLE
feat(search): seed Detail body search from a viewer-search hit

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -76,6 +76,7 @@ import { SessionTreePanel } from "./SessionTreePanel.js";
 import { activityMatches } from "./search/activityMatch.js";
 import { detailMatchLines } from "./search/detailMatches.js";
 import { edgeScrollWindowStart } from "./search/edgeScroll.js";
+import { hasMatch } from "./search/matcher.js";
 import { SearchInput } from "./search/SearchInput.js";
 import type { SearchState } from "./search/searchKey.js";
 import { applyDetailSearchKey } from "./search/searchKey.js";
@@ -597,6 +598,26 @@ export function collapseTargetForChild(
   next.delete(parent.id); // alive: back to the cool/cold summary
   next.delete(expandKey); // cold: hide the sub-agents again
   return { parentId: parent.id, nextExpandedIds: next };
+}
+
+/**
+ * When a Viewer-search hit is opened into the Detail View, carry the query
+ * into a committed Detail body search so the user lands on the matched text
+ * (the Viewer matches the full one-line `detail`, but the match is often
+ * past the truncated row and buried in a long body — see #224). Returns the
+ * Detail SearchState to seed, or null when the body doesn't contain the query
+ * (e.g. the Viewer matched the one-line summary of a tool whose body differs),
+ * in which case the Detail opens with no search. The body searched mirrors
+ * `detailRawLines` (`detailBody ?? detail`).
+ */
+export function seededDetailSearch(
+  act: ActivityEntry,
+  query: string,
+): SearchState | null {
+  if (!query) return null;
+  const body = act.detailBody ?? act.detail ?? "";
+  if (!hasMatch(body, query)) return null;
+  return { surface: "detail", query, index: 0, committed: true };
 }
 
 /**
@@ -1647,6 +1668,7 @@ export function App({
             return;
           }
           // Navigated to a specific match → open its Detail View.
+          let seeded: SearchState | null = null;
           if (hits.length > 0) {
             const safeIndex =
               ((search.index % hits.length) + hits.length) % hits.length;
@@ -1665,10 +1687,15 @@ export function App({
               setIsLive(false);
               setScrollOffset(newScrollOffset);
               const act = mergedActivities[hitIndex];
-              if (act) openActivityDetail(act);
+              if (act) {
+                openActivityDetail(act);
+                // Carry the query into the Detail so the user lands on the
+                // matched text (the row only shows the truncated head).
+                seeded = seededDetailSearch(act, search.query);
+              }
             }
           }
-          setSearch(null);
+          setSearch(seeded);
           return;
         }
         if (key.delete || key.backspace) {

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -50,6 +50,7 @@ const {
   appendSubAgentRows,
   findParentTarget,
   collapseTargetForChild,
+  seededDetailSearch,
   initialSelectedId,
   initialExpandedIds,
   filterTreeByHidden,
@@ -398,6 +399,52 @@ describe("collapseTargetForChild", () => {
     expect(
       collapseTargetForChild("p4", tree, new Set(["__expanded-session-p4"])),
     ).toBeNull();
+  });
+});
+
+describe("seededDetailSearch", () => {
+  const act = (over: Partial<ActivityEntry>): ActivityEntry => ({
+    timestamp: new Date(),
+    type: "tool",
+    icon: "○",
+    label: "Tool",
+    detail: "",
+    ...over,
+  });
+
+  it("seeds a committed detail search when the body (detail) contains the query", () => {
+    // user/thinking-style entry: no detailBody, detail = full text
+    const a = act({
+      type: "thinking",
+      label: "Thinking",
+      detail: "first line\n...lean on the AskUserQuestion tool to surface...",
+    });
+    const seed = seededDetailSearch(a, "AskUserQuestion");
+    expect(seed).toEqual({
+      surface: "detail",
+      query: "AskUserQuestion",
+      index: 0,
+      committed: true,
+    });
+  });
+
+  it("uses detailBody as the body when present", () => {
+    const a = act({
+      detail: "npm test",
+      detailBody: "line 1\nFAIL auth.test.ts\nline 3",
+    });
+    expect(seededDetailSearch(a, "FAIL")?.surface).toBe("detail");
+  });
+
+  it("returns null when the body lacks the query (matched only the one-line detail)", () => {
+    // Viewer matched the one-line `detail`, but the Detail body is detailBody
+    // which doesn't contain it → don't seed an empty search.
+    const a = act({ detail: "run modal", detailBody: "alpha\nbeta\ngamma" });
+    expect(seededDetailSearch(a, "modal")).toBeNull();
+  });
+
+  it("returns null for an empty query", () => {
+    expect(seededDetailSearch(act({ detail: "x" }), "")).toBeNull();
   });
 });
 
@@ -1272,6 +1319,86 @@ describe("viewer search → Enter opens Detail View", () => {
     expect(lastFrame() ?? "").toContain("1/2");
     expect(lastFrame() ?? "").not.toContain("READ_MARKER");
     expect(lastFrame() ?? "").not.toContain("WRITE_MARKER");
+  });
+
+  it("navigated Enter seeds the Detail body search with the query (jumps to the match)", async () => {
+    mockTree = {
+      projects: [
+        {
+          name: "proj",
+          projectPath: "/tmp/proj",
+          hotness: "hot",
+          sessions: [
+            {
+              id: "s1",
+              hideKey: "proj/s1",
+              filePath: "/tmp/proj/s1.jsonl",
+              projectPath: "/tmp/proj",
+              projectName: "proj",
+              lastModifiedMs: Date.now(),
+              status: "hot",
+              modelName: null,
+              subAgents: [],
+              nonInteractive: false,
+              firstUserPrompt: "do auth",
+              liveState: null,
+            },
+          ],
+        },
+      ],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
+    };
+    // Query "config" matches the one-line detail (viewer) AND appears once deep
+    // in the body, so opening the Detail should seed a committed body search.
+    mockActivities = [
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 0),
+        type: "tool",
+        icon: "○",
+        label: "Read",
+        detail: "config.ts",
+        detailBody: "line A\nline B\nuse config here SEED_MARKER\nline D",
+        detailKind: "code",
+      },
+    ];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("config.ts"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\t");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("/");
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("0/0"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    for (const ch of "config") {
+      stdin.write(ch);
+      await tick();
+    }
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/1"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write(DOWN); // mark navigated (single match → index stays 0)
+    await tick();
+    stdin.write("\r"); // Enter → open Detail, seeded with "config"
+
+    // Detail open, the matched line jumped into view, and the seeded body
+    // search is active (the `/config` prompt with its own count is shown).
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("SEED_MARKER"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    expect(lastFrame() ?? "").toContain("/config");
   });
 
   it("Detail's own search resets on Esc without losing the saved viewer search", async () => {

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -1351,22 +1351,34 @@ describe("viewer search → Enter opens Detail View", () => {
       timestamp: new Date().toISOString(),
       hiddenStats: { total: 0, active: 0 },
     };
-    // Query "config" matches the one-line detail (viewer) AND appears once deep
-    // in the body, so opening the Detail should seed a committed body search.
+    // Two activities both matching "config" in the one-line detail, so ↓
+    // advances the count 1/2 → 2/2 (observable — lets the test wait for the
+    // navigated flag to commit before Enter; a single match leaves it 1/1 and
+    // races, exactly the #209 trap). The 2nd carries "config" in its body so
+    // opening it seeds a committed body search.
     mockActivities = [
       {
         timestamp: new Date(2026, 0, 1, 9, 0, 0),
         type: "tool",
         icon: "○",
         label: "Read",
-        detail: "config.ts",
-        detailBody: "line A\nline B\nuse config here SEED_MARKER\nline D",
+        detail: "config one",
+        detailBody: "irrelevant body",
+        detailKind: "code",
+      },
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 1),
+        type: "tool",
+        icon: "○",
+        label: "Read",
+        detail: "config two",
+        detailBody: "line A\nuse config here SEED_MARKER\nline C",
         detailKind: "code",
       },
     ];
 
     const { stdin, lastFrame } = render(<App mode="watch" />);
-    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("config.ts"), {
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("config two"), {
       timeout: 3000,
       interval: 25,
     });
@@ -1384,13 +1396,16 @@ describe("viewer search → Enter opens Detail View", () => {
       stdin.write(ch);
       await tick();
     }
-    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/1"), {
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1/2"), {
       timeout: 3000,
       interval: 25,
     });
-    stdin.write(DOWN); // mark navigated (single match → index stays 0)
-    await tick();
-    stdin.write("\r"); // Enter → open Detail, seeded with "config"
+    stdin.write(DOWN); // ↓ → 2nd match; wait for the count to commit
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("2/2"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("\r"); // Enter → open the 2nd match's Detail, seeded with "config"
 
     // Detail open, the matched line jumped into view, and the seeded body
     // search is active (the `/config` prompt with its own count is shown).


### PR DESCRIPTION
Closes #224

## Problem

The Viewer search matches a row's **full one-line `detail`** (correct), but the matched term is usually beyond the truncated row — and buried in a long body in the Detail View too. A hit looks unexplained. Verified: `AskUserQuestion` matched a Thinking block at char **1010/1429** and a skill-doc User message at offset **4953/477789** — all real, all invisible.

## Fix

On a **navigated Enter** that opens the Detail from an active viewer search, **seed a committed Detail body search with the same query**, so the view jumps to and highlights the match (`DetailViewPanel` already scrolls to `activeMatchLine`). Layered Esc is unchanged: first Esc clears the seeded search (stay in Detail), second closes the Detail and restores the viewer search (#210/#215).

`seededDetailSearch(act, query)` returns `null` when the body (`detailBody ?? detail`) doesn't contain the query — e.g. the viewer matched a tool's one-line summary, not its body — so the Detail opens with **no empty search** (no `0/0`). Fail-soft.

## Test

- `seededDetailSearch` unit tests: seeds when body contains the query (detail or detailBody); null when body lacks it / empty query.
- Integration: viewer-search a term present deep in `detailBody` → navigated Enter → Detail jumps to the match (`SEED_MARKER` visible) with the `/query` search active.
- Existing round-trip/layering tests still pass (their queries aren't in the bodies → no seed, unchanged behaviour).

Full suite 929 green, tsc + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When opening a matched item from viewer search, the Detail view now carries over the search term and highlights matching body content automatically.

* **Bug Fixes**
  * Improved search behavior so matches in the detailed content are preserved instead of clearing the search state after opening the Detail view.
  * Increased UI test timeout to reduce flaky failures on slower environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->