### PR TITLE
feat(tree): sub-agent black-box summary header in the viewer (P1)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-subagent-cards.md
+++ b/docs/superpowers/plans/2026-06-30-subagent-cards.md
@@ -1,0 +1,512 @@
+# Sub-agent Black-Box Cards (P1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a **sub-agent** is selected, the Activity Viewer shows a summary header (status · steps · duration · intent · result) above the existing activity stream; main sessions are unchanged.
+
+**Architecture:** A pure `buildSubAgentSummary(node, activities)` derives the summary from already-parsed data; `App` computes it for the selected node and passes it to `ActivityViewerPanel`, which renders a few header rows above the (existing) stream when the prop is present.
+
+**Tech Stack:** TypeScript, React, Ink, Vitest, ink-testing-library, Biome.
+
+## Global Constraints
+
+- All source/comments/commit messages/docs in **English**.
+- Run `npx biome check --write <files>` before every commit (CI lints whole-repo Biome).
+- TDD: write the failing test first, see it fail for the right reason, then implement.
+- Never commit to `main` — work on branch `feat/226-subagent-cards`.
+- **Zero new data collection.** Use only existing fields: `SessionNode.{agentId, taskDescription, modelName, liveState, status}` and the selected node's already-parsed `ActivityEntry[]`.
+- **isSubAgent ≡ `node.agentId` is set** (main sessions have no `agentId`).
+- **status is `running | done` only** — `running` when `liveState === "working"`, else `done`. No `failed` (no reliable signal; deferred per the spec).
+- **steps = count of `activities` with `type === "tool"`** (tool-call count, not turns).
+- **duration = last activity `timestamp` − first activity `timestamp`** (run length); `null` when fewer than 2 activities.
+- **result = the last activity with `type === "response"`** (its `detail`); `""` when none.
+- Sub-agent header applies to the **non-search** viewer render only; the viewer narrow-finder path is unchanged.
+
+## File Structure
+
+- `src/ui/subAgentSummary.ts` — **new**. Pure: `SubAgentSummary` type, `buildSubAgentSummary`, `formatDuration`. No React, no `App` import.
+- `src/ui/ActivityViewerPanel.tsx` — **modify**. New optional `subAgentSummary` prop; render header rows above the stream when set.
+- `src/ui/App.tsx` — **modify**. Compute the summary for the selected node and pass it to the panel.
+- Tests: `tests/ui/subAgentSummary.test.ts` (new), `tests/ui/ActivityViewerPanel.test.tsx`, `tests/ui/App.test.tsx`.
+
+---
+
+### Task 1: `buildSubAgentSummary` + `formatDuration` (pure)
+
+**Files:**
+- Create: `src/ui/subAgentSummary.ts`
+- Test: `tests/ui/subAgentSummary.test.ts`
+
+**Interfaces:**
+- Consumes: `SessionNode`, `ActivityEntry` from `../types/index.js`.
+- Produces:
+  - `interface SubAgentSummary { status: "running" | "done"; steps: number; durationMs: number | null; intent: string; result: string; model: string | null }`
+  - `buildSubAgentSummary(node: SessionNode, activities: ActivityEntry[]): SubAgentSummary | null` — `null` when `!node.agentId`.
+  - `formatDuration(ms: number): string` — e.g. `5s`, `2m14s`, `1h1m`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ui/subAgentSummary.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { ActivityEntry, SessionNode } from "../../src/types/index.js";
+import {
+  buildSubAgentSummary,
+  formatDuration,
+} from "../../src/ui/subAgentSummary.js";
+
+const node = (over: Partial<SessionNode> = {}): SessionNode => ({
+  id: "id1",
+  hideKey: "p/id1",
+  filePath: "/tmp/id1.jsonl",
+  projectPath: "/tmp/p",
+  projectName: "p",
+  lastModifiedMs: 0,
+  status: "hot",
+  modelName: "sonnet-4.6",
+  subAgents: [],
+  nonInteractive: false,
+  firstUserPrompt: null,
+  liveState: null,
+  ...over,
+});
+
+const tool = (ms: number): ActivityEntry => ({
+  timestamp: new Date(ms),
+  type: "tool",
+  icon: "○",
+  label: "Read",
+  detail: "x.ts",
+});
+const response = (ms: number, text: string): ActivityEntry => ({
+  timestamp: new Date(ms),
+  type: "response",
+  icon: "✦",
+  label: "Response",
+  detail: text,
+});
+
+describe("buildSubAgentSummary", () => {
+  it("returns null for a main session (no agentId)", () => {
+    expect(buildSubAgentSummary(node(), [tool(0)])).toBeNull();
+  });
+
+  it("derives steps, duration, result, intent for a finished sub-agent", () => {
+    const acts = [tool(1000), tool(2000), response(5000, "All done")];
+    const s = buildSubAgentSummary(
+      node({ agentId: "agent-abc", taskDescription: "Do the thing" }),
+      acts,
+    );
+    expect(s).toEqual({
+      status: "done",
+      steps: 2,
+      durationMs: 4000,
+      intent: "Do the thing",
+      result: "All done",
+      model: "sonnet-4.6",
+    });
+  });
+
+  it("reports running when liveState is working", () => {
+    const s = buildSubAgentSummary(
+      node({ agentId: "a", liveState: "working" }),
+      [tool(0)],
+    );
+    expect(s?.status).toBe("running");
+  });
+
+  it("handles 0 and 1 activities (null duration, empty result)", () => {
+    expect(
+      buildSubAgentSummary(node({ agentId: "a" }), []),
+    ).toMatchObject({ steps: 0, durationMs: null, result: "" });
+    expect(
+      buildSubAgentSummary(node({ agentId: "a" }), [tool(10)]),
+    ).toMatchObject({ steps: 1, durationMs: null });
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats seconds, minutes, hours", () => {
+    expect(formatDuration(5000)).toBe("5s");
+    expect(formatDuration(134000)).toBe("2m14s");
+    expect(formatDuration(3_660_000)).toBe("1h1m");
+  });
+});
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `npx vitest run tests/ui/subAgentSummary.test.ts`
+Expected: FAIL — `buildSubAgentSummary`/`formatDuration` not found (module missing).
+
+- [ ] **Step 3: Implement**
+
+Create `src/ui/subAgentSummary.ts`:
+
+```ts
+/**
+ * Derive a sub-agent's "black-box" summary (intent → status/steps/duration →
+ * result) from data already on the node and its parsed activity stream. Pure;
+ * returns null for main sessions (which have no agentId and keep full detail).
+ */
+import type { ActivityEntry, SessionNode } from "../types/index.js";
+
+export interface SubAgentSummary {
+  status: "running" | "done";
+  steps: number;
+  durationMs: number | null;
+  intent: string;
+  result: string;
+  model: string | null;
+}
+
+export function buildSubAgentSummary(
+  node: SessionNode,
+  activities: ActivityEntry[],
+): SubAgentSummary | null {
+  if (!node.agentId) return null;
+  const steps = activities.filter((a) => a.type === "tool").length;
+  const durationMs =
+    activities.length >= 2
+      ? activities[activities.length - 1].timestamp.getTime() -
+        activities[0].timestamp.getTime()
+      : null;
+  let result = "";
+  for (let i = activities.length - 1; i >= 0; i--) {
+    if (activities[i].type === "response") {
+      result = activities[i].detail;
+      break;
+    }
+  }
+  return {
+    status: node.liveState === "working" ? "running" : "done",
+    steps,
+    durationMs,
+    intent: node.taskDescription ?? "",
+    result,
+    model: node.modelName,
+  };
+}
+
+export function formatDuration(ms: number): string {
+  const secs = Math.max(0, Math.round(ms / 1000));
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  if (h > 0) return `${h}h${m}m`;
+  if (m > 0) return `${m}m${s}s`;
+  return `${s}s`;
+}
+```
+
+- [ ] **Step 4: Run it — verify it passes**
+
+Run: `npx vitest run tests/ui/subAgentSummary.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+npx biome check --write src/ui/subAgentSummary.ts tests/ui/subAgentSummary.test.ts
+git add src/ui/subAgentSummary.ts tests/ui/subAgentSummary.test.ts
+git commit -m "feat(subagent): pure buildSubAgentSummary + formatDuration (#226)"
+```
+
+---
+
+### Task 2: Render the summary header in `ActivityViewerPanel`
+
+**Files:**
+- Modify: `src/ui/ActivityViewerPanel.tsx` (props interface; the non-search render tail)
+- Test: `tests/ui/ActivityViewerPanel.test.tsx`
+
+**Interfaces:**
+- Consumes: `SubAgentSummary`, `formatDuration` from `./subAgentSummary.js` (Task 1).
+- Produces: `ActivityViewerPanelProps.subAgentSummary?: SubAgentSummary | null`. When set, the panel renders header rows (chip + intent, optional result, an `─ activity (↵ drill in)` divider) above the stream and shrinks the stream's row budget so the box height is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/ui/ActivityViewerPanel.test.tsx`:
+
+```ts
+describe("ActivityViewerPanel — sub-agent summary header", () => {
+  const summary = {
+    status: "done" as const,
+    steps: 3,
+    durationMs: 134000,
+    intent: "Research the thing",
+    result: "Recommends option B",
+    model: "sonnet-4.6",
+  };
+
+  it("renders the header (intent/result/steps) when subAgentSummary is set", () => {
+    const { lastFrame } = render(
+      <ActivityViewerPanel
+        {...baseProps}
+        activities={[makeActivity("Read", 0)]}
+        subAgentSummary={summary}
+      />,
+    );
+    const out = lastFrame() ?? "";
+    expect(out).toContain("Research the thing"); // intent
+    expect(out).toContain("3 steps"); // metric chip
+    expect(out).toContain("Recommends option B"); // result
+    expect(out).toContain("activity"); // divider label
+    expect(out).toContain("Read"); // stream still present below
+  });
+
+  it("renders no header for a main session (prop absent)", () => {
+    const { lastFrame } = render(
+      <ActivityViewerPanel
+        {...baseProps}
+        activities={[makeActivity("Read", 0)]}
+      />,
+    );
+    const out = lastFrame() ?? "";
+    expect(out).not.toContain("3 steps");
+    expect(out).not.toContain("↵ drill in");
+  });
+});
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `npx vitest run tests/ui/ActivityViewerPanel.test.tsx -t "sub-agent summary header"`
+Expected: FAIL — header text (`Research the thing`, `3 steps`) absent (prop ignored).
+
+- [ ] **Step 3: Add the prop + import**
+
+In `src/ui/ActivityViewerPanel.tsx`, add the import near the other local imports:
+
+```ts
+import type { SubAgentSummary } from "./subAgentSummary.js";
+import { formatDuration } from "./subAgentSummary.js";
+```
+
+Add to `ActivityViewerPanelProps` (after `searchWindowStart?`):
+
+```ts
+  /** When the selected node is a sub-agent, its black-box summary; renders a
+   * header above the (demoted) activity stream. Absent for main sessions. */
+  subAgentSummary?: SubAgentSummary | null;
+```
+
+Add `subAgentSummary` to the destructured parameters of the component (alongside `searchWindowStart`).
+
+- [ ] **Step 4: Build the header rows and shrink the stream budget**
+
+In the **non-search** render tail (the block that starts with `let visibleActivities` / `if (activities.length === 0)` near the end of the component), insert BEFORE `let visibleActivities`:
+
+```tsx
+  // Sub-agent black-box header (P1): fixed rows above the stream. The stream's
+  // row budget shrinks by the header height so the box stays `visibleRows` tall.
+  const headerLines: React.ReactElement[] = [];
+  if (subAgentSummary) {
+    const s = subAgentSummary;
+    const boxRow = (key: string, text: string) => {
+      const t = truncateByWidth(text, contentWidth - 1);
+      const pad = Math.max(0, contentWidth - 1 - getDisplayWidth(t));
+      return (
+        <Text key={key}>
+          {BOX.v} {t}
+          {" ".repeat(pad)}
+          {BOX.v}
+        </Text>
+      );
+    };
+    const dur = s.durationMs === null ? "" : ` · ${formatDuration(s.durationMs)}`;
+    const model = s.model ? ` · ${s.model}` : "";
+    const chip = `${s.status} · ${s.steps} steps${dur}${model}`;
+    headerLines.push(boxRow("sa-chip", `${chip}  ${s.intent}`.trimEnd()));
+    if (s.result) {
+      headerLines.push(
+        boxRow("sa-result", `Result: ${s.result.replace(/\s+/g, " ").trim()}`),
+      );
+    }
+    headerLines.push(boxRow("sa-div", "─ activity (↵ drill in)"));
+  }
+  const streamRows = Math.max(1, visibleRows - headerLines.length);
+```
+
+Then, in that same tail, replace the three `visibleRows` uses that bound the stream with `streamRows`:
+
+```tsx
+  let visibleActivities: ActivityEntry[];
+  if (activities.length === 0) {
+    visibleActivities = [];
+  } else if (isLive) {
+    visibleActivities = activities.slice(-streamRows);
+  } else {
+    const end = Math.max(0, activities.length - scrollOffset);
+    const start = Math.max(0, end - streamRows);
+    visibleActivities = activities.slice(start, end);
+  }
+```
+
+and the padding:
+
+```tsx
+  const padCount = Math.max(0, streamRows - lines.length);
+```
+
+and prepend the header to the final content:
+
+```tsx
+  const finalLines = [...headerLines, ...padded, ...lines];
+```
+
+(The `return (...)` block is unchanged — it already renders `{finalLines}` between the title and bottom lines.)
+
+- [ ] **Step 5: Run it — verify it passes**
+
+Run: `npx vitest run tests/ui/ActivityViewerPanel.test.tsx -t "sub-agent summary header"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the whole panel suite (regression) + lint + commit**
+
+```bash
+npx vitest run tests/ui/ActivityViewerPanel.test.tsx
+npx biome check --write src/ui/ActivityViewerPanel.tsx tests/ui/ActivityViewerPanel.test.tsx
+git add src/ui/ActivityViewerPanel.tsx tests/ui/ActivityViewerPanel.test.tsx
+git commit -m "feat(subagent): viewer renders the sub-agent summary header (#226)"
+```
+
+Expected: panel suite green (main-session renders unchanged).
+
+---
+
+### Task 3: Wire the summary in `App` for the selected node
+
+**Files:**
+- Modify: `src/ui/App.tsx` (import; compute `subAgentSummary`; pass the prop)
+- Test: `tests/ui/App.test.tsx`
+
+**Interfaces:**
+- Consumes: `buildSubAgentSummary` (Task 1); `ActivityViewerPanel.subAgentSummary` prop (Task 2); existing `selectedSession` (the resolved selected `SessionNode`) and `mergedActivities`.
+- Produces: the viewer receives a real summary when a sub-agent is selected, `null` otherwise.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new top-level `describe` in `tests/ui/App.test.tsx` (the file already mocks `parseSessionHistory` → `mockActivities` and `discoverSessions` → `mockTree`, and sets `vi.setConfig({ testTimeout: 20000 })`):
+
+```ts
+describe("App — sub-agent viewer summary header", () => {
+  const tick = () => new Promise((r) => setTimeout(r, 50));
+  const DOWN = String.fromCharCode(27) + "[B"; // ESC prefix REQUIRED (see prior CI fixes)
+
+  it("shows the intent header when a sub-agent row is selected", async () => {
+    mockTree = {
+      projects: [
+        {
+          name: "proj",
+          projectPath: "/tmp/proj",
+          hotness: "hot",
+          sessions: [
+            {
+              id: "s1", hideKey: "proj/s1", filePath: "/tmp/proj/s1.jsonl",
+              projectPath: "/tmp/proj", projectName: "proj",
+              lastModifiedMs: Date.now(), status: "hot", modelName: "sonnet-4.6",
+              nonInteractive: false, firstUserPrompt: "parent", liveState: null,
+              subAgents: [
+                {
+                  id: "a1", hideKey: "proj/a1", filePath: "/tmp/proj/a1.jsonl",
+                  projectPath: "/tmp/proj", projectName: "", lastModifiedMs: Date.now(),
+                  status: "hot", modelName: "sonnet-4.6", subAgents: [],
+                  nonInteractive: false, firstUserPrompt: null, liveState: "working",
+                  agentId: "agent-abc123", taskDescription: "DO_THE_THING",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
+    };
+    mockActivities = [
+      { timestamp: new Date(2026, 0, 1, 9, 0, 0), type: "tool", icon: "○", label: "Read", detail: "x.ts" },
+      { timestamp: new Date(2026, 0, 1, 9, 0, 2), type: "response", icon: "✦", label: "Response", detail: "RESULT_TEXT" },
+    ];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    // Tree is focused at boot; selection starts on the project sentinel.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: expand"), {
+      timeout: 3000, interval: 25,
+    });
+    // ↓ to the session, ↓ to the (running) sub-agent row.
+    stdin.write(DOWN);
+    await tick();
+    stdin.write(DOWN);
+    // The summary header (intent) only renders when the sub-agent is selected.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("DO_THE_THING"), {
+      timeout: 5000, interval: 25,
+    });
+    expect(lastFrame() ?? "").toContain("1 steps"); // metric chip (header-only)
+  });
+});
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "sub-agent viewer summary header"`
+Expected: FAIL — `DO_THE_THING` never appears (App doesn't compute/pass the summary).
+
+- [ ] **Step 3: Implement the wiring**
+
+In `src/ui/App.tsx`, add the import near the other `./` imports:
+
+```ts
+import { buildSubAgentSummary } from "./subAgentSummary.js";
+```
+
+Compute the summary just before the JSX return (near where `selectedSession` and `mergedActivities` are both in scope — `selectedSession` is the resolved node assigned around `const rawSelected = allFlat.find(...)` / `let selectedSession = rawSelected;`):
+
+```ts
+  const subAgentSummary = selectedSession
+    ? buildSubAgentSummary(selectedSession, mergedActivities)
+    : null;
+```
+
+Pass it to the panel — add this prop inside the existing `<ActivityViewerPanel ... />` (e.g. after `searchWindowStart={...}`):
+
+```tsx
+                subAgentSummary={subAgentSummary}
+```
+
+- [ ] **Step 4: Run it — verify it passes**
+
+Run: `npx vitest run tests/ui/App.test.tsx -t "sub-agent viewer summary header"`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + typecheck + lint + commit**
+
+```bash
+npx vitest run
+npx tsc --noEmit
+npx biome check --write src/ui/App.tsx tests/ui/App.test.tsx
+git add src/ui/App.tsx tests/ui/App.test.tsx
+git commit -m "feat(subagent): App passes the sub-agent summary to the viewer (#226)"
+```
+
+Expected: full suite green, tsc clean.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Summary header (intent/status/steps/duration/result/model) → Task 1 (data) + Task 2 (render).
+- isSubAgent ≡ `agentId`; main sessions unchanged → Task 1 returns null; Task 2 "no header" test; Task 3 selects a sub-agent.
+- status running/done; steps=tool count; duration=first→last; result=last response → Task 1 (Global Constraints copied verbatim).
+- Layout = header + stream below, drill-in unchanged → Task 2 (header rows above existing stream; `streamRows` keeps box height; stream/`↵` untouched).
+- 80-col guard via `truncateByWidth` → Task 2 `boxRow` truncates each line to `contentWidth - 1`.
+- Out of scope (cost/fleet roll-up/failed/tree-row metrics) → not in any task, per spec.
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `SubAgentSummary` fields (`status`/`steps`/`durationMs`/`intent`/`result`/`model`) defined in Task 1 and consumed identically in Tasks 2–3. `buildSubAgentSummary(node, activities)` / `formatDuration(ms)` signatures consistent across tasks. Prop name `subAgentSummary` consistent in Tasks 2 and 3.
+
+**Note (minor spec deviation):** the spec's `SubAgentSummary` listed a `name` field; dropped — the panel already renders the node's display name in its title bar, so `name` would be dead. The metric chip carries status/steps/duration/model; intent/result are their own rows.

--- a/docs/superpowers/reports/2026-06-30-subagent-cards.md
+++ b/docs/superpowers/reports/2026-06-30-subagent-cards.md
@@ -10,6 +10,7 @@ appended after each clean review; digest synthesized at PR time.
 ## Ledger
 
 - Task 1: complete (commits 7652357..40c7955, review clean — Approved)
+- Task 2: complete (commits 534c19b..310d4ca, review clean — Approved after 1 fix)
 
 ---
 
@@ -35,5 +36,37 @@ module-not-found).
 time — the panel reuses its existing title; recorded in the plan's self-review.)
 
 **Files touched:** `src/ui/subAgentSummary.ts`, `tests/ui/subAgentSummary.test.ts`.
