### PR TITLE
chore: version-control CodeRabbit config via .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,29 @@
+# CodeRabbit configuration — governs review BEHAVIOR for this repo and takes
+# precedence over the CodeRabbit dashboard UI. It does NOT replace the GitHub
+# App installation: the CodeRabbit app must still be installed for repo access,
+# and this file is only read once the app can see the repo.
+# Schema: https://docs.coderabbit.ai/reference/configuration
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en-US
+
+reviews:
+  # "assertive" = the profile already in use (surfaces more nitpicks/edge cases).
+  profile: assertive
+  # Post the review as GitHub "Request changes" until its comments are resolved.
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    # Review automatically on push (the current behavior we want version-locked).
+    enabled: true
+    # Incremental re-review on each new push to an open PR.
+    auto_incremental_review: true
+    # Skip draft PRs — review once they're marked ready.
+    drafts: false
+    base_branches:
+      - main
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## What
Adds a repo-tracked `.coderabbit.yaml` so CodeRabbit's review behavior lives in the repo (explicit, diffable, reviewable) instead of only in the CodeRabbit dashboard UI.

## Why
The review behavior (auto-review on push, `assertive` profile, etc.) was configured in CodeRabbit's dashboard — invisible from the codebase. This file makes it version-controlled; once present it **takes precedence over the dashboard UI** for this repo.

## Scope / caveat
- Reflects **current observed behavior**: `profile: assertive`, auto-review + incremental review on push, base branch `main`, `request_changes_workflow: true` (matches the CHANGES_REQUESTED reviews we've seen).
- Governs **behavior only**. The CodeRabbit **GitHub App must still be installed** for repo access — a config file can't grant access, and it isn't read without the app.

## Verification
- YAML parses; keys validated against the CodeRabbit v2 schema (`$schema` annotation included for editor validation).

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automated review comments on new pushes, with incremental re-review for open pull requests.
  * Turned on chat auto-replies and added high-level review summaries/status updates.
  * Standardized review settings to English with a more direct review tone and “request changes” workflow.
  * Limited automatic reviews to the main branch and skipped draft pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->