+
+**Follow-ups / known gaps:** None.
+
+---
+
+## Task 2 — Viewer renders the sub-agent summary header
+
+**Intent:** When `subAgentSummary` is set, render a header (chip · intent /
+optional Result / `─ activity (↵ drill in)` divider) above the activity stream,
+keeping the box `visibleRows` tall; main session unchanged.
+
+**What was built:** `ActivityViewerPanel` gained an optional
+`subAgentSummary?: SubAgentSummary | null` prop. In the non-search render tail a
+`boxRow` helper builds the header lines; `streamRows = max(1, visibleRows -
+headerLines.length)` shrinks the stream slice + pad so total height is unchanged;
+`finalLines = [...headerLines, ...padded, ...lines]`. Search path and main-session
+path untouched. Tests: header content, no-header for main session, and full-width
+alignment.
+
+**Key decisions / trade-offs:**
+- Header pinned at top, stream stays bottom-aligned beneath it.
+- Result line normalized to one line (`\s+`→space) and omitted when empty.
+
+**Deviations from the plan:** The plan's `boxRow` snippet had an **off-by-one**
+(`contentWidth - 1`) that rendered header rows one cell too narrow (right border
+misaligned). Caught by task review; fixed to `contentWidth` for both truncate
+budget and pad base (commit 310d4ca) — matches the existing `emptyRow`
+(`contentWidth + 3` cells). Added a width-alignment test (RED 79 → GREEN 80) so
+the class can't regress. Plan code corrected in spirit; the plan file's snippet
+is left as the historical record (this report is the correction note).
+
+**Files touched:** `src/ui/ActivityViewerPanel.tsx`, `tests/ui/ActivityViewerPanel.test.tsx`.
 
 **Follow-ups / known gaps:** None.

--- a/docs/superpowers/reports/2026-06-30-subagent-cards.md
+++ b/docs/superpowers/reports/2026-06-30-subagent-cards.md
@@ -7,6 +7,35 @@
 Durable per-task record (decisions + deviations a diff can't show). Entries
 appended after each clean review; digest synthesized at PR time.
 
+## Feature digest (PR catch-up)
+
+Sub-agents now read as **black boxes** in the live HUD. When the selected tree
+node is a sub-agent (`node.agentId` set), the Activity Viewer shows a **summary
+header** above the (still-present) activity stream: a `status · N steps ·
+<duration> · <model>` chip with the intent, an optional `Result:` line, and a
+`─ activity (↵ drill in)` divider. Main sessions are untouched — they keep their
+full-detail view (they're the hero). The skill/workflow *fleet* overload problem
+is addressed by raising the altitude of each fleet member to one summarized card.
+
+All data is existing (zero new collection): intent = `taskDescription`, status =
+`liveState` (`running`/`done`; no `failed` — no reliable signal, deferred),
+steps = tool-call count, duration = first→last activity span, result = last
+`response`. New pure module `src/ui/subAgentSummary.ts` derives it; `App` passes
+it to `ActivityViewerPanel`, which renders the header and shrinks the stream's
+row budget so the box height is unchanged.
+
+**Built across 3 TDD tasks**, each independently reviewed (+ a final whole-branch
+review = Ready to merge): Task 1 pure helper (`7652357..40c7955`), Task 2 panel
+header (`534c19b..310d4ca`, incl. a width-alignment fix caught in review), Task 3
+App wiring (`0f04eb4..671ec02`). 938 tests green, tsc + Biome clean.
+
+**Deferred to #226 follow-ups (out of P1 scope):** cost field + task/PR cost
+roll-up (P2); skill-fleet roll-up on the parent (P3); `failed` status (needs a
+real signal). **Review-noted minors (non-blocking):** no test pins total panel
+height with a header present; narrow-width (`--once` < 80 cols) truncates the
+chip rather than dropping fields in the spec's stated priority order; `1 steps`
+isn't pluralized.
+
 ## Ledger
 
 - Task 1: complete (commits 7652357..40c7955, review clean — Approved)

--- a/docs/superpowers/reports/2026-06-30-subagent-cards.md
+++ b/docs/superpowers/reports/2026-06-30-subagent-cards.md
@@ -1,0 +1,39 @@
+# Sub-agent black-box cards (P1) — implementation record
+
+> Issue: #226 · Branch: `feat/226-subagent-cards` ·
+> Plan: [`../plans/2026-06-30-subagent-cards.md`](../plans/2026-06-30-subagent-cards.md) ·
+> Spec: [`../specs/2026-06-30-subagent-cards-design.md`](../specs/2026-06-30-subagent-cards-design.md)
+
+Durable per-task record (decisions + deviations a diff can't show). Entries
+appended after each clean review; digest synthesized at PR time.
+
+## Ledger
+
+- Task 1: complete (commits 7652357..40c7955, review clean — Approved)
+
+---
+
+## Task 1 — `buildSubAgentSummary` + `formatDuration` (pure)
+
+**Intent:** Derive a sub-agent's black-box summary (status/steps/duration/intent/
+result/model) from existing node fields + its parsed activity stream — the data
+layer for the later viewer header.
+
+**What was built:** New pure module `src/ui/subAgentSummary.ts`: `SubAgentSummary`
+interface, `buildSubAgentSummary(node, activities)` (returns `null` when
+`!node.agentId`), `formatDuration(ms)`. Unit tests in
+`tests/ui/subAgentSummary.test.ts` (5, all green, TDD RED was genuine
+module-not-found).
+
+**Key decisions / trade-offs:**
+- `result` via a reverse scan for the last `type==="response"` (O(n), no array
+  copy).
+- `durationMs` = first→last activity span (wall time), `null` when <2 activities.
+- Defensive `Math.max(0, …)` in `formatDuration` (harmless, not spec-required).
+
+**Deviations from the plan:** None. (Spec's `name` field already dropped at plan
+time — the panel reuses its existing title; recorded in the plan's self-review.)
+
+**Files touched:** `src/ui/subAgentSummary.ts`, `tests/ui/subAgentSummary.test.ts`.
+
+**Follow-ups / known gaps:** None.

--- a/docs/superpowers/reports/2026-06-30-subagent-cards.md
+++ b/docs/superpowers/reports/2026-06-30-subagent-cards.md
@@ -11,6 +11,7 @@ appended after each clean review; digest synthesized at PR time.
 
 - Task 1: complete (commits 7652357..40c7955, review clean — Approved)
 - Task 2: complete (commits 534c19b..310d4ca, review clean — Approved after 1 fix)
+- Task 3: complete (commits 0f04eb4..671ec02, review clean — Approved)
 
 ---
 
@@ -70,3 +71,31 @@ is left as the historical record (this report is the correction note).
 **Files touched:** `src/ui/ActivityViewerPanel.tsx`, `tests/ui/ActivityViewerPanel.test.tsx`.
 
 **Follow-ups / known gaps:** None.
+
+---
+
+## Task 3 — App wires the summary to the viewer
+
+**Intent:** Compute the summary for the selected node and pass it to the viewer,
+so a selected sub-agent gets the header end-to-end.
+
+**What was built:** In `App.tsx`, `const subAgentSummary = selectedSession ?
+buildSubAgentSummary(selectedSession, mergedActivities) : null;` (computed where
+both are in scope) passed as `subAgentSummary={subAgentSummary}` to the existing
+`<ActivityViewerPanel/>`. Integration test navigates (↓↓) to a running sub-agent
+row and asserts the header-only markers `DO_THE_THING` (intent) + `1 steps`
+(chip); the `1 steps` chip is the true discriminator (taskDescription also shows
+in the tree row).
+
+**Key decisions / trade-offs:**
+- Sentinel/main-session safety comes for free: `buildSubAgentSummary` returns
+  null for nodes without `agentId` (`__sub-`/`__cold__` sentinels, main
+  sessions), so no guard needed at the call site.
+- Not wrapped in `useMemo` — pure + cheap, and `mergedActivities` is already
+  memoized upstream (review-confirmed acceptable).
+
+**Deviations from the plan:** None.
+
+**Files touched:** `src/ui/App.tsx`, `tests/ui/App.test.tsx`.
+
+**Follow-ups / known gaps:** None. Full suite 938/938, tsc clean.

--- a/docs/superpowers/reports/2026-06-30-subagent-cards.md
+++ b/docs/superpowers/reports/2026-06-30-subagent-cards.md
@@ -182,3 +182,37 @@ border-wrapping); #9 documented why `formatDuration` (compound span) and
 `src/ui/subAgentSummary.ts`, `tests/ui/App.test.tsx`,
 `tests/ui/ActivityViewerPanel.test.tsx`, `tests/ui/subAgentSummary.test.ts`,
 spec doc. Full suite 944/944, tsc clean, biome clean.
+
+---
+
+## Review-fix round 2 (PR #227, CodeRabbit COMMENTED)
+
+The re-review (non-blocking `COMMENTED`) re-raised two Major findings; both
+verified against current code before acting.
+
+**Auto-pause budget (Major).** The cursor-anchor auto-pause effect still fed the
+full `viewerRows` into `adjustViewerCursorOnNewActivities` — a call site the
+round-1 B fix missed (`viewerStreamRows` wasn't even in scope there). For a live
+selected sub-agent the cursor could drift header-height rows past the visible top
+before pausing. Fixed by hoisting the `subAgentSummary`/`viewerStreamRows`
+computation above the effect and routing it through `viewerStreamRows`. The
+regression test drives fake timers to advance the 60s refresh poll; it lives in
+its **own file** (`App.autoPause.test.tsx`) because fake timers bleed with the
+~50 real-timer tests in `App.test.tsx` (order-dependent otherwise). Verified it
+fails pre-fix, passes post-fix.
+
+**Waiting status (Major → accepted as a robustness fix).** `status` mapped every
+non-working `liveState` (incl. `waiting`) to `done`. Re-verified reachability:
+Claude sub-agents map a yield to `null` not `waiting` (`sessionLiveness.ts:57`),
+opencode is `working|null`, and kiro/kiro-ide can be `waiting` but attach no
+`agentId` (so `buildSubAgentSummary` returns null) — so it's unreachable *today*.
+But the invariant is fragile and `waiting` means in-progress, so mapped
+`working|waiting → running`, `null → done`. No new status variant (YAGNI: the
+header has no distinct waiting rendering).
+
+**Non-bug (test-only nit).** CodeRabbit asked for a `waiting` test "once the
+status is fixed" — added, plus a `null → done` case.
+
+**Files touched:** `src/ui/App.tsx`, `src/ui/subAgentSummary.ts`,
+`tests/ui/App.test.tsx`, `tests/ui/App.autoPause.test.tsx` (new),
+`tests/ui/subAgentSummary.test.ts`. Full suite 947/947, tsc + biome clean.

--- a/docs/superpowers/reports/2026-06-30-subagent-cards.md
+++ b/docs/superpowers/reports/2026-06-30-subagent-cards.md
@@ -128,3 +128,57 @@ in the tree row).
 **Files touched:** `src/ui/App.tsx`, `tests/ui/App.test.tsx`.
 
 **Follow-ups / known gaps:** None. Full suite 938/938, tsc clean.
+
+---
+
+## Review-fix round (PR #227)
+
+CodeRabbit (`CHANGES_REQUESTED`, 6 comments) and the user's `/code-review`
+(4 Confirmed + 6 Plausible) surfaced findings the per-task and final opus
+reviews had missed. Triaged into must-fix (A–E), cleanup (#9/#10), nits, and
+documented non-bugs (#5/#7/#8).
+
+**A + C — summary from raw activities + memoize.** The header was built from the
+viewer's *filtered/merged* stream, so cycling the type filter to "response" made
+the step count collapse (e.g. `1 step` → `0 steps`). Fixed to build from the
+sub-agent's own raw `activities`, wrapped in `useMemo` keyed on
+`[selectedSession, activities]`. (Supersedes the prior "not wrapped in useMemo"
+note above.) New App test: filter→response, assert chip stays `1 step`.
+
+**B — viewer scroll/cursor/selection account for header height.** The header
+consumes rows, but scroll/cursor/PgUp-Dn/half-page/onScrollTop/getSelectedActivity
+still budgeted against the full `viewerRows`, desyncing selection from what's on
+screen. Introduced `subAgentHeaderRowCount(summary)` (single source of truth,
+2 + result?1:0) and `viewerStreamRows = viewerRows − headerRowCount`; routed all
+stream-relative math through it.
+
+**D — flatten every header row.** Only the Result row normalized whitespace; a
+multi-line `taskDescription` in the chip/intent row would inject a newline and
+break the box border. `boxRow` now flattens `[\r\n\t]+` on every row.
+
+**E — render header in the search path + consistent budget.** The
+search/narrow-finder branch returned before the header, so narrowing hid it.
+Lifted `headerLines` to the top of the render (shared by both paths); the search
+window and App's search scroll math (`edgeScrollWindowStart`,
+`scrollOffsetForCursor`) now budget against `viewerStreamRows` too.
+
+**Cleanup:** #10 hoisted the duplicated blank-row literal to one shared const
+(boxRow/padLine deliberately NOT merged — boxRow is display-width-aware and
+border-wrapping); #9 documented why `formatDuration` (compound span) and
+`formatElapsed` (single-unit age) differ rather than merging.
+
+**Nits:** pluralize step chip (`1 step` / `N steps`); tag spec ASCII fence
+`text` (MD040).
+
+**Documented non-bugs (not fixed):**
+- #5 box-height overflow — guarded: `viewerRows ≥ 5` always exceeds header
+  height ≤ 3.
+- #7 `waiting` status — sub-agents never report `waiting` (suppressed in
+  `detectLiveState`), so only `running`/`done` are reachable.
+- #8 one-line Result — by design for a fixed-height header; full text lives in
+  the drill-in Detail View.
+
+**Files touched:** `src/ui/App.tsx`, `src/ui/ActivityViewerPanel.tsx`,
+`src/ui/subAgentSummary.ts`, `tests/ui/App.test.tsx`,
+`tests/ui/ActivityViewerPanel.test.tsx`, `tests/ui/subAgentSummary.test.ts`,
+spec doc. Full suite 944/944, tsc clean, biome clean.

--- a/docs/superpowers/specs/2026-06-30-subagent-cards-design.md
+++ b/docs/superpowers/specs/2026-06-30-subagent-cards-design.md
@@ -1,0 +1,114 @@
+# Sub-agent black-box cards — design (P1)
+
+> Issue: #226 · Branch: `feat/226-subagent-cards`
+
+## Context
+
+The hero is the live HUD; the goal is its **retention**, not npm-download trials.
+The dominant usage pattern shifted: users rarely hand-spawn one sub-agent — skills
+and workflows (SDD, deep-research, `Workflow`, …) emit **fleets** of sub-agents.
+agenthud currently renders each sub-agent at **full detail, on par with a main
+session**, so a fleet floods the viewer with step-by-step noise.
+
+Treat a sub-agent as a **black box**: intent **in** → (status / steps / duration /
+result) → final result **out**. This spec covers **P1** only.
+
+## Goals (P1)
+
+When the selected node is a **sub-agent**, the Activity Viewer shows a **summary
+header first**, with the step-by-step activity stream kept below it (demoted, but
+still visible and drillable). A **main session is unchanged** — it is the hero and
+keeps its full-detail view.
+
+Out of scope for P1 (tracked on #226 for later):
+- **Cost** field + task/PR cost aggregation (P2).
+- **Skill-fleet roll-up** on the parent (`SDD 5/7 done · 2 running · $1.40`) (P3).
+- **Failed** status. No reliable failure signal exists today (`LiveState` is only
+  `working | waiting`; a finished sub-agent is just `liveState = null`). Status is
+  **running / done** only; failure detection is deferred (see Open questions).
+- Per-row step/duration on **every tree row** — that needs parsing every
+  sub-agent file each poll (perf). Tree rows stay as they are today.
+
+## Layout (chosen: header + stream below)
+
+```
+┌─ » <name>   [running|done] · N steps · <duration> ────────────┐
+│ Intent: <taskDescription, truncated>                          │
+│ Result: <last response text, truncated>                       │
+├─ activity (↵ drill in) ───────────────────────────────────────┤
+│ ○ Read foo.ts                                                 │
+│ $ npm test                                                    │
+│ ○ Write notes.md                                              │
+│ …                                                             │
+```
+
+The activity stream below the header is the **existing** viewer stream —
+scrolling and `↵`-to-drill-into-a-row's-Detail are unchanged. The header is
+additive, rendered only for sub-agents.
+
+## Data — all existing (selected file already parsed)
+
+`isSubAgent` = the selected node has `agentId` (main sessions don't).
+
+| Header field | Source |
+|---|---|
+| name | existing display name (truncated `agentId` / task) |
+| status | `running` when `liveState === "working"`; otherwise `done` |
+| steps | count of activities with `type === "tool"` |
+| duration | last activity `timestamp` − first activity `timestamp` (run length; distinct from the tree row's time-since-last). Omit / `<1s` when < 2 activities or sub-second. |
+| Intent | `node.taskDescription` |
+| Result | the last activity with `type === "response"` (its text); empty when none |
+| model | `node.modelName` (shown in the chip row if width allows) |
+
+No new collection: the viewer already parses the selected node's JSONL into
+`activities`; the node carries `taskDescription`, `agentId`, `modelName`,
+`liveState`, `status`.
+
+## Architecture / components
+
+- **`buildSubAgentSummary(node, activities)` — pure helper** (new). Input: the
+  selected `SessionNode` + its `ActivityEntry[]`. Output:
+  `{ name; status: "running" | "done"; steps: number; durationMs: number | null;
+  intent: string; result: string; model: string | null } | null` — `null` when
+  the node is not a sub-agent (`!node.agentId`). Unit-tested in isolation.
+  - Lives next to the viewer (e.g. `src/ui/subAgentSummary.ts`) so the panel and
+    tests import it without pulling in `App`.
+- **`App.tsx`** computes the summary from the already-resolved selected node +
+  `mergedActivities` and passes it to the viewer as a new optional prop
+  `subAgentSummary?: SubAgentSummary | null`. No change to how the stream itself
+  is built.
+- **`ActivityViewerPanel`** renders a **summary header block** above the stream
+  when `subAgentSummary` is set, then the existing stream beneath a
+  `─ activity (↵ drill in) ─` divider. When the prop is absent (main session, or
+  no selection) it renders exactly as today.
+  - The header consumes a few rows of the panel's height budget; the stream's
+    `visibleRows` shrinks accordingly so nothing overflows the box.
+
+### 80-column guard / truncation
+
+All header lines pass through the existing `truncateByWidth` (display-cell aware).
+Degrade by priority as width shrinks: (1) drop the model from the chip row;
+(2) shorten the `Result:` line; (3) keep the title chip down to `N steps`. The
+header never wraps — one display line per field.
+
+## Testing (TDD)
+
+- **`buildSubAgentSummary`** unit tests: steps = tool count; duration = first→last
+  span; result = last `response` text (and empty when none); intent =
+  `taskDescription`; returns `null` for a main session (no `agentId`); edge cases
+  of 0 and 1 activities.
+- **`ActivityViewerPanel`**: renders Intent / Result / `N steps` when
+  `subAgentSummary` is provided; renders the normal stream (no header) when it is
+  absent (main-session regression); the activity stream is still present below the
+  header.
+- **Truncation**: at 80 cols the header lines stay within the box (right border
+  aligned), Result degrades before the title chip.
+
+## Open questions (resolved for P1)
+
+- **steps = tool-call count** (per the requirement), not assistant turns.
+- **sub-agent-only**; main sessions unchanged.
+- **duration = run length** (first→last activity), not time-since-last.
+- **failed**: deferred — the only candidate signal is the parent's Task
+  `tool_result.is_error` (now captured via #222), which needs parent→sub-agent
+  linking and only catches infra crashes (not "bad work"). Revisit after P1.

--- a/docs/superpowers/specs/2026-06-30-subagent-cards-design.md
+++ b/docs/superpowers/specs/2026-06-30-subagent-cards-design.md
@@ -31,7 +31,7 @@ Out of scope for P1 (tracked on #226 for later):
 
 ## Layout (chosen: header + stream below)
 
-```
+```text
 ┌─ » <name>   [running|done] · N steps · <duration> ────────────┐
 │ Intent: <taskDescription, truncated>                          │
 │ Result: <last response text, truncated>                       │

--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -38,8 +38,11 @@ import {
   createTitleLine,
   getDisplayWidth,
   getInnerWidth,
+  truncateByWidth,
 } from "./constants.js";
 import { matchRanges } from "./search/matcher.js";
+import type { SubAgentSummary } from "./subAgentSummary.js";
+import { formatDuration } from "./subAgentSummary.js";
 
 export interface ActivityStyle {
   color?: string;
@@ -138,6 +141,9 @@ export interface ActivityViewerPanelProps {
    * windowStart from safeSelected, enabling fzf-style stable-window scrolling.
    */
   searchWindowStart?: number;
+  /** When the selected node is a sub-agent, its black-box summary; renders a
+   * header above the (demoted) activity stream. Absent for main sessions. */
+  subAgentSummary?: SubAgentSummary | null;
 }
 
 function formatActivityTime(date: Date, now: Date): string {
@@ -329,6 +335,7 @@ export function ActivityViewerPanel({
   searchQuery,
   searchSelected,
   searchWindowStart,
+  subAgentSummary,
 }: ActivityViewerPanelProps): React.ReactElement {
   const innerWidth = getInnerWidth(width);
   const contentWidth = innerWidth - 1;
@@ -470,16 +477,46 @@ export function ActivityViewerPanel({
     titleSuffix = `[PAUSED ↑${scrollOffset}${badge}${filterSuffix}]`;
   }
 
+  // Sub-agent black-box header (P1): fixed rows above the stream. The stream's
+  // row budget shrinks by the header height so the box stays `visibleRows` tall.
+  const headerLines: React.ReactElement[] = [];
+  if (subAgentSummary) {
+    const s = subAgentSummary;
+    const boxRow = (key: string, text: string) => {
+      const t = truncateByWidth(text, contentWidth - 1);
+      const pad = Math.max(0, contentWidth - 1 - getDisplayWidth(t));
+      return (
+        <Text key={key}>
+          {BOX.v} {t}
+          {" ".repeat(pad)}
+          {BOX.v}
+        </Text>
+      );
+    };
+    const dur =
+      s.durationMs === null ? "" : ` · ${formatDuration(s.durationMs)}`;
+    const model = s.model ? ` · ${s.model}` : "";
+    const chip = `${s.status} · ${s.steps} steps${dur}${model}`;
+    headerLines.push(boxRow("sa-chip", `${chip}  ${s.intent}`.trimEnd()));
+    if (s.result) {
+      headerLines.push(
+        boxRow("sa-result", `Result: ${s.result.replace(/\s+/g, " ").trim()}`),
+      );
+    }
+    headerLines.push(boxRow("sa-div", "─ activity (↵ drill in)"));
+  }
+  const streamRows = Math.max(1, visibleRows - headerLines.length);
+
   // Take a chronological slice (oldest -> newest within the slice). The slice
   // ends `scrollOffset` entries from the newest; live = scrollOffset 0.
   let visibleActivities: ActivityEntry[];
   if (activities.length === 0) {
     visibleActivities = [];
   } else if (isLive) {
-    visibleActivities = activities.slice(-visibleRows);
+    visibleActivities = activities.slice(-streamRows);
   } else {
     const end = Math.max(0, activities.length - scrollOffset);
-    const start = Math.max(0, end - visibleRows);
+    const start = Math.max(0, end - streamRows);
     visibleActivities = activities.slice(start, end);
   }
 
@@ -535,12 +572,12 @@ export function ActivityViewerPanel({
   // The live-edge cue now lives ON the newest activity row (spinner + bold)
   // rather than in a separate slot below.
   const emptyRow = `${BOX.v}${" ".repeat(contentWidth + 1)}${BOX.v}`;
-  const padCount = Math.max(0, visibleRows - lines.length);
+  const padCount = Math.max(0, streamRows - lines.length);
   const padded: React.ReactElement[] = [];
   for (let i = 0; i < padCount; i++) {
     padded.push(<Text key={`pad-${i}`}>{emptyRow}</Text>);
   }
-  const finalLines = [...padded, ...lines];
+  const finalLines = [...headerLines, ...padded, ...lines];
 
   return (
     <Box flexDirection="column" width={width}>

--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -340,6 +340,38 @@ export function ActivityViewerPanel({
   const innerWidth = getInnerWidth(width);
   const contentWidth = innerWidth - 1;
 
+  // Sub-agent black-box header (P1): fixed rows above the stream, rendered the
+  // same way in both the normal and the search/narrow-finder path. The stream's
+  // row budget shrinks by the header height so the box stays `visibleRows` tall.
+  const headerLines: React.ReactElement[] = [];
+  if (subAgentSummary) {
+    const s = subAgentSummary;
+    const boxRow = (key: string, text: string) => {
+      // Flatten newlines/tabs on EVERY header row — an un-flattened value (e.g.
+      // a multi-line taskDescription) would inject a line break and blow out the
+      // box border for the whole header.
+      const flat = text.replace(/[\r\n\t]+/g, " ").trim();
+      const t = truncateByWidth(flat, contentWidth);
+      const pad = Math.max(0, contentWidth - getDisplayWidth(t));
+      return (
+        <Text key={key}>
+          {BOX.v} {t}
+          {" ".repeat(pad)}
+          {BOX.v}
+        </Text>
+      );
+    };
+    const dur =
+      s.durationMs === null ? "" : ` · ${formatDuration(s.durationMs)}`;
+    const model = s.model ? ` · ${s.model}` : "";
+    const chip = `${s.status} · ${s.steps} steps${dur}${model}`;
+    headerLines.push(boxRow("sa-chip", `${chip}  ${s.intent}`));
+    if (s.result) {
+      headerLines.push(boxRow("sa-result", `Result: ${s.result}`));
+    }
+    headerLines.push(boxRow("sa-div", "─ activity (↵ drill in)"));
+  }
+
   // Narrow-finder mode: only narrow once there's a query. An empty query
   // (search just opened, nothing typed) shows the full list — narrowing to
   // zero rows on the first `/` keystroke would blank the viewer.
@@ -354,6 +386,9 @@ export function ActivityViewerPanel({
     const filterSuffix =
       filterLabel && filterLabel !== "all" ? ` · ${filterLabel}` : "";
     const titleSuffix = `[SEARCH${filterSuffix}]`;
+    // Reserve rows for the sub-agent header so the search window matches the
+    // same stream budget the normal path uses (App scrolls against this too).
+    const searchRows = Math.max(1, visibleRows - headerLines.length);
 
     if (searchHits.length === 0) {
       const emptyText = searchQuery ? "No matches" : "No activity yet";
@@ -370,12 +405,12 @@ export function ActivityViewerPanel({
       // `visibleRows`. Use the persisted edge-scroll start from App when
       // available (fzf-style stable window); fall back to pinning the
       // selected hit at the top (legacy behaviour) when it isn't.
-      const maxWindowStart = Math.max(0, searchHits.length - visibleRows);
+      const maxWindowStart = Math.max(0, searchHits.length - searchRows);
       const windowStart =
         searchWindowStart !== undefined
           ? Math.max(0, Math.min(searchWindowStart, maxWindowStart))
           : Math.max(0, Math.min(safeSelected, maxWindowStart));
-      const windowEnd = Math.min(searchHits.length, windowStart + visibleRows);
+      const windowEnd = Math.min(searchHits.length, windowStart + searchRows);
       const windowedHits = searchHits.slice(windowStart, windowEnd);
       for (let wi = 0; wi < windowedHits.length; wi++) {
         const i = windowStart + wi; // global hit index
@@ -447,12 +482,12 @@ export function ActivityViewerPanel({
     }
 
     const emptyRow = `${BOX.v}${" ".repeat(contentWidth + 1)}${BOX.v}`;
-    const padCount = Math.max(0, visibleRows - lines.length);
+    const padCount = Math.max(0, searchRows - lines.length);
     const padded: React.ReactElement[] = [];
     for (let i = 0; i < padCount; i++) {
       padded.push(<Text key={`pad-${i}`}>{emptyRow}</Text>);
     }
-    const finalLines = [...padded, ...lines];
+    const finalLines = [...headerLines, ...padded, ...lines];
 
     return (
       <Box flexDirection="column" width={width}>
@@ -477,34 +512,8 @@ export function ActivityViewerPanel({
     titleSuffix = `[PAUSED ↑${scrollOffset}${badge}${filterSuffix}]`;
   }
 
-  // Sub-agent black-box header (P1): fixed rows above the stream. The stream's
-  // row budget shrinks by the header height so the box stays `visibleRows` tall.
-  const headerLines: React.ReactElement[] = [];
-  if (subAgentSummary) {
-    const s = subAgentSummary;
-    const boxRow = (key: string, text: string) => {
-      const t = truncateByWidth(text, contentWidth);
-      const pad = Math.max(0, contentWidth - getDisplayWidth(t));
-      return (
-        <Text key={key}>
-          {BOX.v} {t}
-          {" ".repeat(pad)}
-          {BOX.v}
-        </Text>
-      );
-    };
-    const dur =
-      s.durationMs === null ? "" : ` · ${formatDuration(s.durationMs)}`;
-    const model = s.model ? ` · ${s.model}` : "";
-    const chip = `${s.status} · ${s.steps} steps${dur}${model}`;
-    headerLines.push(boxRow("sa-chip", `${chip}  ${s.intent}`.trimEnd()));
-    if (s.result) {
-      headerLines.push(
-        boxRow("sa-result", `Result: ${s.result.replace(/\s+/g, " ").trim()}`),
-      );
-    }
-    headerLines.push(boxRow("sa-div", "─ activity (↵ drill in)"));
-  }
+  // headerLines is built once at the top of the render (shared with the search
+  // path); the stream budget shrinks by its height so the box stays visibleRows.
   const streamRows = Math.max(1, visibleRows - headerLines.length);
 
   // Take a chronological slice (oldest -> newest within the slice). The slice

--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -483,8 +483,8 @@ export function ActivityViewerPanel({
   if (subAgentSummary) {
     const s = subAgentSummary;
     const boxRow = (key: string, text: string) => {
-      const t = truncateByWidth(text, contentWidth - 1);
-      const pad = Math.max(0, contentWidth - 1 - getDisplayWidth(t));
+      const t = truncateByWidth(text, contentWidth);
+      const pad = Math.max(0, contentWidth - getDisplayWidth(t));
       return (
         <Text key={key}>
           {BOX.v} {t}

--- a/src/ui/ActivityViewerPanel.tsx
+++ b/src/ui/ActivityViewerPanel.tsx
@@ -339,6 +339,9 @@ export function ActivityViewerPanel({
 }: ActivityViewerPanelProps): React.ReactElement {
   const innerWidth = getInnerWidth(width);
   const contentWidth = innerWidth - 1;
+  // A blank bordered row (│…│), used to pad both the search and normal paths
+  // up to `visibleRows`.
+  const emptyRow = `${BOX.v}${" ".repeat(contentWidth + 1)}${BOX.v}`;
 
   // Sub-agent black-box header (P1): fixed rows above the stream, rendered the
   // same way in both the normal and the search/narrow-finder path. The stream's
@@ -364,7 +367,8 @@ export function ActivityViewerPanel({
     const dur =
       s.durationMs === null ? "" : ` · ${formatDuration(s.durationMs)}`;
     const model = s.model ? ` · ${s.model}` : "";
-    const chip = `${s.status} · ${s.steps} steps${dur}${model}`;
+    const steps = `${s.steps} step${s.steps === 1 ? "" : "s"}`;
+    const chip = `${s.status} · ${steps}${dur}${model}`;
     headerLines.push(boxRow("sa-chip", `${chip}  ${s.intent}`));
     if (s.result) {
       headerLines.push(boxRow("sa-result", `Result: ${s.result}`));
@@ -481,7 +485,6 @@ export function ActivityViewerPanel({
       }
     }
 
-    const emptyRow = `${BOX.v}${" ".repeat(contentWidth + 1)}${BOX.v}`;
     const padCount = Math.max(0, searchRows - lines.length);
     const padded: React.ReactElement[] = [];
     for (let i = 0; i < padCount; i++) {
@@ -580,7 +583,6 @@ export function ActivityViewerPanel({
   // Bottom-aligned: pad at the TOP so newest sits on the last content row.
   // The live-edge cue now lives ON the newest activity row (spinner + bold)
   // rather than in a separate slot below.
-  const emptyRow = `${BOX.v}${" ".repeat(contentWidth + 1)}${BOX.v}`;
   const padCount = Math.max(0, streamRows - lines.length);
   const padded: React.ReactElement[] = [];
   for (let i = 0; i < padCount; i++) {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1051,6 +1051,33 @@ export function App({
   // statusBar(1) + margin(1) + tree(treeRows+2) + margin(1) + viewer(viewerRows+2) = height
   const viewerRows = Math.max(5, height - 7 - treeRows);
 
+  // Sub-agent black-box header: built from the sub-agent's OWN raw activity
+  // stream (`activities`), not the filtered/git-merged `mergedActivities` —
+  // otherwise a type filter or merged git commits would skew steps/duration.
+  // Memoized so it doesn't re-scan the history (and mint a new object identity
+  // that defeats downstream React.memo) on every ~100ms poll/spinner render.
+  // Declared HERE (not lower) so the cursor-anchor effect just below can budget
+  // against the header-reduced stream height. `rawSelected` (the flat-list hit)
+  // is enough — the project-sentinel massaging done later resolves to a
+  // top-level session, which has no agentId and yields a null summary anyway.
+  const rawSelectedForSummary = allFlat.find((s) => s.id === selectedId);
+  const subAgentSummary = useMemo(
+    () =>
+      rawSelectedForSummary
+        ? buildSubAgentSummary(rawSelectedForSummary, activities)
+        : null,
+    [rawSelectedForSummary, activities],
+  );
+  // The sub-agent header eats rows off the top of the viewer box, so the
+  // scrollable activity stream is shorter than `viewerRows`. All viewer
+  // scroll/cursor/paging/selection math must use THIS budget to stay in sync
+  // with what the panel actually renders (0 header rows for main sessions, so
+  // this equals viewerRows there — no behavior change off the sub-agent path).
+  const viewerStreamRows = Math.max(
+    1,
+    viewerRows - subAgentHeaderRowCount(subAgentSummary),
+  );
+
   // Keep the viewer cursor anchored to its activity when new entries
   // arrive in LIVE mode. Without this, the visible window auto-scrolls
   // to show new content but cursorLine stays at the same screen row —
@@ -1072,7 +1099,7 @@ export function App({
       prevActivityCount: prev,
       newActivityCount: mergedActivities.length,
       isLive,
-      viewerRows,
+      viewerRows: viewerStreamRows,
     });
     if (result.cursorLine !== viewerCursorLine) {
       setViewerCursorLine(result.cursorLine);
@@ -1082,7 +1109,7 @@ export function App({
       setScrollOffset((o) => o + result.scrollDelta);
       setNewCount((n) => n + result.scrollDelta);
     }
-  }, [mergedActivities.length, isLive, viewerRows, viewerCursorLine]);
+  }, [mergedActivities.length, isLive, viewerStreamRows, viewerCursorLine]);
 
   // While PAUSED, keep the view frozen on its current snapshot as new
   // entries arrive — bump `scrollOffset` and `newCount` by the delta
@@ -1916,27 +1943,8 @@ export function App({
         ? selectedSession.projectName || selectedSession.id.slice(0, 8)
         : (selectedSession.agentId ?? selectedSession.id.slice(0, 8));
 
-  // Built from the sub-agent's OWN raw activity stream (`activities`), not the
-  // filtered/git-merged `mergedActivities` — otherwise a type filter or merged
-  // git commits would skew steps/duration. Memoized so it doesn't re-scan the
-  // history (and mint a new object identity that defeats downstream React.memo)
-  // on every ~100ms poll/spinner render.
-  const subAgentSummary = useMemo(
-    () =>
-      selectedSession
-        ? buildSubAgentSummary(selectedSession, activities)
-        : null,
-    [selectedSession, activities],
-  );
-  // The sub-agent header eats rows off the top of the viewer box, so the
-  // scrollable activity stream is shorter than `viewerRows`. All viewer
-  // scroll/cursor/paging/selection math must use THIS budget to stay in sync
-  // with what the panel actually renders (0 header rows for main sessions, so
-  // this equals viewerRows there — no behavior change off the sub-agent path).
-  const viewerStreamRows = Math.max(
-    1,
-    viewerRows - subAgentHeaderRowCount(subAgentSummary),
-  );
+  // `subAgentSummary` and `viewerStreamRows` are computed once near the top of
+  // the component (above the cursor-anchor effect that needs the reduced budget).
 
   const MIN_WIDTH = 80;
   const MIN_HEIGHT = 20;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1653,7 +1653,12 @@ export function App({
             s ? { ...s, index: newIndex, navigated: true } : s,
           );
           setViewerSearchWindowStart((prev) =>
-            edgeScrollWindowStart(prev, newIndex, viewerRows, hits.length),
+            edgeScrollWindowStart(
+              prev,
+              newIndex,
+              viewerStreamRows,
+              hits.length,
+            ),
           );
           return;
         }
@@ -1665,7 +1670,12 @@ export function App({
             s ? { ...s, index: newIndex, navigated: true } : s,
           );
           setViewerSearchWindowStart((prev) =>
-            edgeScrollWindowStart(prev, newIndex, viewerRows, hits.length),
+            edgeScrollWindowStart(
+              prev,
+              newIndex,
+              viewerStreamRows,
+              hits.length,
+            ),
           );
           return;
         }
@@ -1684,7 +1694,7 @@ export function App({
               const newScrollOffset = scrollOffsetForCursor(
                 mergedActivities.length,
                 hitIndex,
-                viewerRows,
+                viewerStreamRows,
               );
               setSavedViewerSearch({
                 search,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1900,9 +1900,18 @@ export function App({
         ? selectedSession.projectName || selectedSession.id.slice(0, 8)
         : (selectedSession.agentId ?? selectedSession.id.slice(0, 8));
 
-  const subAgentSummary = selectedSession
-    ? buildSubAgentSummary(selectedSession, mergedActivities)
-    : null;
+  // Built from the sub-agent's OWN raw activity stream (`activities`), not the
+  // filtered/git-merged `mergedActivities` — otherwise a type filter or merged
+  // git commits would skew steps/duration. Memoized so it doesn't re-scan the
+  // history (and mint a new object identity that defeats downstream React.memo)
+  // on every ~100ms poll/spinner render.
+  const subAgentSummary = useMemo(
+    () =>
+      selectedSession
+        ? buildSubAgentSummary(selectedSession, activities)
+        : null,
+    [selectedSession, activities],
+  );
 
   const MIN_WIDTH = 80;
   const MIN_HEIGHT = 20;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -81,6 +81,7 @@ import { SearchInput } from "./search/SearchInput.js";
 import type { SearchState } from "./search/searchKey.js";
 import { applyDetailSearchKey } from "./search/searchKey.js";
 import { filterTreeBySearch, treeSearchHits } from "./search/treeSearch.js";
+import { buildSubAgentSummary } from "./subAgentSummary.js";
 import {
   adjustViewerCursorOnNewActivities,
   scrollOffsetForCursor,
@@ -1899,6 +1900,10 @@ export function App({
         ? selectedSession.projectName || selectedSession.id.slice(0, 8)
         : (selectedSession.agentId ?? selectedSession.id.slice(0, 8));
 
+  const subAgentSummary = selectedSession
+    ? buildSubAgentSummary(selectedSession, mergedActivities)
+    : null;
+
   const MIN_WIDTH = 80;
   const MIN_HEIGHT = 20;
   if (isWatchMode && (width < MIN_WIDTH || height + 1 < MIN_HEIGHT)) {
@@ -2062,6 +2067,7 @@ export function App({
                     ? viewerSearchWindowStart
                     : undefined
                 }
+                subAgentSummary={subAgentSummary}
               />
             )}
           </Box>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -81,7 +81,10 @@ import { SearchInput } from "./search/SearchInput.js";
 import type { SearchState } from "./search/searchKey.js";
 import { applyDetailSearchKey } from "./search/searchKey.js";
 import { filterTreeBySearch, treeSearchHits } from "./search/treeSearch.js";
-import { buildSubAgentSummary } from "./subAgentSummary.js";
+import {
+  buildSubAgentSummary,
+  subAgentHeaderRowCount,
+} from "./subAgentSummary.js";
 import {
   adjustViewerCursorOnNewActivities,
   scrollOffsetForCursor,
@@ -1216,7 +1219,7 @@ export function App({
         const prev = Math.max(0, selectedIndex - 1);
         setSelectedId(allFlat[prev]?.id ?? selectedId);
       } else {
-        if (viewerCursorLine < viewerRows - 1) {
+        if (viewerCursorLine < viewerStreamRows - 1) {
           setViewerCursorLine((c) => c + 1);
         } else {
           // cursor at top of viewport — scroll viewport toward older.
@@ -1225,7 +1228,10 @@ export function App({
           // mergedActivities, not raw activities).
           setIsLive(false);
           setScrollOffset((o) =>
-            Math.min(o + 1, Math.max(0, mergedActivities.length - viewerRows)),
+            Math.min(
+              o + 1,
+              Math.max(0, mergedActivities.length - viewerStreamRows),
+            ),
           );
         }
       }
@@ -1265,8 +1271,8 @@ export function App({
         setIsLive(false);
         setScrollOffset((o) =>
           Math.min(
-            o + viewerRows,
-            Math.max(0, mergedActivities.length - viewerRows),
+            o + viewerStreamRows,
+            Math.max(0, mergedActivities.length - viewerStreamRows),
           ),
         );
       }
@@ -1279,7 +1285,7 @@ export function App({
       } else {
         setViewerCursorLine(0);
         setScrollOffset((o) => {
-          const newOffset = Math.max(0, o - viewerRows);
+          const newOffset = Math.max(0, o - viewerStreamRows);
           if (newOffset === 0) {
             setIsLive(true);
             setNewCount(0);
@@ -1298,8 +1304,8 @@ export function App({
         setIsLive(false);
         setScrollOffset((o) =>
           Math.min(
-            o + Math.floor(viewerRows / 2),
-            Math.max(0, mergedActivities.length - viewerRows),
+            o + Math.floor(viewerStreamRows / 2),
+            Math.max(0, mergedActivities.length - viewerStreamRows),
           ),
         );
       }
@@ -1315,7 +1321,7 @@ export function App({
       } else {
         setViewerCursorLine(0);
         setScrollOffset((o) => {
-          const newOffset = Math.max(0, o - Math.floor(viewerRows / 2));
+          const newOffset = Math.max(0, o - Math.floor(viewerStreamRows / 2));
           if (newOffset === 0) {
             setIsLive(true);
             setNewCount(0);
@@ -1328,9 +1334,9 @@ export function App({
       // g = top of viewport = oldest visible; cursor lands on the top row
       // (which is the oldest visible — `viewerRows - 1` entries back from
       // the newest in the slice).
-      setViewerCursorLine(Math.max(0, viewerRows - 1));
+      setViewerCursorLine(Math.max(0, viewerStreamRows - 1));
       setIsLive(false);
-      setScrollOffset(Math.max(0, mergedActivities.length - viewerRows));
+      setScrollOffset(Math.max(0, mergedActivities.length - viewerStreamRows));
     },
     onScrollBottom: () => {
       // G = bottom of viewport = newest = live; cursor on the live edge.
@@ -1369,7 +1375,7 @@ export function App({
           mergedActivities,
           isLive,
           scrollOffset,
-          viewerRows,
+          viewerStreamRows,
           viewerCursorLine,
         );
         if (act) openActivityDetail(act);
@@ -1911,6 +1917,15 @@ export function App({
         ? buildSubAgentSummary(selectedSession, activities)
         : null,
     [selectedSession, activities],
+  );
+  // The sub-agent header eats rows off the top of the viewer box, so the
+  // scrollable activity stream is shorter than `viewerRows`. All viewer
+  // scroll/cursor/paging/selection math must use THIS budget to stay in sync
+  // with what the panel actually renders (0 header rows for main sessions, so
+  // this equals viewerRows there — no behavior change off the sub-agent path).
+  const viewerStreamRows = Math.max(
+    1,
+    viewerRows - subAgentHeaderRowCount(subAgentSummary),
   );
 
   const MIN_WIDTH = 80;

--- a/src/ui/subAgentSummary.ts
+++ b/src/ui/subAgentSummary.ts
@@ -42,6 +42,20 @@ export function buildSubAgentSummary(
   };
 }
 
+/**
+ * How many rows the viewer's sub-agent header occupies: a chip line + an
+ * optional Result line + the divider (0 when there is no summary). The panel
+ * renders exactly this many header rows, and App subtracts it from the viewer
+ * row budget so scroll/cursor/selection stay in sync with the shorter stream.
+ * Single source of truth for both sides.
+ */
+export function subAgentHeaderRowCount(
+  summary: SubAgentSummary | null | undefined,
+): number {
+  if (!summary) return 0;
+  return 2 + (summary.result ? 1 : 0); // chip + [result] + divider
+}
+
 export function formatDuration(ms: number): string {
   const secs = Math.max(0, Math.round(ms / 1000));
   const h = Math.floor(secs / 3600);

--- a/src/ui/subAgentSummary.ts
+++ b/src/ui/subAgentSummary.ts
@@ -56,6 +56,12 @@ export function subAgentHeaderRowCount(
   return 2 + (summary.result ? 1 : 0); // chip + [result] + divider
 }
 
+/**
+ * Format a *span* (start→end duration) compactly: `5s`, `2m14s`, `1h1m`.
+ * Distinct on purpose from SessionTreePanel's `formatElapsed`, which formats
+ * *time-since-now* as a single coarse unit (`49m`, `3d`, `2mo`). A span reads
+ * better compound; an age reads better as one bucket — do not merge them.
+ */
 export function formatDuration(ms: number): string {
   const secs = Math.max(0, Math.round(ms / 1000));
   const h = Math.floor(secs / 3600);

--- a/src/ui/subAgentSummary.ts
+++ b/src/ui/subAgentSummary.ts
@@ -32,8 +32,14 @@ export function buildSubAgentSummary(
       break;
     }
   }
+  // "working" and "waiting" both mean the agent is alive/in-progress; only a
+  // missing live signal (null) reads as done. Mapping "waiting" → "done" would
+  // show an agent that's blocked on a tool/approval as finished.
   return {
-    status: node.liveState === "working" ? "running" : "done",
+    status:
+      node.liveState === "working" || node.liveState === "waiting"
+        ? "running"
+        : "done",
     steps,
     durationMs,
     intent: node.taskDescription ?? "",

--- a/src/ui/subAgentSummary.ts
+++ b/src/ui/subAgentSummary.ts
@@ -1,0 +1,53 @@
+/**
+ * Derive a sub-agent's "black-box" summary (intent → status/steps/duration →
+ * result) from data already on the node and its parsed activity stream. Pure;
+ * returns null for main sessions (which have no agentId and keep full detail).
+ */
+import type { ActivityEntry, SessionNode } from "../types/index.js";
+
+export interface SubAgentSummary {
+  status: "running" | "done";
+  steps: number;
+  durationMs: number | null;
+  intent: string;
+  result: string;
+  model: string | null;
+}
+
+export function buildSubAgentSummary(
+  node: SessionNode,
+  activities: ActivityEntry[],
+): SubAgentSummary | null {
+  if (!node.agentId) return null;
+  const steps = activities.filter((a) => a.type === "tool").length;
+  const durationMs =
+    activities.length >= 2
+      ? activities[activities.length - 1].timestamp.getTime() -
+        activities[0].timestamp.getTime()
+      : null;
+  let result = "";
+  for (let i = activities.length - 1; i >= 0; i--) {
+    if (activities[i].type === "response") {
+      result = activities[i].detail;
+      break;
+    }
+  }
+  return {
+    status: node.liveState === "working" ? "running" : "done",
+    steps,
+    durationMs,
+    intent: node.taskDescription ?? "",
+    result,
+    model: node.modelName,
+  };
+}
+
+export function formatDuration(ms: number): string {
+  const secs = Math.max(0, Math.round(ms / 1000));
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  if (h > 0) return `${h}h${m}m`;
+  if (m > 0) return `${m}m${s}s`;
+  return `${s}s`;
+}

--- a/tests/ui/ActivityViewerPanel.test.tsx
+++ b/tests/ui/ActivityViewerPanel.test.tsx
@@ -289,6 +289,21 @@ describe("ActivityViewerPanel — sub-agent summary header", () => {
     model: "sonnet-4.6",
   };
 
+  it("pads every header row to the full panel width (right border aligned)", () => {
+    const W = 80;
+    const { lastFrame } = render(
+      <ActivityViewerPanel
+        {...baseProps}
+        activities={[makeActivity("Read", 0)]}
+        width={W}
+        subAgentSummary={summary}
+      />,
+    );
+    const lines = (lastFrame() ?? "").split("\n").filter(Boolean);
+    expect(lines.some((l) => l.includes("Research the thing"))).toBe(true);
+    for (const l of lines) expect([...l].length).toBe(W);
+  });
+
   it("renders the header (intent/result/steps) when subAgentSummary is set", () => {
     const { lastFrame } = render(
       <ActivityViewerPanel

--- a/tests/ui/ActivityViewerPanel.test.tsx
+++ b/tests/ui/ActivityViewerPanel.test.tsx
@@ -320,6 +320,27 @@ describe("ActivityViewerPanel — sub-agent summary header", () => {
     expect(out).toContain("Read"); // stream still present below
   });
 
+  it("flattens newlines in every header row so the border stays aligned", () => {
+    const W = 80;
+    const { lastFrame } = render(
+      <ActivityViewerPanel
+        {...baseProps}
+        activities={[makeActivity("Read", 0)]}
+        width={W}
+        subAgentSummary={{
+          ...summary,
+          intent: "line one\nline two", // newline in intent (was un-flattened)
+          result: "res\tone\ntwo",
+        }}
+      />,
+    );
+    const lines = (lastFrame() ?? "").split("\n").filter(Boolean);
+    // Every line stays exactly W wide — a stray newline would split a header
+    // row and break the right border.
+    for (const l of lines) expect([...l].length).toBe(W);
+    expect(lines.some((l) => l.includes("line one line two"))).toBe(true);
+  });
+
   it("renders no header for a main session (prop absent)", () => {
     const { lastFrame } = render(
       <ActivityViewerPanel
@@ -368,5 +389,35 @@ describe("ActivityViewerPanel search", () => {
       />,
     );
     expect(lastFrame() ?? "").toContain("No matches");
+  });
+
+  it("renders the sub-agent header in the search path too", () => {
+    const W = 80;
+    const { lastFrame } = render(
+      <ActivityViewerPanel
+        {...baseProps}
+        width={W}
+        activities={acts}
+        searchQuery="ea"
+        searchHits={[0]} // "Read" matches
+        searchSelected={0}
+        subAgentSummary={{
+          status: "done",
+          steps: 3,
+          durationMs: 134000,
+          intent: "Research the thing",
+          result: "Recommends option B",
+          model: "sonnet-4.6",
+        }}
+      />,
+    );
+    const out = lastFrame() ?? "";
+    // Header stays visible while narrowed.
+    expect(out).toContain("Research the thing"); // intent
+    expect(out).toContain("3 steps"); // metric chip
+    expect(out).toContain("↵ drill in"); // divider
+    // Border stays aligned with the header rows present.
+    const lines = out.split("\n").filter(Boolean);
+    for (const l of lines) expect([...l].length).toBe(W);
   });
 });

--- a/tests/ui/ActivityViewerPanel.test.tsx
+++ b/tests/ui/ActivityViewerPanel.test.tsx
@@ -279,6 +279,45 @@ describe("ActivityViewerPanel — row width alignment", () => {
   });
 });
 
+describe("ActivityViewerPanel — sub-agent summary header", () => {
+  const summary = {
+    status: "done" as const,
+    steps: 3,
+    durationMs: 134000,
+    intent: "Research the thing",
+    result: "Recommends option B",
+    model: "sonnet-4.6",
+  };
+
+  it("renders the header (intent/result/steps) when subAgentSummary is set", () => {
+    const { lastFrame } = render(
+      <ActivityViewerPanel
+        {...baseProps}
+        activities={[makeActivity("Read", 0)]}
+        subAgentSummary={summary}
+      />,
+    );
+    const out = lastFrame() ?? "";
+    expect(out).toContain("Research the thing"); // intent
+    expect(out).toContain("3 steps"); // metric chip
+    expect(out).toContain("Recommends option B"); // result
+    expect(out).toContain("activity"); // divider label
+    expect(out).toContain("Read"); // stream still present below
+  });
+
+  it("renders no header for a main session (prop absent)", () => {
+    const { lastFrame } = render(
+      <ActivityViewerPanel
+        {...baseProps}
+        activities={[makeActivity("Read", 0)]}
+      />,
+    );
+    const out = lastFrame() ?? "";
+    expect(out).not.toContain("3 steps");
+    expect(out).not.toContain("↵ drill in");
+  });
+});
+
 describe("ActivityViewerPanel search", () => {
   const acts = [
     makeActivity("Read", 0),

--- a/tests/ui/App.autoPause.test.tsx
+++ b/tests/ui/App.autoPause.test.tsx
@@ -1,0 +1,168 @@
+// tests/ui/App.autoPause.test.tsx
+//
+// Isolated on purpose: this test drives fake timers to advance the 60s refresh
+// poll. Run alongside the ~50 real-timer tests in App.test.tsx, leftover
+// intervals from un-unmounted prior renders bleed into the fake-timer window and
+// make it order-dependent. A dedicated file gets vitest's per-file module
+// isolation, so it runs clean every time.
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+import type { ActivityEntry, SessionTree } from "../../src/types/index.js";
+
+vi.mock("../../src/config/globalConfig.js", () => ({
+  loadGlobalConfig: () => ({
+    refreshIntervalMs: 60000,
+    hiddenSessions: [],
+    hiddenSubAgents: [],
+    filterPresets: [[], ["response"], ["commit"]],
+  }),
+  hasProjectLevelConfig: () => false,
+}));
+
+let mockTree: SessionTree = {
+  projects: [],
+  coldProjects: [],
+  totalCount: 0,
+  timestamp: new Date(1_800_000_000_000).toISOString(),
+  hiddenStats: { total: 0, active: 0 },
+};
+
+vi.mock("../../src/data/sessions.js", () => ({
+  discoverSessions: () => mockTree,
+  getProjectsDir: () => "/tmp/nonexistent-projects-dir",
+}));
+
+let mockActivities: ActivityEntry[] = [];
+vi.mock("../../src/data/sessionHistory.js", () => ({
+  parseSessionHistory: () => mockActivities,
+}));
+
+vi.setConfig({ testTimeout: 20000 });
+
+const { App } = await import("../../src/ui/App.js");
+
+describe("App — cursor-anchor auto-pause budget", () => {
+  const ESC = String.fromCharCode(27);
+  const DOWN = `${ESC}[B`;
+  const UP = `${ESC}[A`;
+  const RECENT = 1_800_000_000_000; // fixed ms, independent of the fake clock
+
+  // A TOP-LEVEL session that carries an agentId (all buildSubAgentSummary needs)
+  // so the viewer renders the black-box header. A top-level node stays in the
+  // flattened list across the 60s refresh, so refresh's "selected item
+  // disappeared → fall back to parent" path never fires and the selection stays
+  // put while activities grow.
+  const agentSessionTree = (): SessionTree => ({
+    projects: [
+      {
+        name: "proj",
+        projectPath: "/tmp/proj",
+        hotness: "hot",
+        sessions: [
+          {
+            id: "s1",
+            hideKey: "proj/s1",
+            filePath: "/tmp/proj/s1.jsonl",
+            projectPath: "/tmp/proj",
+            projectName: "proj",
+            lastModifiedMs: RECENT,
+            status: "hot",
+            modelName: "sonnet-4.6",
+            subAgents: [],
+            nonInteractive: false,
+            firstUserPrompt: "p",
+            liveState: "working",
+            agentId: "agent-abc",
+            taskDescription: "DO_THE_THING",
+          },
+        ],
+      },
+    ],
+    coldProjects: [],
+    totalCount: 1,
+    timestamp: new Date(RECENT).toISOString(),
+    hiddenStats: { total: 0, active: 0 },
+  });
+
+  it("auto-pauses using the header-reduced budget for a live sub-agent (fix #1)", async () => {
+    // The cursor-anchor auto-pause effect must budget against the stream that's
+    // actually rendered (viewerRows − header height), not the full viewerRows.
+    // With the cursor parked at the true top of the reduced window, ONE new
+    // activity must push its anchored row off-screen → auto-PAUSE. Under the old
+    // unreduced viewerRows the effect would see headroom (the header gap) and
+    // stay LIVE.
+    vi.useFakeTimers();
+    try {
+      mockTree = agentSessionTree();
+      // Enough activities to overflow the viewer window so the cursor can climb
+      // to the reduced top with content above it.
+      mockActivities = Array.from({ length: 40 }, (_, i) => ({
+        timestamp: new Date(2026, 0, 1, 9, 0, i),
+        type: "tool" as const,
+        icon: "○",
+        label: "Read",
+        detail: `f${i}.ts`,
+      }));
+
+      const { stdin, lastFrame } = render(<App mode="watch" />);
+      await vi.advanceTimersByTimeAsync(250); // mount + initial load
+
+      // Select the agent session (its viewer header divider shows once selected).
+      for (let i = 0; i < 60; i++) {
+        if ((lastFrame() ?? "").includes("drill in")) break;
+        stdin.write(DOWN);
+        await vi.advanceTimersByTimeAsync(60);
+      }
+      expect(lastFrame() ?? "").toContain("drill in");
+
+      stdin.write("\t"); // focus tree → viewer
+      await vi.advanceTimersByTimeAsync(60);
+
+      // Wait until the live window is fully populated (newest row f39 present)
+      // before measuring — counting a half-filled frame would misjudge the top.
+      for (let i = 0; i < 40; i++) {
+        if ((lastFrame() ?? "").includes("f39.ts")) break;
+        await vi.advanceTimersByTimeAsync(60);
+      }
+      expect(lastFrame() ?? "").toContain("f39.ts");
+
+      // When live and full, the viewer shows exactly `viewerStreamRows` stream
+      // rows — read that budget off the frame instead of recomputing the layout.
+      const streamRows = (lastFrame() ?? "")
+        .split("\n")
+        .filter((l) => /Read: f\d/.test(l)).length;
+      expect(streamRows).toBeGreaterThan(3);
+
+      // Climb to the top row of the visible window (cursor = streamRows−1) while
+      // staying LIVE. One more ↑ would scroll+pause, so press exactly that many.
+      for (let i = 0; i < streamRows - 1; i++) {
+        stdin.write(UP);
+        await vi.advanceTimersByTimeAsync(15);
+      }
+      expect(lastFrame() ?? "").toContain("LIVE"); // cursor at top, still live
+
+      // One new activity arrives; the 60s poll re-reads the grown stream without
+      // resetting the cursor (selection is stable — see the tree note above).
+      mockActivities = [
+        ...mockActivities,
+        {
+          timestamp: new Date(2026, 0, 1, 9, 1, 0),
+          type: "tool",
+          icon: "○",
+          label: "Read",
+          detail: "new.ts",
+        },
+      ];
+      mockTree = agentSessionTree();
+      await vi.advanceTimersByTimeAsync(60000); // fire the refresh poll
+      // Let the re-render settle; poll so a lagged frame doesn't flake.
+      for (let i = 0; i < 20; i++) {
+        if ((lastFrame() ?? "").includes("PAUSED")) break;
+        await vi.advanceTimersByTimeAsync(100);
+      }
+      expect(lastFrame() ?? "").toContain("PAUSED");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/ui/App.autoPause.test.tsx
+++ b/tests/ui/App.autoPause.test.tsx
@@ -9,9 +9,13 @@ import { render } from "ink-testing-library";
 import { describe, expect, it, vi } from "vitest";
 import type { ActivityEntry, SessionTree } from "../../src/types/index.js";
 
+// Short refresh interval: the test advances fake time to fire the refresh poll,
+// and advancing the real 60s interval steps through hundreds of spinner-timer
+// ticks (each a render) — slow enough to time out on CI. 300ms keeps the single
+// advance tiny while still exercising the same refresh → grow-activities path.
 vi.mock("../../src/config/globalConfig.js", () => ({
   loadGlobalConfig: () => ({
-    refreshIntervalMs: 60000,
+    refreshIntervalMs: 300,
     hiddenSessions: [],
     hiddenSubAgents: [],
     filterPresets: [[], ["response"], ["commit"]],
@@ -154,11 +158,11 @@ describe("App — cursor-anchor auto-pause budget", () => {
         },
       ];
       mockTree = agentSessionTree();
-      await vi.advanceTimersByTimeAsync(60000); // fire the refresh poll
-      // Let the re-render settle; poll so a lagged frame doesn't flake.
+      // Fire the refresh poll (300ms interval) and let the re-render settle;
+      // poll so a lagged frame doesn't flake.
       for (let i = 0; i < 20; i++) {
         if ((lastFrame() ?? "").includes("PAUSED")) break;
-        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(350);
       }
       expect(lastFrame() ?? "").toContain("PAUSED");
     } finally {

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -1615,18 +1615,21 @@ describe("App — sub-agent viewer summary header", () => {
       timeout: 3000,
       interval: 25,
     });
-    // ↓ to the session, ↓ to the (running) sub-agent row.
-    stdin.write(DOWN);
-    await tick();
-    stdin.write(DOWN);
-    // The summary header (intent) only renders when the sub-agent is selected.
-    await vi.waitFor(
-      () => expect(lastFrame() ?? "").toContain("DO_THE_THING"),
-      {
-        timeout: 5000,
-        interval: 25,
-      },
-    );
-    expect(lastFrame() ?? "").toContain("1 steps"); // metric chip (header-only)
+    // Navigate down to the sub-agent. It is the LAST nav row (sentinel →
+    // session → sub-agent), so over-pressing ↓ is safe — `onScrollDown` clamps
+    // at the bottom row. Sending extra ↓ keeps this robust against a CI race
+    // where a later ↓ would otherwise read a not-yet-committed selectedIndex
+    // and stop short of the sub-agent.
+    for (let i = 0; i < 4; i++) {
+      stdin.write(DOWN);
+      await tick();
+    }
+    // The summary header (intent) only renders when the sub-agent is selected;
+    // `DO_THE_THING` (full, untruncated) and the `1 steps` chip are header-only.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1 steps"), {
+      timeout: 5000,
+      interval: 25,
+    });
+    expect(lastFrame() ?? "").toContain("DO_THE_THING"); // intent in header
   });
 });

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -1615,17 +1615,18 @@ describe("App — sub-agent viewer summary header", () => {
       timeout: 3000,
       interval: 25,
     });
-    // Navigate down to the sub-agent. It is the LAST nav row (sentinel →
-    // session → sub-agent), so over-pressing ↓ is safe — `onScrollDown` clamps
-    // at the bottom row. Sending extra ↓ keeps this robust against a CI race
-    // where a later ↓ would otherwise read a not-yet-committed selectedIndex
-    // and stop short of the sub-agent.
-    for (let i = 0; i < 4; i++) {
+    // Navigate down to the sub-agent (the LAST nav row: sentinel → session →
+    // sub-agent). Press ↓ repeatedly until the header appears, NOT a fixed
+    // count: on slow CI a render can take longer than one tick to commit the
+    // new selectedIndex, so a burst of ↓ stalls at the session row. Re-pressing
+    // is safe (↓ clamps at the bottom), and selecting the sub-agent scrolls its
+    // otherwise-folded row into view. `1 steps` is the header-only chip (the
+    // true discriminator — `taskDescription` also shows in the tree row).
+    for (let i = 0; i < 60; i++) {
+      if ((lastFrame() ?? "").includes("1 steps")) break;
       stdin.write(DOWN);
       await tick();
     }
-    // The summary header (intent) only renders when the sub-agent is selected;
-    // `DO_THE_THING` (full, untruncated) and the `1 steps` chip are header-only.
     await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1 steps"), {
       timeout: 5000,
       interval: 25,

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -1545,83 +1545,76 @@ describe("App — sub-agent viewer summary header", () => {
   const tick = () => new Promise((r) => setTimeout(r, 50));
   const DOWN = String.fromCharCode(27) + "[B"; // ESC prefix REQUIRED (see prior CI fixes)
 
-  it("shows the intent header when a sub-agent row is selected", async () => {
-    mockTree = {
-      projects: [
-        {
-          name: "proj",
-          projectPath: "/tmp/proj",
-          hotness: "hot",
-          sessions: [
-            {
-              id: "s1",
-              hideKey: "proj/s1",
-              filePath: "/tmp/proj/s1.jsonl",
-              projectPath: "/tmp/proj",
-              projectName: "proj",
-              lastModifiedMs: Date.now(),
-              status: "hot",
-              modelName: "sonnet-4.6",
-              nonInteractive: false,
-              firstUserPrompt: "parent",
-              liveState: null,
-              subAgents: [
-                {
-                  id: "a1",
-                  hideKey: "proj/a1",
-                  filePath: "/tmp/proj/a1.jsonl",
-                  projectPath: "/tmp/proj",
-                  projectName: "",
-                  lastModifiedMs: Date.now(),
-                  status: "hot",
-                  modelName: "sonnet-4.6",
-                  subAgents: [],
-                  nonInteractive: false,
-                  firstUserPrompt: null,
-                  liveState: "working",
-                  agentId: "agent-abc123",
-                  taskDescription: "DO_THE_THING",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      coldProjects: [],
-      totalCount: 1,
-      timestamp: new Date().toISOString(),
-      hiddenStats: { total: 0, active: 0 },
-    };
-    mockActivities = [
+  // Tree: proj → session s1 → running sub-agent a1 (intent DO_THE_THING).
+  const subAgentTree = (): SessionTree => ({
+    projects: [
       {
-        timestamp: new Date(2026, 0, 1, 9, 0, 0),
-        type: "tool",
-        icon: "○",
-        label: "Read",
-        detail: "x.ts",
+        name: "proj",
+        projectPath: "/tmp/proj",
+        hotness: "hot",
+        sessions: [
+          {
+            id: "s1",
+            hideKey: "proj/s1",
+            filePath: "/tmp/proj/s1.jsonl",
+            projectPath: "/tmp/proj",
+            projectName: "proj",
+            lastModifiedMs: Date.now(),
+            status: "hot",
+            modelName: "sonnet-4.6",
+            subAgents: [
+              {
+                id: "a1",
+                hideKey: "proj/a1",
+                filePath: "/tmp/proj/a1.jsonl",
+                projectPath: "/tmp/proj",
+                projectName: "",
+                lastModifiedMs: Date.now(),
+                status: "hot",
+                modelName: "sonnet-4.6",
+                subAgents: [],
+                nonInteractive: false,
+                firstUserPrompt: null,
+                liveState: "working",
+                agentId: "agent-abc123",
+                taskDescription: "DO_THE_THING",
+              },
+            ],
+            nonInteractive: false,
+            firstUserPrompt: "parent",
+            liveState: null,
+          },
+        ],
       },
-      {
-        timestamp: new Date(2026, 0, 1, 9, 0, 2),
-        type: "response",
-        icon: "✦",
-        label: "Response",
-        detail: "RESULT_TEXT",
-      },
-    ];
-
-    const { stdin, lastFrame } = render(<App mode="watch" />);
-    // Tree is focused at boot; selection starts on the project sentinel.
-    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: expand"), {
-      timeout: 3000,
-      interval: 25,
-    });
-    // Navigate down to the sub-agent (the LAST nav row: sentinel → session →
-    // sub-agent). Press ↓ repeatedly until the header appears, NOT a fixed
-    // count: on slow CI a render can take longer than one tick to commit the
-    // new selectedIndex, so a burst of ↓ stalls at the session row. Re-pressing
-    // is safe (↓ clamps at the bottom), and selecting the sub-agent scrolls its
-    // otherwise-folded row into view. `1 steps` is the header-only chip (the
-    // true discriminator — `taskDescription` also shows in the tree row).
+    ],
+    coldProjects: [],
+    totalCount: 1,
+    timestamp: new Date().toISOString(),
+    hiddenStats: { total: 0, active: 0 },
+  });
+  // The sub-agent's own stream: one tool call + one response.
+  const subAgentActivities = (): ActivityEntry[] => [
+    {
+      timestamp: new Date(2026, 0, 1, 9, 0, 0),
+      type: "tool",
+      icon: "○",
+      label: "Read",
+      detail: "x.ts",
+    },
+    {
+      timestamp: new Date(2026, 0, 1, 9, 0, 2),
+      type: "response",
+      icon: "✦",
+      label: "Response",
+      detail: "RESULT_TEXT",
+    },
+  ];
+  // Press ↓ until the header-only `1 steps` chip appears (↓ clamps at the
+  // bottom row; selecting the sub-agent scrolls its folded row into view).
+  const selectSubAgent = async (
+    stdin: { write: (s: string) => void },
+    lastFrame: () => string | undefined,
+  ) => {
     for (let i = 0; i < 60; i++) {
       if ((lastFrame() ?? "").includes("1 steps")) break;
       stdin.write(DOWN);
@@ -1631,6 +1624,52 @@ describe("App — sub-agent viewer summary header", () => {
       timeout: 5000,
       interval: 25,
     });
+  };
+
+  it("shows the intent header when a sub-agent row is selected", async () => {
+    mockTree = subAgentTree();
+    mockActivities = subAgentActivities();
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: expand"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    await selectSubAgent(stdin, lastFrame);
     expect(lastFrame() ?? "").toContain("DO_THE_THING"); // intent in header
+  });
+
+  it("summary uses the sub-agent's own stream, not the filtered viewer merge", async () => {
+    mockTree = subAgentTree();
+    mockActivities = subAgentActivities();
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: expand"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    await selectSubAgent(stdin, lastFrame);
+
+    // Focus the viewer and cycle the type filter to "response" (filterPresets
+    // = [[], ["response"], ["commit"]]). That drops the tool from the viewer's
+    // *merged/filtered* stream — but the sub-agent summary must reflect the
+    // agent's OWN raw activity (1 tool), so the chip must stay `1 steps`, not
+    // collapse to `0 steps`.
+    stdin.write("\t"); // focus tree → viewer
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    stdin.write("f"); // filter → response (hides the tool row)
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("f: response"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    // Header still counts the raw tool call.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1 steps"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    expect(lastFrame() ?? "").not.toContain("0 steps");
   });
 });

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -1609,18 +1609,18 @@ describe("App — sub-agent viewer summary header", () => {
       detail: "RESULT_TEXT",
     },
   ];
-  // Press ↓ until the header-only `1 steps` chip appears (↓ clamps at the
+  // Press ↓ until the header-only `1 step` chip appears (↓ clamps at the
   // bottom row; selecting the sub-agent scrolls its folded row into view).
   const selectSubAgent = async (
     stdin: { write: (s: string) => void },
     lastFrame: () => string | undefined,
   ) => {
     for (let i = 0; i < 60; i++) {
-      if ((lastFrame() ?? "").includes("1 steps")) break;
+      if ((lastFrame() ?? "").includes("1 step")) break;
       stdin.write(DOWN);
       await tick();
     }
-    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1 steps"), {
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1 step"), {
       timeout: 5000,
       interval: 25,
     });
@@ -1653,7 +1653,7 @@ describe("App — sub-agent viewer summary header", () => {
     // Focus the viewer and cycle the type filter to "response" (filterPresets
     // = [[], ["response"], ["commit"]]). That drops the tool from the viewer's
     // *merged/filtered* stream — but the sub-agent summary must reflect the
-    // agent's OWN raw activity (1 tool), so the chip must stay `1 steps`, not
+    // agent's OWN raw activity (1 tool), so the chip must stay `1 step`, not
     // collapse to `0 steps`.
     stdin.write("\t"); // focus tree → viewer
     await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: detail"), {
@@ -1666,7 +1666,7 @@ describe("App — sub-agent viewer summary header", () => {
       interval: 25,
     });
     // Header still counts the raw tool call.
-    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1 steps"), {
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("1 step"), {
       timeout: 3000,
       interval: 25,
     });

--- a/tests/ui/App.test.tsx
+++ b/tests/ui/App.test.tsx
@@ -1540,3 +1540,93 @@ describe("viewer search → Enter opens Detail View", () => {
     });
   });
 });
+
+describe("App — sub-agent viewer summary header", () => {
+  const tick = () => new Promise((r) => setTimeout(r, 50));
+  const DOWN = String.fromCharCode(27) + "[B"; // ESC prefix REQUIRED (see prior CI fixes)
+
+  it("shows the intent header when a sub-agent row is selected", async () => {
+    mockTree = {
+      projects: [
+        {
+          name: "proj",
+          projectPath: "/tmp/proj",
+          hotness: "hot",
+          sessions: [
+            {
+              id: "s1",
+              hideKey: "proj/s1",
+              filePath: "/tmp/proj/s1.jsonl",
+              projectPath: "/tmp/proj",
+              projectName: "proj",
+              lastModifiedMs: Date.now(),
+              status: "hot",
+              modelName: "sonnet-4.6",
+              nonInteractive: false,
+              firstUserPrompt: "parent",
+              liveState: null,
+              subAgents: [
+                {
+                  id: "a1",
+                  hideKey: "proj/a1",
+                  filePath: "/tmp/proj/a1.jsonl",
+                  projectPath: "/tmp/proj",
+                  projectName: "",
+                  lastModifiedMs: Date.now(),
+                  status: "hot",
+                  modelName: "sonnet-4.6",
+                  subAgents: [],
+                  nonInteractive: false,
+                  firstUserPrompt: null,
+                  liveState: "working",
+                  agentId: "agent-abc123",
+                  taskDescription: "DO_THE_THING",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      coldProjects: [],
+      totalCount: 1,
+      timestamp: new Date().toISOString(),
+      hiddenStats: { total: 0, active: 0 },
+    };
+    mockActivities = [
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 0),
+        type: "tool",
+        icon: "○",
+        label: "Read",
+        detail: "x.ts",
+      },
+      {
+        timestamp: new Date(2026, 0, 1, 9, 0, 2),
+        type: "response",
+        icon: "✦",
+        label: "Response",
+        detail: "RESULT_TEXT",
+      },
+    ];
+
+    const { stdin, lastFrame } = render(<App mode="watch" />);
+    // Tree is focused at boot; selection starts on the project sentinel.
+    await vi.waitFor(() => expect(lastFrame() ?? "").toContain("↵: expand"), {
+      timeout: 3000,
+      interval: 25,
+    });
+    // ↓ to the session, ↓ to the (running) sub-agent row.
+    stdin.write(DOWN);
+    await tick();
+    stdin.write(DOWN);
+    // The summary header (intent) only renders when the sub-agent is selected.
+    await vi.waitFor(
+      () => expect(lastFrame() ?? "").toContain("DO_THE_THING"),
+      {
+        timeout: 5000,
+        interval: 25,
+      },
+    );
+    expect(lastFrame() ?? "").toContain("1 steps"); // metric chip (header-only)
+  });
+});

--- a/tests/ui/subAgentSummary.test.ts
+++ b/tests/ui/subAgentSummary.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { ActivityEntry, SessionNode } from "../../src/types/index.js";
+import {
+  buildSubAgentSummary,
+  formatDuration,
+} from "../../src/ui/subAgentSummary.js";
+
+const node = (over: Partial<SessionNode> = {}): SessionNode => ({
+  id: "id1",
+  hideKey: "p/id1",
+  filePath: "/tmp/id1.jsonl",
+  projectPath: "/tmp/p",
+  projectName: "p",
+  lastModifiedMs: 0,
+  status: "hot",
+  modelName: "sonnet-4.6",
+  subAgents: [],
+  nonInteractive: false,
+  firstUserPrompt: null,
+  liveState: null,
+  ...over,
+});
+
+const tool = (ms: number): ActivityEntry => ({
+  timestamp: new Date(ms),
+  type: "tool",
+  icon: "○",
+  label: "Read",
+  detail: "x.ts",
+});
+const response = (ms: number, text: string): ActivityEntry => ({
+  timestamp: new Date(ms),
+  type: "response",
+  icon: "✦",
+  label: "Response",
+  detail: text,
+});
+
+describe("buildSubAgentSummary", () => {
+  it("returns null for a main session (no agentId)", () => {
+    expect(buildSubAgentSummary(node(), [tool(0)])).toBeNull();
+  });
+
+  it("derives steps, duration, result, intent for a finished sub-agent", () => {
+    const acts = [tool(1000), tool(2000), response(5000, "All done")];
+    const s = buildSubAgentSummary(
+      node({ agentId: "agent-abc", taskDescription: "Do the thing" }),
+      acts,
+    );
+    expect(s).toEqual({
+      status: "done",
+      steps: 2,
+      durationMs: 4000,
+      intent: "Do the thing",
+      result: "All done",
+      model: "sonnet-4.6",
+    });
+  });
+
+  it("reports running when liveState is working", () => {
+    const s = buildSubAgentSummary(
+      node({ agentId: "a", liveState: "working" }),
+      [tool(0)],
+    );
+    expect(s?.status).toBe("running");
+  });
+
+  it("handles 0 and 1 activities (null duration, empty result)", () => {
+    expect(buildSubAgentSummary(node({ agentId: "a" }), [])).toMatchObject({
+      steps: 0,
+      durationMs: null,
+      result: "",
+    });
+    expect(
+      buildSubAgentSummary(node({ agentId: "a" }), [tool(10)]),
+    ).toMatchObject({ steps: 1, durationMs: null });
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats seconds, minutes, hours", () => {
+    expect(formatDuration(5000)).toBe("5s");
+    expect(formatDuration(134000)).toBe("2m14s");
+    expect(formatDuration(3_660_000)).toBe("1h1m");
+  });
+});

--- a/tests/ui/subAgentSummary.test.ts
+++ b/tests/ui/subAgentSummary.test.ts
@@ -3,6 +3,7 @@ import type { ActivityEntry, SessionNode } from "../../src/types/index.js";
 import {
   buildSubAgentSummary,
   formatDuration,
+  subAgentHeaderRowCount,
 } from "../../src/ui/subAgentSummary.js";
 
 const node = (over: Partial<SessionNode> = {}): SessionNode => ({
@@ -74,6 +75,25 @@ describe("buildSubAgentSummary", () => {
     expect(
       buildSubAgentSummary(node({ agentId: "a" }), [tool(10)]),
     ).toMatchObject({ steps: 1, durationMs: null });
+  });
+});
+
+describe("subAgentHeaderRowCount", () => {
+  it("is 0 with no summary", () => {
+    expect(subAgentHeaderRowCount(null)).toBe(0);
+    expect(subAgentHeaderRowCount(undefined)).toBe(0);
+  });
+  it("is 2 without a result (chip + divider)", () => {
+    const s = buildSubAgentSummary(node({ agentId: "a" }), [tool(0)]);
+    expect(s?.result).toBe("");
+    expect(subAgentHeaderRowCount(s)).toBe(2);
+  });
+  it("is 3 with a result (chip + result + divider)", () => {
+    const s = buildSubAgentSummary(node({ agentId: "a" }), [
+      tool(0),
+      response(1000, "done"),
+    ]);
+    expect(subAgentHeaderRowCount(s)).toBe(3);
   });
 });
 

--- a/tests/ui/subAgentSummary.test.ts
+++ b/tests/ui/subAgentSummary.test.ts
@@ -66,6 +66,24 @@ describe("buildSubAgentSummary", () => {
     expect(s?.status).toBe("running");
   });
 
+  it("reports running (not done) when liveState is waiting", () => {
+    // A "waiting" agent is alive/yielded, not finished. Unreachable for Claude
+    // sub-agents today (sessionLiveness maps sub-agent yield → null), but the
+    // header must not lie if a provider ever emits agentId + waiting.
+    const s = buildSubAgentSummary(
+      node({ agentId: "a", liveState: "waiting" }),
+      [tool(0)],
+    );
+    expect(s?.status).toBe("running");
+  });
+
+  it("reports done when there is no live signal (liveState null)", () => {
+    const s = buildSubAgentSummary(node({ agentId: "a", liveState: null }), [
+      tool(0),
+    ]);
+    expect(s?.status).toBe("done");
+  });
+
   it("handles 0 and 1 activities (null duration, empty result)", () => {
     expect(buildSubAgentSummary(node({ agentId: "a" }), [])).toMatchObject({
       steps: 0,


### PR DESCRIPTION
Closes #226

## What & why

Raise **hero (live HUD) retention** by fixing sub-agent information overload. Skills/workflows (SDD, deep-research, Workflow) emit *fleets* of sub-agents; agenthud rendered each at full detail, on par with a main session. Now a sub-agent reads as a **black box**.

When the selected tree node is a sub-agent (`node.agentId` set), the Activity Viewer shows a **summary header** above the (still-present, drillable) activity stream:

```
┌─ » <name>   [running|done] · N steps · <duration> · <model> ─┐
│ <chip>  Intent…                                              │
│ Result: <last response…>                                     │
├─ activity (↵ drill in) ──────────────────────────────────────┤
│ ○ Read …                                                     │
```

Main sessions are **unchanged** (they're the hero). Box height stays `visibleRows` tall (the stream's row budget shrinks by the header height).

## Data — zero new collection

intent = `taskDescription` · status = `liveState` (`running`/`done`) · steps = tool-call count · duration = first→last activity span · result = last `response`. New pure `src/ui/subAgentSummary.ts` derives it; `App` passes it to `ActivityViewerPanel`.

## How it was built

Spec → plan → 3 TDD tasks, each implemented by a fresh sub-agent and independently reviewed, + a final whole-branch review (**Ready to merge**). Docs in this PR: spec (`docs/superpowers/specs/2026-06-30-…`), plan (`…/plans/…`), per-task record + digest (`…/reports/…`). Task 2's panel had a 1-cell width misalignment caught in review and fixed (regression-locked by a width test).

## Verification

938 tests passing, `tsc --noEmit` clean, Biome clean.

## Deferred (tracked on #226)

- `failed` status — no reliable signal today (deferred).
- P2: cost field + task/PR cost roll-up. P3: skill-fleet roll-up on the parent.
- Minor follow-ups: pin total panel height with a header in a test; narrow-width (`--once` <80 cols) field-priority truncation; pluralize `1 step`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact “sub-agent” summary header to the activity viewer (intent, status, step count, duration, model, and latest result when available).
  * Kept overall panel height stable by budgeting the space used by the header, including in the narrowed/search view.
* **Bug Fixes**
  * Ensured the header reflects the selected sub-agent’s own activity stream and stays correctly aligned.
* **Documentation**
  * Added design and implementation records for the sub-agent black-box card P1.
* **Tests**
  * Added unit and UI tests covering header rendering, formatting, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->